### PR TITLE
Add glossary page and rename last documentation box Other Documentation

### DIFF
--- a/pages/documentation/glossary.rst
+++ b/pages/documentation/glossary.rst
@@ -1,0 +1,30 @@
+.. title: Glossary
+.. slug: glossary
+.. description: Glossary of commonly used abbreviations in Cantera
+
+********
+Glossary
+********
+
+The following abbreviations are used in Cantera, both in documentation and in
+the names of variables and classes:
+
+* **CK**: Chemkin
+* **CT**: Cantera
+* **CTI**: Cantera Input
+* **CTML**: Cantera Markup Language
+* **HKFT**: Helgeson-Kirkham-Flowers-Tanger
+* **HMW**: Harvie, Møller, and Weare
+* **IAPWS**: International Association for the Properties of Water and Steam
+* **MFTP**: Mixture Fugacity ThermoPhase
+* **PDSS**: Pressure-dependent standard state
+* **RT**: Product of the gas constant (R) and the temperature
+* **SHE**: Single half-electrode
+* **SP**: Surface Problem
+* **SS**: Standard state
+* **SSTP**: SingleSpeciesTP (ThermoPhase)
+* **STIT**: SpeciesThermoInterpType
+* **VCS**: Villars Cruise Smith
+* **VPSS**: Variable Pressure Standard State
+* **VPSSTP**: Variable Pressure Standard State ThermoPhase
+* **wrt**: with respect to

--- a/pages/documentation/index.html
+++ b/pages/documentation/index.html
@@ -94,15 +94,16 @@
     </div>
   </div>
   <div class="col-sm-6">
-    <div class="card" id="cti-docs">
+    <div class="card" id="other-docs">
       <div class="card-header section-card">
-        CTI Input Format
+        Other Documentation
       </div>
       <div class="list-group list-group-flush">
         <a href="/tutorials/input-files.html" class="list-group-item docs">CTI Input File Tutorial</a>
         <a href="{{% ct_docs sphinx/html/cti/classes.html %}}" class="list-group-item docs">
           CTI Input File Class Reference
         </a>
+        <a href="{{% doc glossary }}" class="list-group-item docs">Glossary of Terms</a>
       </div>
     </div>
   </div>

--- a/pages/documentation/index.html
+++ b/pages/documentation/index.html
@@ -103,7 +103,7 @@
         <a href="{{% ct_docs sphinx/html/cti/classes.html %}}" class="list-group-item docs">
           CTI Input File Class Reference
         </a>
-        <a href="{{% doc glossary }}" class="list-group-item docs">Glossary of Terms</a>
+        <a href="/documentation/glossary.html" class="list-group-item docs">Glossary of Terms</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The glossary page defines some useful abbreviations for the docs and the 
main Cantera code

Closes #27 

I haven't tested this yet on my local machine, so I want do do that before this is merged