### PR TITLE
Update the documentation to include the Windows paths

### DIFF
--- a/pages/compiling/installation-reqs.rst
+++ b/pages/compiling/installation-reqs.rst
@@ -112,12 +112,21 @@ Conda Requirements
 
 * After you've :ref:`cloned the source code <sec-source-code>`, configure the Cantera build by
   adding the following options to a file called ``cantera.conf`` in the root of the source directory
-  (creating the file if it doesn't exist):
+  (creating the file if it doesn't exist)
+  
+  On macOS and Linux, add the following code to your ``cantera.conf`` file:
 
   .. code:: python
 
      python3_package = 'full'
      boost_inc_dir = '/path/to/conda/install/folder/envs/cantera/include'
+
+  On Windows, add the following code to your ``cantera.conf`` file:
+
+  .. code:: python
+
+     python3_package = 'full'
+     boost_inc_dir = '/path/to/conda/install/folder/envs/cantera/Library/include'
 
 * Now you can build Cantera with
 


### PR DESCRIPTION
Updated the documentation of compiling Cantera from source using Conda & Anaconda to include the Windows paths as well.

After update:
![image](https://user-images.githubusercontent.com/38394281/54487281-55ac8f80-48ba-11e9-8535-3f5bd6286115.png)


Ref: https://groups.google.com/forum/#!topic/cantera-users/c8-he6x8QHY