### PR TITLE
Add MagicLink extension to Markdown

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1047,11 +1047,23 @@ MARKDOWN_EXTENSIONS = [
     "markdown.extensions.fenced_code",
     "markdown.extensions.codehilite",
     "markdown.extensions.extra",
+    "pymdownx.magiclink"
 ]
 
 # Options to be passed to markdown extensions (See https://python-markdown.github.io/reference/)
 # Default is {} (no config at all)
-# MARKDOWN_EXTENSION_CONFIGS = {}
+MARKDOWN_EXTENSION_CONFIGS = {
+    DEFAULT_LANG: {
+        "pymdownx.magiclink": {
+            "hide_protocol": True,
+            "repo_url_shortener": True,
+            "repo_url_shorthand": True,
+            "provider": "github",
+            "user": "Cantera",
+            "repo": "cantera"
+        }
+    }
+}
 
 
 # Extra options to pass to the pandoc command.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Nikola[extras]==8.0.*
 yapsy==1.11.*
 attrs>=17.4.0
+pymdown-extensions==5.0


### PR DESCRIPTION
This pull request adds PyMdown's MagicLink extension to Markdown, enabling auto-linking and shorthand display formats for web addresses and Github references.

See the full documentation for MagicLink here: https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/

Note: `requirements.txt` has been updated, please reinstall before building the site.