### PR TITLE
Add search capability to documentation pages

### DIFF
--- a/pages/documentation/dev-docs.html
+++ b/pages/documentation/dev-docs.html
@@ -13,6 +13,18 @@
     the <code>master</code> branch, this documentation describes any changes that have been made
     since the last release.
   </p>
+
+  <div id="searchbox" style="display: inline-block" role="search">
+    <h3>Search the documentation</h3>
+      <div class="searchformwrapper">
+      <form class="search" action="{{% ct_dev_docs sphinx/html/search.html %}}" method="get">
+        <input type="text" name="q" size="50" />
+        <input type="submit" value="Go" />
+        <input type="hidden" name="check_keywords" value="yes" />
+        <input type="hidden" name="area" value="default" />
+      </form>
+      </div>
+  </div>
 </div>
 
 <div class="row">

--- a/pages/documentation/index.html
+++ b/pages/documentation/index.html
@@ -12,6 +12,18 @@
     Sometimes you just need a little more detail. You'll find documentation for
     (almost) every function in Cantera right here.
   </p>
+
+  <div id="searchbox" style="display: inline-block" role="search">
+    <h3>Search the documentation</h3>
+      <div class="searchformwrapper">
+      <form class="search" action="{{% ct_docs sphinx/html/search.html %}}" method="get">
+        <input type="text" name="q" size="50" />
+        <input type="submit" value="Go" />
+        <input type="hidden" name="check_keywords" value="yes" />
+        <input type="hidden" name="area" value="default" />
+      </form>
+      </div>
+  </div>
 </div>
 
 <div class="row">

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Nikola[extras]==8.0.0b2
+Nikola[extras]==8.0.0b3


### PR DESCRIPTION
Fixes #19. Adds search to the main documentation index page and the 
developer's documentation version.