### PR TITLE
Delete text containing wrong link to current documentation

### DIFF
--- a/api-docs/docs-2.0/sphinx/html/index.html
+++ b/api-docs/docs-2.0/sphinx/html/index.html
@@ -99,9 +99,6 @@ electrolyte solutions, plasmas, and thin film deposition.</p>
 <p>Cantera can be used from Python and Matlab, or in applications written
 in C++ and Fortran 90.</p>
 
-<p style="color:red"><b>This documentation is for Cantera 2.0.2, which is now obsolete.
-Documentation for the current version of Cantera is available <a href="https://cantera.org/docs/sphinx/html/index.html">here</a>.</b></p>
-
 <div class="section" id="documentation">
 <h2>Documentation<a class="headerlink" href="#documentation" title="Permalink to this headline">&#182;</a></h2>
 <div class="toctree-wrapper compound">

--- a/api-docs/docs-2.1/sphinx/html/index.html
+++ b/api-docs/docs-2.1/sphinx/html/index.html
@@ -95,9 +95,6 @@ electrolyte solutions, plasmas, and thin film deposition.</p>
 <p>Cantera can be used from Python and Matlab, or in applications written
 in C++ and Fortran 90.</p>
 
-<p style="color:red"><b>This documentation is for Cantera 2.1.2, which is now obsolete.
-Documentation for the current version of Cantera is available <a href="https://cantera.org/docs/sphinx/html/index.html">here</a>.</b></p>
-
 <div class="section" id="documentation">
 <h2>Documentation<a class="headerlink" href="#documentation" title="Permalink to this headline">&#182;</a></h2>
 <div class="toctree-wrapper compound">

--- a/api-docs/docs-2.2/sphinx/html/index.html
+++ b/api-docs/docs-2.2/sphinx/html/index.html
@@ -95,9 +95,6 @@ electrolyte solutions, plasmas, and thin film deposition.</p>
 <p>Cantera can be used from Python and Matlab, or in applications written
 in C++ and Fortran 90.</p>
 
-<p style="color:red"><b>This documentation is for Cantera 2.2.1, which is now obsolete.
-Documentation for the current version of Cantera is available <a href="https://cantera.org/docs/sphinx/html/index.html">here</a>.</b></p>
-
 <div class="section" id="documentation">
 <h2>Documentation<a class="headerlink" href="#documentation" title="Permalink to this headline">&#182;</a></h2>
 <div class="toctree-wrapper compound">


### PR DESCRIPTION
Fixes #69 