### PR TITLE
[Cantera 2.5] Update valve/etc. in science section

### DIFF
--- a/pages/science/reactors.rst
+++ b/pages/science/reactors.rst
@@ -326,26 +326,27 @@ to the reactors previously mentioned:
 
   .. math::
 
-     \dot m = c g(t) f(\Delta P)
+     \dot m = K_v g(t) f(P_1 - P_2)
 
-  with *c* being a proportionality constant. Further, *g* and *f* are functions
-  of time :math:`t` and pressure drop :math:`\Delta P` that are set by class
-  methods :py:meth:`setTimeFunction` and :py:meth:`setPressureFunction`,
+  with :math:`K_v` being a proportionality constant that is set using the class
+  property :py:attr:`Valve.valve_coeff`. Further, :math:`g` and :math:`f`
+  are functions of time and pressure drop that are set by class methods
+  :py:func:`Valve.set_time_function` and :py:func:`Valve.set_valve_function`,
   respectively. If no functions are specified, the mass flow rate defaults to:
 
   .. math::
 
-     \dot m = c \Delta P
+     \dot m = K_v (P_1 - P_2)
 
   The pressure difference between upstream (*1*) and downstream (*2*) reservoir
-  is defined as :math:`\Delta P = P_1 - P_2`. It is never possible for the
-  flow to reverse and go from the downstream to the upstream reactor/reservoir
-  through a line containing a Valve object, which means that the flow rate is
-  set to zero if :math:`P_1 < P_2`.
+  is defined as :math:`P_1 - P_2`. It is never possible for the flow to reverse
+  and go from the downstream to the upstream reactor/reservoir through a line
+  containing a Valve object, which means that the flow rate is set to zero if
+  :math:`P_1 < P_2`.
 
   Valve objects are often used between an upstream reactor and a downstream
   reactor or reservoir to maintain them both at nearly the same pressure. By
-  setting the constant :math:`c` to a sufficiently large value, very small
+  setting the constant :math:`K_v` to a sufficiently large value, very small
   pressure differences will result in flow between the reactors that counteracts
   the pressure difference.
 
@@ -355,15 +356,16 @@ to the reactors previously mentioned:
 
   .. math::
 
-     \dot m = m g(t)
+     \dot m = m_0 g(t)
 
-  where *m* is a mass flow coefficient and *g* is a function of time that is set
-  by the class method :py:meth:`setTimeFunction`. If no function is specified,
-  the mass flow rate defaults to:
+  where :math:`m_0` is a mass flow coefficient and :math:`g` is a function of time
+  which are set by class property :py:attr:`MassFlowController.mass_flow_coeff`
+  and method :py:func:`MassFlowController.set_time_function`, respectively. If no
+  function is specified, the mass flow rate defaults to:
 
   .. math::
 
-     \dot m = m
+     \dot m = m_0
 
   Note that if :math:`\dot m < 0`, the mass flow rate will be set to zero,
   since a reversal of the flow direction is not allowed.
@@ -385,16 +387,17 @@ to the reactors previously mentioned:
 
   .. math::
 
-     dot m = \dot m_{\mathrm{master}} + c f(\Delta P)
+     \dot m = \dot m_{\text{master}} + K_v f(P_1 - P_2)
 
-  where *c* is a proportionality constant and *f* is a function of pressure drop
-  :math:`\Delta P = P_1 - P_2` that is set by the class method
-  :py:meth:`setPressureFunction`. If no function is specified, the mass flow rate
-  defaults to:
+  where :math:`K_v` is a proportionality constant and :math:`f` is a function of
+  pressure drop :math:`\P_1 - P_2` that are set by class property
+  :py:attr:`PressureController.pressure_coeff` and method
+  :py:func:`PressureController.set_pressure_function`, respectively. If no
+  function is specified, the mass flow rate defaults to:
 
   .. math::
 
-     \dot m = \dot m_{\mathrm{master}} + c \Delta P
+     \dot m = \dot m_{\text{master}} + K_v (P_1 - P_2)
 
   Note that if :math:`\dot m < 0`, the mass flow rate will be set to zero,
   since a reversal of the flow direction is not allowed.

--- a/pages/science/reactors.rst
+++ b/pages/science/reactors.rst
@@ -329,7 +329,7 @@ to the reactors previously mentioned:
      \dot m = K_v g(t) f(P_1 - P_2)
 
   with :math:`K_v` being a proportionality constant that is set using the class
-  property :py:attr:`Valve.valve_coeff`. Further, :math:`g` and :math:`f`
+  property :py:func:`Valve.valve_coeff`. Further, :math:`g` and :math:`f`
   are functions of time and pressure drop that are set by class methods
   :py:func:`Valve.set_time_function` and :py:func:`Valve.set_valve_function`,
   respectively. If no functions are specified, the mass flow rate defaults to:
@@ -341,10 +341,10 @@ to the reactors previously mentioned:
   The pressure difference between upstream (*1*) and downstream (*2*) reservoir
   is defined as :math:`P_1 - P_2`. It is never possible for the flow to reverse
   and go from the downstream to the upstream reactor/reservoir through a line
-  containing a Valve object, which means that the flow rate is set to zero if
+  containing a :py:class:`Valve` object, which means that the flow rate is set to zero if
   :math:`P_1 < P_2`.
 
-  Valve objects are often used between an upstream reactor and a downstream
+  :py:class:`Valve` objects are often used between an upstream reactor and a downstream
   reactor or reservoir to maintain them both at nearly the same pressure. By
   setting the constant :math:`K_v` to a sufficiently large value, very small
   pressure differences will result in flow between the reactors that counteracts
@@ -359,7 +359,7 @@ to the reactors previously mentioned:
      \dot m = m_0 g(t)
 
   where :math:`m_0` is a mass flow coefficient and :math:`g` is a function of time
-  which are set by class property :py:attr:`MassFlowController.mass_flow_coeff`
+  which are set by class property :py:func:`MassFlowController.mass_flow_coeff`
   and method :py:func:`MassFlowController.set_time_function`, respectively. If no
   function is specified, the mass flow rate defaults to:
 
@@ -379,7 +379,7 @@ to the reactors previously mentioned:
 
 - :py:class:`PressureController`: A pressure controller is designed to be used in
   conjunction with another 'master' flow controller, typically a
-  MassFlowController. The master flow controller is installed on the inlet of
+  :py:class:`MassFlowController`. The master flow controller is installed on the inlet of
   the reactor, and the corresponding :py:class:`PressureController` is installed on on
   outlet of the reactor. The :py:class:`PressureController` mass flow rate is equal to the
   master mass flow rate, plus a small correction dependent on the pressure
@@ -391,7 +391,7 @@ to the reactors previously mentioned:
 
   where :math:`K_v` is a proportionality constant and :math:`f` is a function of
   pressure drop :math:`\P_1 - P_2` that are set by class property
-  :py:attr:`PressureController.pressure_coeff` and method
+  :py:func:`PressureController.pressure_coeff` and method
   :py:func:`PressureController.set_pressure_function`, respectively. If no
   function is specified, the mass flow rate defaults to:
 
@@ -417,7 +417,7 @@ current state of the system, it can be advanced in time by one of the following 
   :math:`\Delta t_{\mathrm{max}}`. The new time :math:`t_{\mathrm{new}}` is
   returned by this function.
 
-- ``advance``\ :math:`(t_{\mathrm{new}})`: This method computes the state of the
+- ``advance(``\ :math:`t_{\mathrm{new}}`\ ``)``: This method computes the state of the
   system at time :math:`t_{\mathrm{new}}`. :math:`t_{\mathrm{new}}` describes
   the absolute time from the initial time of the system. By calling this method
   in a for loop for pre-defined times, the state of the system is obtained for

--- a/pages/science/reactors.rst
+++ b/pages/science/reactors.rst
@@ -322,26 +322,30 @@ to the reactors previously mentioned:
   detail of how the wall affects the connected reactors.
 
 - :py:class:`Valve`: A valve is a flow devices with mass flow rate that is a function of
-  the pressure drop across it. The default behavior is linear:
+  the pressure drop across it. The mass flow rate is computed as:
 
   .. math::
 
-     \dot m = K_v (P_1 - P_2)
+     \dot m = c g(t) f(\Delta P)
 
-  if :math:`P_1 > P_2.` Otherwise, :math:`\dot m = 0`. However, an arbitrary
-  function can also be specified, such that
+  with *c* being a proportionality constant. Further, *g* and *f* are functions
+  of time :math:`t` and pressure drop :math:`\Delta P` that are set by class
+  methods :py:meth:`setTimeFunction` and :py:meth:`setPressureFunction`,
+  respectively. If no functions are specified, the mass flow rate defaults to:
 
   .. math::
 
-     \dot m = F(P_1 - P_2)
+     \dot m = c \Delta P
 
-  if :math:`P_1 > P_2`, or :math:`\dot m = 0` otherwise. It is never possible
-  for the flow to reverse and go from the downstream to the upstream
-  reactor/reservoir through a line containing a Valve object.
+  The pressure difference between upstream (*1*) and downstream (*2*) reservoir
+  is defined as :math:`\Delta P = P_1 - P_2`. It is never possible for the
+  flow to reverse and go from the downstream to the upstream reactor/reservoir
+  through a line containing a Valve object, which means that the flow rate is
+  set to zero if :math:`P_1 < P_2`.
 
   Valve objects are often used between an upstream reactor and a downstream
   reactor or reservoir to maintain them both at nearly the same pressure. By
-  setting the constant :math:`K_v` to a sufficiently large value, very small
+  setting the constant :math:`c` to a sufficiently large value, very small
   pressure differences will result in flow between the reactors that counteracts
   the pressure difference.
 
@@ -351,11 +355,18 @@ to the reactors previously mentioned:
 
   .. math::
 
-     \dot m = \max(\dot m_0, 0.0)
+     \dot m = m g(t)
 
-  where :math:`\dot m_0` is either a constant value or a function of time. Note
-  that if :math:`\dot m_0 < 0`, the mass flow rate will be set to zero, since
-  reversal of the flow direction is not allowed.
+  where *m* is a mass flow coefficient and *g* is a function of time that is set
+  by the class method :py:meth:`setTimeFunction`. If no function is specified,
+  the mass flow rate defaults to:
+
+  .. math::
+
+     \dot m = m
+
+  Note that if :math:`\dot m < 0`, the mass flow rate will be set to zero,
+  since a reversal of the flow direction is not allowed.
 
   Unlike a real mass flow controller, a :py:class:`MassFlowController` object will maintain
   the flow even if the downstream pressure is greater than the upstream
@@ -374,7 +385,19 @@ to the reactors previously mentioned:
 
   .. math::
 
-     \dot m = \dot m_{\mathrm{master}} + K_v(P_1 - P_2).
+     dot m = \dot m_{\mathrm{master}} + c f(\Delta P)
+
+  where *c* is a proportionality constant and *f* is a function of pressure drop
+  :math:`\Delta P = P_1 - P_2` that is set by the class method
+  :py:meth:`setPressureFunction`. If no function is specified, the mass flow rate
+  defaults to:
+
+  .. math::
+
+     \dot m = \dot m_{\mathrm{master}} + c \Delta P
+
+  Note that if :math:`\dot m < 0`, the mass flow rate will be set to zero,
+  since a reversal of the flow direction is not allowed.
 
 Time Integration
 ----------------


### PR DESCRIPTION
Addresses @speth's comment in Cantera/cantera#667

> The one remaining to-do for this change is to update the "science" documentation for the reactor model on cantera.org (https://cantera.org/science/reactors.html#reactor-networks-and-devices).

Per @bryanwweber's comment in #88, the update should be parked as a PR until the release of 2.5.