### PR TITLE
cantera-website: Add Gentoo Cantera package installation instructions.

### DIFF
--- a/pages/install/gentoo-install.rst
+++ b/pages/install/gentoo-install.rst
@@ -1,0 +1,66 @@
+.. title: Installing Cantera on Gentoo
+.. slug: gentoo-install
+.. date: 2019-06-26 20:00:00 UTC-04:00
+.. description: Installation instructions for Cantera on Gentoo
+.. type: text
+.. _sec-install-gentoo:
+
+.. jumbotron::
+
+   .. raw:: html
+
+      <h1 class="display-3">Installing on Gentoo</h1>
+
+   .. class:: lead
+
+      Gentoo `sci-libs/cantera-2.4.0 <https://packages.gentoo.org/packages/sci-libs/cantera>`__ package is provided using a main portage tree.
+      Additionally the `app-doc/cantera-docs <https://packages.gentoo.org/packages/app-doc/cantera-docs>`__ package
+      is provided for offline Documentation API reference for Cantera package libraries.
+      Note that the Matlab interface is not available from this package; to install the
+      Matlab interface on Gentoo, you must :ref:`compile the source code <sec-compiling>`.
+
+The following interfaces and tools are installed by default:
+
+- C++ Libraries and header files for compiling your own programs that use Cantera.
+
+- `CTI tools <../tutorials/ck2cti-tutorial.html>`__ (``cti`` USE flag, optional).
+
+- Python module for Python 3 (``python`` USE flag with appropriate ``PYTHON_SINGLE_TARGET``, optional).
+
+The following additional interface is available:
+
+- Fortran Library and module files for compiling your own programs that use Cantera (``fortran`` USE flag, optional)
+
+More information about ``USE flags`` can be found in the `Gentoo Handbook <https://wiki.gentoo.org/wiki/Handbook:Parts/Working/USE>`__.
+To know about per-package control of ``USE flags`` please refer to the `/etc/portage/package.use <https://wiki.gentoo.org/wiki//etc/portage/package.use>`__ article.
+
+To install ``sci-libs/cantera`` and ``app-doc/cantera-docs`` packages:
+
+.. code-block:: bash
+
+    emerge --ask cantera cantera-docs
+
+Most likely these packages and/or some of their dependencies still have unstable status in the Gentoo portage tree
+and then you have to ``unmask`` (allow to install within stable system) them preliminarily using `/etc/portage/package.accept_keywords <https://wiki.gentoo.org/wiki//etc/portage/package.accept_keywords>`__.
+
+If ``/etc/portage/package.accept_keywords`` is present in your system as file then (for 64-bit architecture) you could unmask ``sci-libs/cantera`` package by running command (as root)
+
+.. code-block:: bash
+
+    echo "sci-libs/cantera ~amd64" >> /etc/portage/package.accept_keywords
+
+Otherwise if ``/etc/portage/package.accept_keywords`` is present in your system as directory then run command (as root)
+
+.. code-block:: bash
+
+    echo "sci-libs/cantera ~amd64" >> /etc/portage/package.accept_keywords/cantera
+
+If you plan on using Cantera from Python, you may also want to install IPython
+(`dev-python/ipython <https://packages.gentoo.org/packages/dev-python/ipython>`__, an advanced interactive Python interpreter)
+and Matplotlib (`dev-python/matplotlib <https://packages.gentoo.org/packages/dev-python/matplotlib>`__, a plotting
+library). Matplotlib is required to run some of the Python examples. These packages can be installed with:
+
+.. code-block:: bash
+
+    emerge --ask ipython matplotlib
+

--- a/pages/install/install.rst
+++ b/pages/install/install.rst
@@ -1,6 +1,6 @@
 .. title: Installing Cantera
 .. slug: index
-.. date: 2018-06-15 11:20:56 UTC-04:00
+.. date: 2019-06-26 20:00:00 UTC-04:00
 .. description: Installation instructions for Cantera
 .. type: text
 
@@ -89,6 +89,19 @@
          .. container:: card
 
             .. container:: card-header section-card
+               :attributes: id=heading-gentoo
+                            href=gentoo-install.html
+               :tagname: a
+
+               Gentoo Install Instructions
+
+            .. container:: card-body
+
+               Install Cantera on Gentoo using a portage.
+
+         .. container:: card
+
+            .. container:: card-header section-card
                :attributes: id=heading-other-linux
                             href=other-linux-install.html
                :tagname: a
@@ -97,9 +110,15 @@
 
             .. container:: card-body
 
-               Linux distributions other than Ubuntu can install the Python interface via Conda
+               Linux distributions other than Ubuntu and Gentoo can install the Python interface via Conda
                (see :ref:`the Conda instructions <sec-install-conda>`). Other interfaces can be
                installed by :ref:`compiling from source <sec-compiling>`.
+
+.. container::
+
+   .. row::
+
+      .. container:: card-deck
 
          .. container:: card
 

--- a/pages/install/install.rst
+++ b/pages/install/install.rst
@@ -18,117 +18,119 @@
       recommend that all new users install the Python interface via Conda. If you want to use one of
       the other interfaces, please select the installation instructions for your platform.
 
-.. container::
+.. container:: container
 
    .. row::
 
-      .. container:: card-deck
+      .. container:: col-12
 
-         .. container:: card
+         .. container:: card-deck
 
-            .. container:: card-header section-card
-               :attributes: id=heading-conda
-                            href=conda-install.html
-               :tagname: a
+            .. container:: card
 
-               Conda (Highly Recommended)
+               .. container:: card-header section-card
+                  :attributes: id=heading-conda
+                              href=conda-install.html
+                  :tagname: a
 
-            .. container:: card-body
+                  Conda (Highly Recommended)
 
-               Install the Cantera Python interface with Conda (Highly recommended for all users)
+               .. container:: card-body
 
-         .. container:: card
+                  Install the Cantera Python interface with Conda (Highly recommended for all users)
 
-            .. container:: card-header section-card
-               :attributes: id=heading-windows
-                            href=windows-install.html
-               :tagname: a
+            .. container:: card
 
-               Windows Install Instructions
+               .. container:: card-header section-card
+                  :attributes: id=heading-windows
+                              href=windows-install.html
+                  :tagname: a
 
-            .. container:: card-body
+                  Windows Install Instructions
 
-               Install Cantera on Windows. Cantera officially supports the versions of Windows that
-               Microsoft presently supports, although it may continue working on older versions of
-               Windows.
+               .. container:: card-body
 
-         .. container:: card
+                  Install Cantera on Windows. Cantera officially supports the versions of Windows that
+                  Microsoft presently supports, although it may continue working on older versions of
+                  Windows.
 
-            .. container:: card-header section-card
-               :attributes: id=heading-macos
-                            href=macos-install.html
-               :tagname: a
+            .. container:: card
 
-               macOS Install Instructions
+               .. container:: card-header section-card
+                  :attributes: id=heading-macos
+                              href=macos-install.html
+                  :tagname: a
 
-            .. container:: card-body
+                  macOS Install Instructions
 
-               Install Cantera on macOS/Mac OS X. The Cantera installer supports Mac OS X version
-               10.11 (El Capitan) and higher. For older versions of Mac OS X, users should
-               :ref:`compile from source <sec-compiling>`.
+               .. container:: card-body
 
-.. container::
-
-   .. row::
-
-      .. container:: card-deck
-
-         .. container:: card
-
-            .. container:: card-header section-card
-               :attributes: id=heading-ubuntu
-                            href=ubuntu-install.html
-               :tagname: a
-
-               Ubuntu Install Instructions
-
-            .. container:: card-body
-
-               Install Cantera on Ubuntu using a PPA.
-
-         .. container:: card
-
-            .. container:: card-header section-card
-               :attributes: id=heading-gentoo
-                            href=gentoo-install.html
-               :tagname: a
-
-               Gentoo Install Instructions
-
-            .. container:: card-body
-
-               Install Cantera on Gentoo using a portage.
-
-         .. container:: card
-
-            .. container:: card-header section-card
-               :attributes: id=heading-other-linux
-                            href=other-linux-install.html
-               :tagname: a
-
-               Other Linux Distributions Install Instructions
-
-            .. container:: card-body
-
-               Linux distributions other than Ubuntu and Gentoo can install the Python interface via Conda
-               (see :ref:`the Conda instructions <sec-install-conda>`). Other interfaces can be
-               installed by :ref:`compiling from source <sec-compiling>`.
-
-.. container::
+                  Install Cantera on macOS/Mac OS X. The Cantera installer supports Mac OS X version
+                  10.11 (El Capitan) and higher. For older versions of Mac OS X, users should
+                  :ref:`compile from source <sec-compiling>`.
 
    .. row::
 
-      .. container:: card-deck
+      .. container:: col-12
 
-         .. container:: card
+         .. container:: card-deck
 
-            .. container:: card-header section-card
-               :attributes: id=heading-compiling
-                            href=compiling-install.html
-               :tagname: a
+            .. container:: card
 
-               Compile Cantera from Source
+               .. container:: card-header section-card
+                  :attributes: id=heading-ubuntu
+                              href=ubuntu-install.html
+                  :tagname: a
 
-            .. container:: card-body
+                  Ubuntu Install Instructions
 
-               Compile Cantera directly from the source code for your platform.
+               .. container:: card-body
+
+                  Install Cantera on Ubuntu using a PPA.
+
+            .. container:: card
+
+               .. container:: card-header section-card
+                  :attributes: id=heading-gentoo
+                              href=gentoo-install.html
+                  :tagname: a
+
+                  Gentoo Install Instructions
+
+               .. container:: card-body
+
+                  Install Cantera on Gentoo using a portage.
+
+            .. container:: card
+
+               .. container:: card-header section-card
+                  :attributes: id=heading-other-linux
+                              href=other-linux-install.html
+                  :tagname: a
+
+                  Other Linux Distributions Install Instructions
+
+               .. container:: card-body
+
+                  Linux distributions other than Ubuntu and Gentoo can install the Python interface via Conda
+                  (see :ref:`the Conda instructions <sec-install-conda>`). Other interfaces can be
+                  installed by :ref:`compiling from source <sec-compiling>`.
+
+   .. row::
+
+      .. container:: col-sm-4 mx-auto
+
+         .. container:: card-deck
+
+            .. container:: card
+
+               .. container:: card-header section-card
+                  :attributes: id=heading-compiling
+                              href=compiling-install.html
+                  :tagname: a
+
+                  Compile Cantera from Source
+
+               .. container:: card-body
+
+                  Compile Cantera directly from the source code for your platform.

--- a/pages/install/other-linux-install.rst
+++ b/pages/install/other-linux-install.rst
@@ -1,6 +1,6 @@
 .. title: Installing Cantera on other Linux distributions
 .. slug: other-linux-install
-.. date: 2018-08-23 20:16:00 UTC-04:00
+.. date: 2019-06-26 20:00:00 UTC-04:00
 .. description: Installation instructions for Cantera on other Linux distributions
 .. type: text
 .. _sec-install-other-linux:
@@ -11,7 +11,7 @@
 
       <h1 class="display-3">Other Linux Distributions</h1>
 
-On Linux distributions other than Ubuntu, we recommend that you use the Conda package, described
+On Linux distributions other than Ubuntu and Gentoo, we recommend that you use the Conda package, described
 :ref:`on the Conda installation page <sec-install-conda>`. However, due to the limitations of
 distributing binary packages, the Conda package will not work on all Linux distributions (for
 instance, RHEL 6 is not supported). For these platforms, or if you want to use an interface other


### PR DESCRIPTION
This commit adds information about installation of Cantera 2.4.0
package in Gentoo Linux using Portage package system.

New `https://cantera.org/install/index.html` page after patch (note that Ubuntu and Gentoo rows are spanned special to avoid creation of third row but I could move the new instruction to `Other Linux Distributions Install Instructions` page):  

(initial view, see new one in the conversation below)
![install](https://user-images.githubusercontent.com/18756734/60218264-82881f80-9877-11e9-8c26-38c62c5d4cd0.png)

New `https://cantera.org/install/gentoo-install.html` page after patch:  

(initial view, see new one in the conversation below)
![gentoo-install](https://user-images.githubusercontent.com/18756734/60218263-81ef8900-9877-11e9-9477-e039c74f5755.png)
