### PR TITLE
Update katex

### DIFF
--- a/api-docs/bump_katex.py
+++ b/api-docs/bump_katex.py
@@ -1,0 +1,41 @@
+import lxml.html as lh
+from pathlib import Path
+
+for f in Path("api-docs/docs-2.4/sphinx/html").glob("**/*.html"):
+    print(f)
+    doc = lh.parse(str(f))
+    head = doc.find("head")
+    for l in head.findall("link"):
+        if "jsdelivr" not in l.get("href", ""):
+            continue
+        l.set("href", "https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css")
+        l.set(
+            "integrity",
+            "sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq",
+        )
+        l.set("crossorigin", "anonymous")
+
+    for l in head.findall("script"):
+        if "jsdelivr" not in l.get("src", ""):
+            continue
+        if "katex.min.js" in l.get("src"):
+            l.set("src", "https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js")
+            l.set(
+                "integrity",
+                "sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz",
+            )
+        elif "auto-render.min.js" in l.get("src"):
+            l.set(
+                "src",
+                "https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js",
+            )
+            l.set(
+                "integrity",
+                "sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI",
+            )
+
+        l.set("defer", None)
+        l.set("crossorigin", "anonymous")
+
+    with open(f, "w") as file_obj:
+        file_obj.write(lh.tostring(doc).decode("utf-8"))

--- a/api-docs/docs-2.4/sphinx/html/cti/classes.html
+++ b/api-docs/docs-2.4/sphinx/html/cti/classes.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>CTI Class Reference | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,25 +77,25 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="module-cantera.ctml_writer">
-<span id="cti-class-reference"></span><h1>CTI Class Reference<a class="headerlink" href="#module-cantera.ctml_writer" title="Permalink to this headline">¶</a></h1>
+<span id="cti-class-reference"></span><h1>CTI Class Reference<a class="headerlink" href="#module-cantera.ctml_writer" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="basic-classes-functions">
-<h2>Basic Classes &amp; Functions<a class="headerlink" href="#basic-classes-functions" title="Permalink to this headline">¶</a></h2>
+<h2>Basic Classes &amp; Functions<a class="headerlink" href="#basic-classes-functions" title="Permalink to this headline">&#182;</a></h2>
 <dl class="function">
 <dt id="cantera.ctml_writer.units">
-<code class="descclassname">cantera.ctml_writer.</code><code class="descname">units</code><span class="sig-paren">(</span><em>length=''</em>, <em>quantity=''</em>, <em>mass=''</em>, <em>time=''</em>, <em>act_energy=''</em>, <em>energy=''</em>, <em>pressure=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.units" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.ctml_writer.</code><code class="descname">units</code><span class="sig-paren">(</span><em>length=''</em>, <em>quantity=''</em>, <em>mass=''</em>, <em>time=''</em>, <em>act_energy=''</em>, <em>energy=''</em>, <em>pressure=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.units" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the default units.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>length</strong> – The default units for length. Default: <code class="docutils literal notranslate"><span class="pre">'m'</span></code></li>
-<li><strong>mass</strong> – The default units for mass. Default: <code class="docutils literal notranslate"><span class="pre">'kg'</span></code></li>
-<li><strong>quantity</strong> – The default units to specify number of molecules. Default: <code class="docutils literal notranslate"><span class="pre">'kmol'</span></code></li>
-<li><strong>time</strong> – The default units for time. Default: <code class="docutils literal notranslate"><span class="pre">'s'</span></code></li>
-<li><strong>energy</strong> – The default units for energies. Default: <code class="docutils literal notranslate"><span class="pre">'J'</span></code></li>
-<li><strong>act_energy</strong> – The default units for activation energies. Default: <code class="docutils literal notranslate"><span class="pre">'K'</span></code></li>
-<li><strong>pressure</strong> – The default units for pressure. Default: <code class="docutils literal notranslate"><span class="pre">'Pa'</span></code></li>
+<li><strong>length</strong> &#8211; The default units for length. Default: <code class="docutils literal notranslate"><span class="pre">'m'</span></code></li>
+<li><strong>mass</strong> &#8211; The default units for mass. Default: <code class="docutils literal notranslate"><span class="pre">'kg'</span></code></li>
+<li><strong>quantity</strong> &#8211; The default units to specify number of molecules. Default: <code class="docutils literal notranslate"><span class="pre">'kmol'</span></code></li>
+<li><strong>time</strong> &#8211; The default units for time. Default: <code class="docutils literal notranslate"><span class="pre">'s'</span></code></li>
+<li><strong>energy</strong> &#8211; The default units for energies. Default: <code class="docutils literal notranslate"><span class="pre">'J'</span></code></li>
+<li><strong>act_energy</strong> &#8211; The default units for activation energies. Default: <code class="docutils literal notranslate"><span class="pre">'K'</span></code></li>
+<li><strong>pressure</strong> &#8211; The default units for pressure. Default: <code class="docutils literal notranslate"><span class="pre">'Pa'</span></code></li>
 </ul>
 </td>
 </tr>
@@ -109,15 +105,15 @@ lang="en">
 
 <dl class="function">
 <dt id="cantera.ctml_writer.validate">
-<code class="descclassname">cantera.ctml_writer.</code><code class="descname">validate</code><span class="sig-paren">(</span><em>species='yes'</em>, <em>reactions='yes'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.validate" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.ctml_writer.</code><code class="descname">validate</code><span class="sig-paren">(</span><em>species='yes'</em>, <em>reactions='yes'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.validate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Enable or disable validation of species and reactions.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>species</strong> – Set to <code class="docutils literal notranslate"><span class="pre">'yes'</span></code> (default) or <code class="docutils literal notranslate"><span class="pre">'no'</span></code>.</li>
-<li><strong>reactions</strong> – Set to <code class="docutils literal notranslate"><span class="pre">'yes'</span></code> (default) or <code class="docutils literal notranslate"><span class="pre">'no'</span></code>. This controls duplicate reaction checks
+<li><strong>species</strong> &#8211; Set to <code class="docutils literal notranslate"><span class="pre">'yes'</span></code> (default) or <code class="docutils literal notranslate"><span class="pre">'no'</span></code>.</li>
+<li><strong>reactions</strong> &#8211; Set to <code class="docutils literal notranslate"><span class="pre">'yes'</span></code> (default) or <code class="docutils literal notranslate"><span class="pre">'no'</span></code>. This controls duplicate reaction checks
 and validation of rate expressions for some reaction types.</li>
 </ul>
 </td>
@@ -128,23 +124,23 @@ and validation of rate expressions for some reaction types.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.state">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">state</code><span class="sig-paren">(</span><em>temperature=None</em>, <em>pressure=None</em>, <em>mole_fractions=None</em>, <em>mass_fractions=None</em>, <em>density=None</em>, <em>coverages=None</em>, <em>solute_molalities=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.state" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">state</code><span class="sig-paren">(</span><em>temperature=None</em>, <em>pressure=None</em>, <em>mole_fractions=None</em>, <em>mass_fractions=None</em>, <em>density=None</em>, <em>coverages=None</em>, <em>solute_molalities=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.state" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>An embedded entry that specifies the thermodynamic state of a phase
 or interface.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>temperature</strong> – The temperature.</li>
-<li><strong>pressure</strong> – The pressure.</li>
-<li><strong>density</strong> – The density. Cannot be specified if the phase is incompressible.</li>
-<li><strong>mole_fractions</strong> – A string specifying the species mole fractions. Unspecified species
+<li><strong>temperature</strong> &#8211; The temperature.</li>
+<li><strong>pressure</strong> &#8211; The pressure.</li>
+<li><strong>density</strong> &#8211; The density. Cannot be specified if the phase is incompressible.</li>
+<li><strong>mole_fractions</strong> &#8211; A string specifying the species mole fractions. Unspecified species
 are set to zero.</li>
-<li><strong>mass_fractions</strong> – A string specifying the species mass fractions. Unspecified species
+<li><strong>mass_fractions</strong> &#8211; A string specifying the species mass fractions. Unspecified species
 are set to zero.</li>
-<li><strong>coverages</strong> – A string specifying the species coverages. Unspecified species are
+<li><strong>coverages</strong> &#8211; A string specifying the species coverages. Unspecified species are
 set to zero. Can only be specified for interfaces.</li>
 </ul>
 </td>
@@ -155,34 +151,34 @@ set to zero. Can only be specified for interfaces.</li>
 
 </div>
 <div class="section" id="phases-of-matter">
-<h2>Phases of Matter<a class="headerlink" href="#phases-of-matter" title="Permalink to this headline">¶</a></h2>
+<h2>Phases of Matter<a class="headerlink" href="#phases-of-matter" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.ctml_writer.phase">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">phase</code><span class="sig-paren">(</span><em>name=''</em>, <em>dim=3</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>reactions='none'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.phase" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">phase</code><span class="sig-paren">(</span><em>name=''</em>, <em>dim=3</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>reactions='none'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.phase" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>Base class for phases of matter.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>name</strong> – A string to identify the phase. Must be unique among the phase
+<li><strong>name</strong> &#8211; A string to identify the phase. Must be unique among the phase
 names within the file.</li>
-<li><strong>elements</strong> – The elements. A string of element symbols.</li>
-<li><strong>species</strong> – The species. A string or sequence of strings in the format
+<li><strong>elements</strong> &#8211; The elements. A string of element symbols.</li>
+<li><strong>species</strong> &#8211; The species. A string or sequence of strings in the format
 described in <a class="reference external" href="https://cantera.org/tutorials/cti/phases.html#defining-the-species">Defining the Species</a>.</li>
-<li><strong>note</strong> – A user-defined comment. Not evaluated by Cantera itself.</li>
-<li><strong>reactions</strong> – The homogeneous reactions. If omitted, no reactions will be
+<li><strong>note</strong> &#8211; A user-defined comment. Not evaluated by Cantera itself.</li>
+<li><strong>reactions</strong> &#8211; The homogeneous reactions. If omitted, no reactions will be
 included. A string or sequence of strings in the format described
 in <a class="reference external" href="https://cantera.org/tutorials/cti/phases.html#declaring-the-reactions">Declaring the Reactions</a>.
 This field is not allowed for <code class="docutils literal notranslate"><span class="pre">stoichiometric_solid</span></code> and
 <code class="docutils literal notranslate"><span class="pre">stoichiometric_liquid</span></code> entries.</li>
-<li><strong>kinetics</strong> – The kinetics model. Optional; if omitted, the default model for the
+<li><strong>kinetics</strong> &#8211; The kinetics model. Optional; if omitted, the default model for the
 phase type will be used.</li>
-<li><strong>transport</strong> – The transport property model. Optional. If omitted, transport
+<li><strong>transport</strong> &#8211; The transport property model. Optional. If omitted, transport
 property calculation will be disabled.</li>
-<li><strong>initial_state</strong> – Initial thermodynamic state, specified with an embedded state entry.</li>
-<li><strong>options</strong> – Special processing options. Optional.</li>
+<li><strong>initial_state</strong> &#8211; Initial thermodynamic state, specified with an embedded state entry.</li>
+<li><strong>options</strong> &#8211; Special processing options. Optional.</li>
 </ul>
 </td>
 </tr>
@@ -192,20 +188,20 @@ property calculation will be disabled.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.ideal_gas">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">ideal_gas</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>reactions='none'</em>, <em>kinetics='GasKinetics'</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.ideal_gas" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">ideal_gas</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>reactions='none'</em>, <em>kinetics='GasKinetics'</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.ideal_gas" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.phase</span></code></a></p>
 <p>An ideal gas mixture.</p>
 <p>The parameters correspond to those of <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">phase</span></code></a>, with the
 following modifications:</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>kinetics</strong> – The kinetics model. Usually this field is omitted, in which case
+<li><strong>kinetics</strong> &#8211; The kinetics model. Usually this field is omitted, in which case
 kinetics model GasKinetics, appropriate for reactions in ideal gas
 mixtures, is used.</li>
-<li><strong>transport</strong> – The transport property model. One of the strings <code class="docutils literal notranslate"><span class="pre">'none'</span></code>,
+<li><strong>transport</strong> &#8211; The transport property model. One of the strings <code class="docutils literal notranslate"><span class="pre">'none'</span></code>,
 <code class="docutils literal notranslate"><span class="pre">'multi'</span></code>, or <code class="docutils literal notranslate"><span class="pre">'mix'</span></code>. Default: <code class="docutils literal notranslate"><span class="pre">'none'</span></code>.</li>
 </ul>
 </td>
@@ -214,7 +210,7 @@ mixtures, is used.</li>
 </table>
 <dl class="method">
 <dt id="cantera.ctml_writer.ideal_gas.is_ideal_gas">
-<code class="descname">is_ideal_gas</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.ideal_gas.is_ideal_gas" title="Permalink to this definition">¶</a></dt>
+<code class="descname">is_ideal_gas</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.ideal_gas.is_ideal_gas" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>True if the entry represents an ideal gas.</p>
 </dd></dl>
 
@@ -222,7 +218,7 @@ mixtures, is used.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.stoichiometric_solid">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">stoichiometric_solid</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>density=None</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.stoichiometric_solid" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">stoichiometric_solid</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>density=None</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.stoichiometric_solid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.phase</span></code></a></p>
 <p>A solid compound or pure element. Stoichiometric solid phases contain
 exactly one species, which always has unit activity. The solid is assumed
@@ -234,7 +230,7 @@ phase, since the concentration is always the same.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.stoichiometric_liquid">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">stoichiometric_liquid</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>density=-1.0</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.stoichiometric_liquid" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">stoichiometric_liquid</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>density=-1.0</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.stoichiometric_liquid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.stoichiometric_solid" title="cantera.ctml_writer.stoichiometric_solid"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.stoichiometric_solid</span></code></a></p>
 <p>An incompressible stoichiometric liquid. Currently, there is no
 distinction between stoichiometric liquids and solids.</p>
@@ -243,12 +239,12 @@ distinction between stoichiometric liquids and solids.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.metal">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">metal</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>density=-1.0</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.metal" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">metal</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>density=-1.0</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.metal" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.phase</span></code></a></p>
 <p>A metal.</p>
 <dl class="method">
 <dt id="cantera.ctml_writer.metal.conc_dim">
-<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.metal.conc_dim" title="Permalink to this definition">¶</a></dt>
+<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.metal.conc_dim" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Concentration dimensions. Used in computing the units for reaction
 rate coefficients.</p>
 </dd></dl>
@@ -257,12 +253,12 @@ rate coefficients.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.semiconductor">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">semiconductor</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>density=-1.0</em>, <em>bandgap=96485336.4595687</em>, <em>effectiveMass_e=9.10938291e-31</em>, <em>effectiveMass_h=9.10938291e-31</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.semiconductor" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">semiconductor</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>density=-1.0</em>, <em>bandgap=96485336.4595687</em>, <em>effectiveMass_e=9.10938291e-31</em>, <em>effectiveMass_h=9.10938291e-31</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.semiconductor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.phase</span></code></a></p>
 <p>A semiconductor.</p>
 <dl class="method">
 <dt id="cantera.ctml_writer.semiconductor.conc_dim">
-<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.semiconductor.conc_dim" title="Permalink to this definition">¶</a></dt>
+<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.semiconductor.conc_dim" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Concentration dimensions. Used in computing the units for reaction
 rate coefficients.</p>
 </dd></dl>
@@ -271,12 +267,12 @@ rate coefficients.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.incompressible_solid">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">incompressible_solid</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>density=None</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.incompressible_solid" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">incompressible_solid</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>density=None</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.incompressible_solid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.phase</span></code></a></p>
 <p>An incompressible solid.</p>
 <dl class="method">
 <dt id="cantera.ctml_writer.incompressible_solid.conc_dim">
-<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.incompressible_solid.conc_dim" title="Permalink to this definition">¶</a></dt>
+<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.incompressible_solid.conc_dim" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Concentration dimensions. Used in computing the units for reaction
 rate coefficients.</p>
 </dd></dl>
@@ -285,18 +281,18 @@ rate coefficients.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.lattice">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">lattice</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>reactions='none'</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em>, <em>site_density=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.lattice" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">lattice</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>reactions='none'</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em>, <em>site_density=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.lattice" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.phase</span></code></a></p>
 </dd></dl>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.lattice_solid">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">lattice_solid</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>lattices=[]</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.lattice_solid" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">lattice_solid</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>lattices=[]</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.lattice_solid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.phase</span></code></a></p>
 <p>A solid crystal consisting of one or more sublattices.</p>
 <dl class="method">
 <dt id="cantera.ctml_writer.lattice_solid.conc_dim">
-<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.lattice_solid.conc_dim" title="Permalink to this definition">¶</a></dt>
+<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.lattice_solid.conc_dim" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Concentration dimensions. Used in computing the units for reaction
 rate coefficients.</p>
 </dd></dl>
@@ -305,7 +301,7 @@ rate coefficients.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.liquid_vapor">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">liquid_vapor</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>substance_flag=0</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.liquid_vapor" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">liquid_vapor</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>substance_flag=0</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.liquid_vapor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.phase</span></code></a></p>
 <p>A fluid with a complete liquid/vapor equation of state.
 This entry type selects one of a set of predefined fluids with
@@ -314,7 +310,7 @@ parameter selects the fluid. See liquidvapor.cti and liquidvapor.py
 for the usage of this entry type.</p>
 <dl class="method">
 <dt id="cantera.ctml_writer.liquid_vapor.conc_dim">
-<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.liquid_vapor.conc_dim" title="Permalink to this definition">¶</a></dt>
+<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.liquid_vapor.conc_dim" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Concentration dimensions. Used in computing the units for reaction
 rate coefficients.</p>
 </dd></dl>
@@ -323,21 +319,21 @@ rate coefficients.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.ideal_interface">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">ideal_interface</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>reactions='none'</em>, <em>site_density=0.0</em>, <em>phases=[]</em>, <em>kinetics='Interface'</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.ideal_interface" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">ideal_interface</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>reactions='none'</em>, <em>site_density=0.0</em>, <em>phases=[]</em>, <em>kinetics='Interface'</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.ideal_interface" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.phase</span></code></a></p>
 <p>A chemically-reacting ideal surface solution of multiple species.</p>
 <p>The parameters correspond to those of <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">phase</span></code></a>, with the
 following modifications:</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>reactions</strong> – The heterogeneous reactions at this interface. If omitted, no
+<li><strong>reactions</strong> &#8211; The heterogeneous reactions at this interface. If omitted, no
 reactions will be included. A string or sequence of strings in the
 format described in <a class="reference external" href="https://cantera.org/tutorials/cti/phases.html#declaring-the-reactions">Declaring the Reactions</a>.</li>
-<li><strong>site_density</strong> – The number of adsorption sites per unit area.</li>
-<li><strong>phases</strong> – A string listing the bulk phases that participate in reactions
+<li><strong>site_density</strong> &#8211; The number of adsorption sites per unit area.</li>
+<li><strong>phases</strong> &#8211; A string listing the bulk phases that participate in reactions
 at this interface.</li>
 </ul>
 </td>
@@ -346,7 +342,7 @@ at this interface.</li>
 </table>
 <dl class="method">
 <dt id="cantera.ctml_writer.ideal_interface.conc_dim">
-<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.ideal_interface.conc_dim" title="Permalink to this definition">¶</a></dt>
+<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.ideal_interface.conc_dim" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Concentration dimensions. Used in computing the units for reaction
 rate coefficients.</p>
 </dd></dl>
@@ -355,12 +351,12 @@ rate coefficients.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.edge">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">edge</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>reactions='none'</em>, <em>site_density=0.0</em>, <em>phases=[]</em>, <em>kinetics='Edge'</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.edge" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">edge</code><span class="sig-paren">(</span><em>name=''</em>, <em>elements=''</em>, <em>species=''</em>, <em>note=''</em>, <em>reactions='none'</em>, <em>site_density=0.0</em>, <em>phases=[]</em>, <em>kinetics='Edge'</em>, <em>transport='None'</em>, <em>initial_state=None</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.edge" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.phase" title="cantera.ctml_writer.phase"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.phase</span></code></a></p>
 <p>A 1D boundary between two surface phases.</p>
 <dl class="method">
 <dt id="cantera.ctml_writer.edge.conc_dim">
-<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.edge.conc_dim" title="Permalink to this definition">¶</a></dt>
+<code class="descname">conc_dim</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.edge.conc_dim" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Concentration dimensions. Used in computing the units for reaction
 rate coefficients.</p>
 </dd></dl>
@@ -369,19 +365,19 @@ rate coefficients.</p>
 
 </div>
 <div class="section" id="elements-and-species">
-<h2>Elements and Species<a class="headerlink" href="#elements-and-species" title="Permalink to this headline">¶</a></h2>
+<h2>Elements and Species<a class="headerlink" href="#elements-and-species" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.ctml_writer.element">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">element</code><span class="sig-paren">(</span><em>symbol=''</em>, <em>atomic_mass=0.01</em>, <em>atomic_number=0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.element" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">element</code><span class="sig-paren">(</span><em>symbol=''</em>, <em>atomic_mass=0.01</em>, <em>atomic_number=0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.element" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>An atomic element or isotope.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>symbol</strong> – The symbol for the element or isotope.</li>
-<li><strong>atomic_mass</strong> – The atomic mass in amu.</li>
+<li><strong>symbol</strong> &#8211; The symbol for the element or isotope.</li>
+<li><strong>atomic_mass</strong> &#8211; The atomic mass in amu.</li>
 </ul>
 </td>
 </tr>
@@ -391,36 +387,36 @@ rate coefficients.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.species">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">species</code><span class="sig-paren">(</span><em>name='missing name!'</em>, <em>atoms=''</em>, <em>note=''</em>, <em>thermo=None</em>, <em>transport=None</em>, <em>charge=-999</em>, <em>size=1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.species" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">species</code><span class="sig-paren">(</span><em>name='missing name!'</em>, <em>atoms=''</em>, <em>note=''</em>, <em>thermo=None</em>, <em>transport=None</em>, <em>charge=-999</em>, <em>size=1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>A constituent of a phase or interface.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>name</strong> – The species name (or formula). The name may be arbitrarily long,
+<li><strong>name</strong> &#8211; The species name (or formula). The name may be arbitrarily long,
 although usually a relatively short, abbreviated name is most
 convenient. Required parameter.</li>
-<li><strong>atoms</strong> – The atomic composition, specified by a string containing
+<li><strong>atoms</strong> &#8211; The atomic composition, specified by a string containing
 space-delimited <code class="docutils literal notranslate"><span class="pre">&lt;element&gt;:&lt;atoms&gt;</span></code> pairs. The number of atoms may be
 either an integer or a floating-point number.</li>
-<li><strong>note</strong> – A user-defined comment. Not evaluated by Cantera itself.</li>
-<li><strong>thermo</strong> – The parameterization to use to compute the reference-state
+<li><strong>note</strong> &#8211; A user-defined comment. Not evaluated by Cantera itself.</li>
+<li><strong>thermo</strong> &#8211; The parameterization to use to compute the reference-state
 thermodynamic properties. This must be one of the entry types
 described in <a class="reference external" href="https://cantera.org/science/science-species.html#sec-thermo-models">Thermodynamic Property Models</a>.
 To specify multiple parameterizations, each for a different temperature range,
 group them in parentheses.</li>
-<li><strong>transport</strong> – An entry specifying parameters to compute this species’
+<li><strong>transport</strong> &#8211; An entry specifying parameters to compute this species&#8217;
 contribution to the transport properties. This must be one of the
 entry types described in <a class="reference external" href="https://cantera.org/science/science-species.html#species-transport-coefficients">Species Transport Coefficients</a>,
 and must be consistent with the transport model of the phase into which
 the species is imported. To specify parameters for multiple
 transport models, group the entries in parentheses.</li>
-<li><strong>size</strong> – The species “size”. Currently used only for surface species,
+<li><strong>size</strong> &#8211; The species &#8220;size&#8221;. Currently used only for surface species,
 where it represents the number of sites occupied.</li>
-<li><strong>charge</strong> – The charge, in multiples of <span class="math">\(|e|\)</span>. If not specified, the
-charge will be calculated from the number of “atoms” of element
+<li><strong>charge</strong> &#8211; The charge, in multiples of <span class="math">\(|e|\)</span>. If not specified, the
+charge will be calculated from the number of &#8220;atoms&#8221; of element
 <code class="docutils literal notranslate"><span class="pre">E</span></code>, which represents an electron.</li>
 </ul>
 </td>
@@ -431,10 +427,10 @@ charge will be calculated from the number of “atoms” of element
 
 </div>
 <div class="section" id="thermodynamic-properties">
-<h2>Thermodynamic Properties<a class="headerlink" href="#thermodynamic-properties" title="Permalink to this headline">¶</a></h2>
+<h2>Thermodynamic Properties<a class="headerlink" href="#thermodynamic-properties" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.ctml_writer.Mu0_table">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Mu0_table</code><span class="sig-paren">(</span><em>Trange=(0.0</em>, <em>0.0)</em>, <em>h298=0.0</em>, <em>mu0=None</em>, <em>p0=-1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.Mu0_table" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Mu0_table</code><span class="sig-paren">(</span><em>Trange=(0.0</em>, <em>0.0)</em>, <em>h298=0.0</em>, <em>mu0=None</em>, <em>p0=-1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.Mu0_table" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.thermo</span></code></p>
 <p>Properties are computed by specifying a table of standard
 chemical potentials vs. T.</p>
@@ -442,19 +438,19 @@ chemical potentials vs. T.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.NASA">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">NASA</code><span class="sig-paren">(</span><em>Trange=(0.0</em>, <em>0.0)</em>, <em>coeffs=[]</em>, <em>p0=-1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.NASA" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">NASA</code><span class="sig-paren">(</span><em>Trange=(0.0</em>, <em>0.0)</em>, <em>coeffs=[]</em>, <em>p0=-1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.NASA" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.thermo</span></code></p>
 <p>The 7-coefficient NASA polynomial parameterization.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>Trange</strong> – The temperature range over which the parameterization is valid.
+<li><strong>Trange</strong> &#8211; The temperature range over which the parameterization is valid.
 This must be entered as a sequence of two temperature values.
 Required.</li>
-<li><strong>coeffs</strong> – List of seven coefficients <span class="math">\((a_0, \ldots , a_6)\)</span></li>
-<li><strong>p0</strong> – The reference-state pressure, usually 1 atm or 1 bar. If omitted,
+<li><strong>coeffs</strong> &#8211; List of seven coefficients <span class="math">\((a_0, \ldots , a_6)\)</span></li>
+<li><strong>p0</strong> &#8211; The reference-state pressure, usually 1 atm or 1 bar. If omitted,
 the default value is used, which is set by the <code class="docutils literal notranslate"><span class="pre">standard_pressure</span></code>
 directive.</li>
 </ul>
@@ -466,19 +462,19 @@ directive.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.NASA9">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">NASA9</code><span class="sig-paren">(</span><em>Trange=(0.0</em>, <em>0.0)</em>, <em>coeffs=[]</em>, <em>p0=-1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.NASA9" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">NASA9</code><span class="sig-paren">(</span><em>Trange=(0.0</em>, <em>0.0)</em>, <em>coeffs=[]</em>, <em>p0=-1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.NASA9" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.thermo</span></code></p>
 <p>NASA9 polynomial parameterization for a single temperature region.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>Trange</strong> – The temperature range over which the parameterization is valid.
+<li><strong>Trange</strong> &#8211; The temperature range over which the parameterization is valid.
 This must be entered as a sequence of two temperature values.
 Required.</li>
-<li><strong>coeffs</strong> – List of nine coefficients <span class="math">\((a_0, \ldots , a_8)\)</span></li>
-<li><strong>p0</strong> – The reference-state pressure, usually 1 atm or 1 bar. If omitted,
+<li><strong>coeffs</strong> &#8211; List of nine coefficients <span class="math">\((a_0, \ldots , a_8)\)</span></li>
+<li><strong>p0</strong> &#8211; The reference-state pressure, usually 1 atm or 1 bar. If omitted,
 the default value is used, which is set by the <code class="docutils literal notranslate"><span class="pre">standard_pressure</span></code>
 directive.</li>
 </ul>
@@ -490,19 +486,19 @@ directive.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.Shomate">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Shomate</code><span class="sig-paren">(</span><em>Trange=(0.0</em>, <em>0.0)</em>, <em>coeffs=[]</em>, <em>p0=-1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.Shomate" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Shomate</code><span class="sig-paren">(</span><em>Trange=(0.0</em>, <em>0.0)</em>, <em>coeffs=[]</em>, <em>p0=-1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.Shomate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.thermo</span></code></p>
 <p>Shomate polynomial parameterization.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>Trange</strong> – The temperature range over which the parameterization is valid.
+<li><strong>Trange</strong> &#8211; The temperature range over which the parameterization is valid.
 This must be entered as a sequence of two temperature values.
 Required input.</li>
-<li><strong>coeffs</strong> – Sequence of seven coefficients <span class="math">\((A, \ldots ,G)\)</span></li>
-<li><strong>p0</strong> – The reference-state pressure, usually 1 atm or 1 bar. If omitted,
+<li><strong>coeffs</strong> &#8211; Sequence of seven coefficients <span class="math">\((A, \ldots ,G)\)</span></li>
+<li><strong>p0</strong> &#8211; The reference-state pressure, usually 1 atm or 1 bar. If omitted,
 the default value set by the <code class="docutils literal notranslate"><span class="pre">standard_pressure</span></code> directive is used.</li>
 </ul>
 </td>
@@ -513,7 +509,7 @@ the default value set by the <code class="docutils literal notranslate"><span cl
 
 <dl class="class">
 <dt id="cantera.ctml_writer.Adsorbate">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Adsorbate</code><span class="sig-paren">(</span><em>Trange=(0.0</em>, <em>0.0)</em>, <em>binding_energy=0.0</em>, <em>frequencies=[]</em>, <em>p0=-1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.Adsorbate" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Adsorbate</code><span class="sig-paren">(</span><em>Trange=(0.0</em>, <em>0.0)</em>, <em>binding_energy=0.0</em>, <em>frequencies=[]</em>, <em>p0=-1.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.Adsorbate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.thermo</span></code></p>
 <p>Adsorbed species characterized by a binding energy and a set of
 vibrational frequencies.</p>
@@ -521,18 +517,18 @@ vibrational frequencies.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.const_cp">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">const_cp</code><span class="sig-paren">(</span><em>t0=298.15</em>, <em>cp0=0.0</em>, <em>h0=0.0</em>, <em>s0=0.0</em>, <em>tmax=5000.0</em>, <em>tmin=100.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.const_cp" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">const_cp</code><span class="sig-paren">(</span><em>t0=298.15</em>, <em>cp0=0.0</em>, <em>h0=0.0</em>, <em>s0=0.0</em>, <em>tmax=5000.0</em>, <em>tmin=100.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.const_cp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.thermo</span></code></p>
 <p>Constant specific heat.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>t0</strong> – Temperature parameter T0. Default: 298.15 K.</li>
-<li><strong>cp0</strong> – Reference-state molar heat capacity (constant). Default: 0.0.</li>
-<li><strong>h0</strong> – Reference-state molar enthalpy at temperature T0. Default: 0.0.</li>
-<li><strong>s0</strong> – Reference-state molar entropy at temperature T0. Default: 0.0.</li>
+<li><strong>t0</strong> &#8211; Temperature parameter T0. Default: 298.15 K.</li>
+<li><strong>cp0</strong> &#8211; Reference-state molar heat capacity (constant). Default: 0.0.</li>
+<li><strong>h0</strong> &#8211; Reference-state molar enthalpy at temperature T0. Default: 0.0.</li>
+<li><strong>s0</strong> &#8211; Reference-state molar entropy at temperature T0. Default: 0.0.</li>
 </ul>
 </td>
 </tr>
@@ -542,30 +538,30 @@ vibrational frequencies.</p>
 
 </div>
 <div class="section" id="transport-properties">
-<h2>Transport Properties<a class="headerlink" href="#transport-properties" title="Permalink to this headline">¶</a></h2>
+<h2>Transport Properties<a class="headerlink" href="#transport-properties" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.ctml_writer.gas_transport">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">gas_transport</code><span class="sig-paren">(</span><em>geom</em>, <em>diam=0.0</em>, <em>well_depth=0.0</em>, <em>dipole=0.0</em>, <em>polar=0.0</em>, <em>rot_relax=0.0</em>, <em>acentric_factor=None</em>, <em>disp_coeff=0.0</em>, <em>quad_polar=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.gas_transport" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">gas_transport</code><span class="sig-paren">(</span><em>geom</em>, <em>diam=0.0</em>, <em>well_depth=0.0</em>, <em>dipole=0.0</em>, <em>polar=0.0</em>, <em>rot_relax=0.0</em>, <em>acentric_factor=None</em>, <em>disp_coeff=0.0</em>, <em>quad_polar=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.gas_transport" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.transport</span></code></p>
 <p>Species-specific Transport coefficients for gas-phase transport models.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>geom</strong> – A string specifying the molecular geometry. One of <code class="docutils literal notranslate"><span class="pre">atom</span></code>,
+<li><strong>geom</strong> &#8211; A string specifying the molecular geometry. One of <code class="docutils literal notranslate"><span class="pre">atom</span></code>,
 <code class="docutils literal notranslate"><span class="pre">linear</span></code>, or <code class="docutils literal notranslate"><span class="pre">nonlinear</span></code>. Required.</li>
-<li><strong>diam</strong> – The Lennard-Jones collision diameter in Angstroms. Required.</li>
-<li><strong>well_depth</strong> – The Lennard-Jones well depth in Kelvin. Required.</li>
-<li><strong>dipole</strong> – The permanent dipole moment in Debye. Default: 0.0</li>
-<li><strong>polar</strong> – The polarizability in A^3. Default: 0.0</li>
-<li><strong>rot_relax</strong> – The rotational relaxation collision number at 298 K. Dimensionless.
+<li><strong>diam</strong> &#8211; The Lennard-Jones collision diameter in Angstroms. Required.</li>
+<li><strong>well_depth</strong> &#8211; The Lennard-Jones well depth in Kelvin. Required.</li>
+<li><strong>dipole</strong> &#8211; The permanent dipole moment in Debye. Default: 0.0</li>
+<li><strong>polar</strong> &#8211; The polarizability in A^3. Default: 0.0</li>
+<li><strong>rot_relax</strong> &#8211; The rotational relaxation collision number at 298 K. Dimensionless.
 Default: 0.0</li>
-<li><strong>w_ac</strong> – Pitzer’s acentric factor.  Dimensionless.
+<li><strong>w_ac</strong> &#8211; Pitzer&#8217;s acentric factor.  Dimensionless.
 Default: 0.0</li>
-<li><strong>disp_coeff</strong> – The dispersion coefficient in A^5
+<li><strong>disp_coeff</strong> &#8211; The dispersion coefficient in A^5
 Default: 0.0</li>
-<li><strong>quad_polar</strong> – The quadrupole polarizability
+<li><strong>quad_polar</strong> &#8211; The quadrupole polarizability
 Default: 0.0</li>
 </ul>
 </td>
@@ -576,32 +572,32 @@ Default: 0.0</li>
 
 </div>
 <div class="section" id="reactions">
-<h2>Reactions<a class="headerlink" href="#reactions" title="Permalink to this headline">¶</a></h2>
+<h2>Reactions<a class="headerlink" href="#reactions" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.ctml_writer.reaction">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">reaction</code><span class="sig-paren">(</span><em>equation=''</em>, <em>kf=None</em>, <em>id=''</em>, <em>order=''</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.reaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">reaction</code><span class="sig-paren">(</span><em>equation=''</em>, <em>kf=None</em>, <em>id=''</em>, <em>order=''</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>A homogeneous chemical reaction with pressure-independent rate coefficient
 and mass-action kinetics.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>equation</strong> – A string specifying the chemical equation.</li>
-<li><strong>kf</strong> – The rate coefficient for the forward direction. If a sequence of
+<li><strong>equation</strong> &#8211; A string specifying the chemical equation.</li>
+<li><strong>kf</strong> &#8211; The rate coefficient for the forward direction. If a sequence of
 three numbers is given, these will be interpreted as [A, b, E] in
 the modified Arrhenius function <span class="math">\(A T^b exp(-E/\hat{R}T)\)</span>.</li>
-<li><strong>id</strong> – An optional identification string. If omitted, it defaults to a
+<li><strong>id</strong> &#8211; An optional identification string. If omitted, it defaults to a
 four-digit numeric string beginning with 0001 for the first
 reaction in the file.</li>
-<li><strong>order</strong> – Override the default reaction orders implied by the reactant
+<li><strong>order</strong> &#8211; Override the default reaction orders implied by the reactant
 stoichiometric coefficients. Given as a string of key:value pairs,
-e.g., <code class="docutils literal notranslate"><span class="pre">&quot;CH4:0.25</span> <span class="pre">O2:1.5&quot;</span></code>.</li>
-<li><strong>options</strong> – Processing options, as described in
+e.g., <code class="docutils literal notranslate"><span class="pre">"CH4:0.25</span> <span class="pre">O2:1.5"</span></code>.</li>
+<li><strong>options</strong> &#8211; Processing options, as described in
 <a class="reference external" href="https://cantera.org/tutorials/cti/reactions.html#options">Options</a>.
 May be one or more (as a list) of the
-following: <code class="docutils literal notranslate"><span class="pre">'skip'</span></code>, <code class="docutils literal notranslate"><span class="pre">'duplicate'</span></code>, <code class="docutils literal notranslate"><span class="pre">'negative_A'</span></code>,`` ‘negative_orders’<code class="docutils literal notranslate"><span class="pre">,</span>
+following: <code class="docutils literal notranslate"><span class="pre">'skip'</span></code>, <code class="docutils literal notranslate"><span class="pre">'duplicate'</span></code>, <code class="docutils literal notranslate"><span class="pre">'negative_A'</span></code>,`` &#8216;negative_orders&#8217;<code class="docutils literal notranslate"><span class="pre">,</span>
 <span class="pre">``'nonreactant_orders'</span></code>.</li>
 </ul>
 </td>
@@ -610,7 +606,7 @@ following: <code class="docutils literal notranslate"><span class="pre">'skip'</
 </table>
 <dl class="method">
 <dt id="cantera.ctml_writer.reaction.unit_factor">
-<code class="descname">unit_factor</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.reaction.unit_factor" title="Permalink to this definition">¶</a></dt>
+<code class="descname">unit_factor</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.reaction.unit_factor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Conversion factor from given rate constant units to the MKS (+kmol)
 used internally by Cantera, taking into account the reaction order.</p>
 </dd></dl>
@@ -619,20 +615,20 @@ used internally by Cantera, taking into account the reaction order.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.Arrhenius">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Arrhenius</code><span class="sig-paren">(</span><em>A=0.0</em>, <em>b=0.0</em>, <em>E=0.0</em>, <em>coverage=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.Arrhenius" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Arrhenius</code><span class="sig-paren">(</span><em>A=0.0</em>, <em>b=0.0</em>, <em>E=0.0</em>, <em>coverage=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.Arrhenius" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.rate_expression</span></code></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>A</strong> – The pre-exponential coefficient. Required input. If entered without
+<li><strong>A</strong> &#8211; The pre-exponential coefficient. Required input. If entered without
 units, the units will be computed considering all factors that
 affect the units. The resulting units string is written to the CTML
 file individually for each reaction pre-exponential coefficient.</li>
-<li><strong>b</strong> – The temperature exponent. Dimensionless. Default: 0.0.</li>
-<li><strong>E</strong> – Activation energy. Default: 0.0.</li>
-<li><strong>coverage</strong> – For a single coverage dependency, a list with four
+<li><strong>b</strong> &#8211; The temperature exponent. Dimensionless. Default: 0.0.</li>
+<li><strong>E</strong> &#8211; Activation energy. Default: 0.0.</li>
+<li><strong>coverage</strong> &#8211; For a single coverage dependency, a list with four
 elements: the species name followed by the three coverage
 parameters. For multiple coverage dependencies, a list of lists
 containing the individual sets of coverage parameters. Only used for
@@ -646,26 +642,26 @@ surface and edge reactions.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.three_body_reaction">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">three_body_reaction</code><span class="sig-paren">(</span><em>equation=''</em>, <em>kf=None</em>, <em>efficiencies=''</em>, <em>id=''</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.three_body_reaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">three_body_reaction</code><span class="sig-paren">(</span><em>equation=''</em>, <em>kf=None</em>, <em>efficiencies=''</em>, <em>id=''</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.three_body_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.reaction" title="cantera.ctml_writer.reaction"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.reaction</span></code></a></p>
 <p>A three-body reaction.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>equation</strong> – A string specifying the chemical equation. The reaction can be
+<li><strong>equation</strong> &#8211; A string specifying the chemical equation. The reaction can be
 written in either the association or dissociation directions, and
 may be reversible or irreversible.</li>
-<li><strong>kf</strong> – The rate coefficient for the forward direction. If a sequence of
+<li><strong>kf</strong> &#8211; The rate coefficient for the forward direction. If a sequence of
 three numbers is given, these will be interpreted as [A, b, E] in
 the modified Arrhenius function.</li>
-<li><strong>efficiencies</strong> – A string specifying the third-body collision efficiencies.
+<li><strong>efficiencies</strong> &#8211; A string specifying the third-body collision efficiencies.
 The efficiencies for unspecified species are set to 1.0.</li>
-<li><strong>id</strong> – An optional identification string. If omitted, it defaults to a
+<li><strong>id</strong> &#8211; An optional identification string. If omitted, it defaults to a
 four-digit numeric string beginning with 0001 for the first
 reaction in the file.</li>
-<li><strong>options</strong> – Processing options, as described in
+<li><strong>options</strong> &#8211; Processing options, as described in
 <a class="reference external" href="https://cantera.org/tutorials/cti/reactions.html#options">Options</a>.</li>
 </ul>
 </td>
@@ -676,29 +672,29 @@ reaction in the file.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.falloff_reaction">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">falloff_reaction</code><span class="sig-paren">(</span><em>equation</em>, <em>kf0</em>, <em>kf</em>, <em>efficiencies=''</em>, <em>falloff=None</em>, <em>id=''</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.falloff_reaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">falloff_reaction</code><span class="sig-paren">(</span><em>equation</em>, <em>kf0</em>, <em>kf</em>, <em>efficiencies=''</em>, <em>falloff=None</em>, <em>id=''</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.falloff_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.pdep_reaction</span></code></p>
 <p>A gas-phase falloff reaction.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>equation</strong> – A string specifying the chemical equation.</li>
-<li><strong>kf</strong> – The rate coefficient for the forward direction in the high-pressure
+<li><strong>equation</strong> &#8211; A string specifying the chemical equation.</li>
+<li><strong>kf</strong> &#8211; The rate coefficient for the forward direction in the high-pressure
 limit. If a sequence of three numbers is given, these will be
 interpreted as [A, b, E] in the modified Arrhenius function.</li>
-<li><strong>kf0</strong> – The rate coefficient for the forward direction in the low-pressure
+<li><strong>kf0</strong> &#8211; The rate coefficient for the forward direction in the low-pressure
 limit. If a sequence of three numbers is given, these will be
 interpreted as [A, b, E] in the modified Arrhenius function.</li>
-<li><strong>efficiencies</strong> – A string specifying the third-body collision efficiencies. The
+<li><strong>efficiencies</strong> &#8211; A string specifying the third-body collision efficiencies. The
 efficiency for unspecified species is set to 1.0.</li>
-<li><strong>falloff</strong> – An embedded entry specifying a falloff function. If omitted, a
+<li><strong>falloff</strong> &#8211; An embedded entry specifying a falloff function. If omitted, a
 unity falloff function (Lindemann form) will be used.</li>
-<li><strong>id</strong> – An optional identification string. If omitted, it defaults to a
+<li><strong>id</strong> &#8211; An optional identification string. If omitted, it defaults to a
 four-digit numeric string beginning with 0001 for the first
 reaction in the file.</li>
-<li><strong>options</strong> – Processing options, as described in
+<li><strong>options</strong> &#8211; Processing options, as described in
 <a class="reference external" href="https://cantera.org/tutorials/cti/reactions.html#options">Options</a>.</li>
 </ul>
 </td>
@@ -709,29 +705,29 @@ reaction in the file.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.chemically_activated_reaction">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">chemically_activated_reaction</code><span class="sig-paren">(</span><em>equation</em>, <em>kLow</em>, <em>kHigh</em>, <em>efficiencies=''</em>, <em>falloff=None</em>, <em>id=''</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.chemically_activated_reaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">chemically_activated_reaction</code><span class="sig-paren">(</span><em>equation</em>, <em>kLow</em>, <em>kHigh</em>, <em>efficiencies=''</em>, <em>falloff=None</em>, <em>id=''</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.chemically_activated_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.pdep_reaction</span></code></p>
 <p>A gas-phase, chemically activated reaction.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>equation</strong> – A string specifying the chemical equation.</li>
-<li><strong>kLow</strong> – The rate coefficient for the forward direction in the low-pressure
+<li><strong>equation</strong> &#8211; A string specifying the chemical equation.</li>
+<li><strong>kLow</strong> &#8211; The rate coefficient for the forward direction in the low-pressure
 limit. If a sequence of three numbers is given, these will be
 interpreted as [A, b, E] in the modified Arrhenius function.</li>
-<li><strong>kHigh</strong> – The rate coefficient for the forward direction in the high-pressure
+<li><strong>kHigh</strong> &#8211; The rate coefficient for the forward direction in the high-pressure
 limit. If a sequence of three numbers is given, these will be
 interpreted as [A, b, E] in the modified Arrhenius function.</li>
-<li><strong>efficiencies</strong> – A string specifying the third-body collision efficiencies. The
+<li><strong>efficiencies</strong> &#8211; A string specifying the third-body collision efficiencies. The
 efficiency for unspecified species is set to 1.0.</li>
-<li><strong>falloff</strong> – An embedded entry specifying a falloff function. If omitted, a
+<li><strong>falloff</strong> &#8211; An embedded entry specifying a falloff function. If omitted, a
 unity falloff function (Lindemann form) will be used.</li>
-<li><strong>id</strong> – An optional identification string. If omitted, it defaults to a
+<li><strong>id</strong> &#8211; An optional identification string. If omitted, it defaults to a
 four-digit numeric string beginning with 0001 for the first
 reaction in the file.</li>
-<li><strong>options</strong> – Processing options, as described in
+<li><strong>options</strong> &#8211; Processing options, as described in
 <a class="reference external" href="https://cantera.org/tutorials/cti/reactions.html#options">Options</a>.</li>
 </ul>
 </td>
@@ -742,17 +738,17 @@ reaction in the file.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.pdep_arrhenius">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">pdep_arrhenius</code><span class="sig-paren">(</span><em>equation=''</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.pdep_arrhenius" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">pdep_arrhenius</code><span class="sig-paren">(</span><em>equation=''</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.pdep_arrhenius" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.reaction" title="cantera.ctml_writer.reaction"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.reaction</span></code></a></p>
 <p>Pressure-dependent rate calculated by interpolating between Arrhenius
 expressions at different pressures.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>equation</strong> – A string specifying the chemical equation.</li>
-<li><strong>args</strong> – Each additional argument is a sequence of four elements specifying the
+<li><strong>equation</strong> &#8211; A string specifying the chemical equation.</li>
+<li><strong>args</strong> &#8211; Each additional argument is a sequence of four elements specifying the
 pressure and the Arrhenius parameters at that pressure.</li>
 </ul>
 </td>
@@ -763,21 +759,21 @@ pressure and the Arrhenius parameters at that pressure.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.chebyshev_reaction">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">chebyshev_reaction</code><span class="sig-paren">(</span><em>equation='', Tmin=300.0, Tmax=2500.0, Pmin=(0.001, 'atm'), Pmax=(100.0, 'atm'), coeffs=[[]], **kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.chebyshev_reaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">chebyshev_reaction</code><span class="sig-paren">(</span><em>equation='', Tmin=300.0, Tmax=2500.0, Pmin=(0.001, 'atm'), Pmax=(100.0, 'atm'), coeffs=[[]], **kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.chebyshev_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.reaction" title="cantera.ctml_writer.reaction"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.reaction</span></code></a></p>
 <p>Pressure-dependent rate calculated in terms of a bivariate Chebyshev
 polynomial.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>equation</strong> – A string specifying the chemical equation.</li>
-<li><strong>Tmin</strong> – The minimum temperature at which the rate expression is defined</li>
-<li><strong>Tmax</strong> – the maximum temperature at which the rate expression is defined</li>
-<li><strong>Pmin</strong> – The minimum pressure at which the rate expression is defined</li>
-<li><strong>Pmax</strong> – The maximum pressure at which the rate expression is defined</li>
-<li><strong>coeffs</strong> – A 2D array of the coefficients defining the rate expression. For a
+<li><strong>equation</strong> &#8211; A string specifying the chemical equation.</li>
+<li><strong>Tmin</strong> &#8211; The minimum temperature at which the rate expression is defined</li>
+<li><strong>Tmax</strong> &#8211; the maximum temperature at which the rate expression is defined</li>
+<li><strong>Pmin</strong> &#8211; The minimum pressure at which the rate expression is defined</li>
+<li><strong>Pmax</strong> &#8211; The maximum pressure at which the rate expression is defined</li>
+<li><strong>coeffs</strong> &#8211; A 2D array of the coefficients defining the rate expression. For a
 polynomial with M points in temperature and N points in pressure, this
 should be a list of M lists each with N elements.</li>
 </ul>
@@ -789,30 +785,30 @@ should be a list of M lists each with N elements.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.surface_reaction">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">surface_reaction</code><span class="sig-paren">(</span><em>equation=''</em>, <em>kf=None</em>, <em>id=''</em>, <em>order=''</em>, <em>beta=0.0</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.surface_reaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">surface_reaction</code><span class="sig-paren">(</span><em>equation=''</em>, <em>kf=None</em>, <em>id=''</em>, <em>order=''</em>, <em>beta=0.0</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.surface_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.reaction" title="cantera.ctml_writer.reaction"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.reaction</span></code></a></p>
 <p>A heterogeneous chemical reaction with pressure-independent rate
 coefficient and mass-action kinetics.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>equation</strong> – A string specifying the chemical equation.</li>
-<li><strong>kf</strong> – The rate coefficient for the forward direction. If a sequence of
+<li><strong>equation</strong> &#8211; A string specifying the chemical equation.</li>
+<li><strong>kf</strong> &#8211; The rate coefficient for the forward direction. If a sequence of
 three numbers is given, these will be interpreted as [A, b, E] in
 the modified Arrhenius function.</li>
-<li><strong>sticking_prob</strong> – The reactive sticking probability for the forward direction. This
+<li><strong>sticking_prob</strong> &#8211; The reactive sticking probability for the forward direction. This
 can only be specified if there is only one bulk-phase reactant and
 it belongs to an ideal gas phase. If a sequence of three numbers is
 given, these will be interpreted as [A, b, E] in the modified
 Arrhenius function.</li>
-<li><strong>id</strong> – An optional identification string. If omitted, it defaults to a
+<li><strong>id</strong> &#8211; An optional identification string. If omitted, it defaults to a
 four-digit numeric string beginning with 0001 for the first
 reaction in the file.</li>
-<li><strong>options</strong> – Processing options, as described in
+<li><strong>options</strong> &#8211; Processing options, as described in
 <a class="reference external" href="https://cantera.org/tutorials/cti/reactions.html#options">Options</a>.</li>
-<li><strong>beta</strong> – Charge transfer coefficient: A number between 0 and 1 which, for a
+<li><strong>beta</strong> &#8211; Charge transfer coefficient: A number between 0 and 1 which, for a
 charge transfer reaction, determines how much of the electric
 potential difference between two phases is applied to the
 activiation energy of the fwd reaction.  The remainder is applied to
@@ -826,15 +822,15 @@ the reverse reaction.</li>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.edge_reaction">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">edge_reaction</code><span class="sig-paren">(</span><em>equation=''</em>, <em>kf=None</em>, <em>id=''</em>, <em>order=''</em>, <em>beta=0.0</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.edge_reaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">edge_reaction</code><span class="sig-paren">(</span><em>equation=''</em>, <em>kf=None</em>, <em>id=''</em>, <em>order=''</em>, <em>beta=0.0</em>, <em>options=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.edge_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <a class="reference internal" href="#cantera.ctml_writer.reaction" title="cantera.ctml_writer.reaction"><code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.ctml_writer.reaction</span></code></a></p>
 </dd></dl>
 
 <div class="section" id="falloff-parameterizations">
-<h3>Falloff Parameterizations<a class="headerlink" href="#falloff-parameterizations" title="Permalink to this headline">¶</a></h3>
+<h3>Falloff Parameterizations<a class="headerlink" href="#falloff-parameterizations" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ctml_writer.Troe">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Troe</code><span class="sig-paren">(</span><em>A=0.0</em>, <em>T3=0.0</em>, <em>T1=0.0</em>, <em>T2=-999.9</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.Troe" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Troe</code><span class="sig-paren">(</span><em>A=0.0</em>, <em>T3=0.0</em>, <em>T1=0.0</em>, <em>T2=-999.9</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.Troe" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>The Troe falloff function.</p>
 <p>Parameters: <em>A</em>, <em>T3</em>, <em>T1</em>, <em>T2</em>. These must be entered as pure
@@ -843,7 +839,7 @@ numbers with no attached dimensions.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.SRI">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">SRI</code><span class="sig-paren">(</span><em>A=0.0</em>, <em>B=0.0</em>, <em>C=0.0</em>, <em>D=-999.9</em>, <em>E=-999.9</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.SRI" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">SRI</code><span class="sig-paren">(</span><em>A=0.0</em>, <em>B=0.0</em>, <em>C=0.0</em>, <em>D=-999.9</em>, <em>E=-999.9</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ctml_writer.SRI" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>The SRI falloff function.</p>
 <p>Parameters: <em>A</em>, <em>B</em>, <em>C</em>, <em>D</em>, <em>E</em>. These must be entered as
@@ -852,7 +848,7 @@ pure numbers without attached dimensions.</p>
 
 <dl class="class">
 <dt id="cantera.ctml_writer.Lindemann">
-<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Lindemann</code><a class="headerlink" href="#cantera.ctml_writer.Lindemann" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.ctml_writer.</code><code class="descname">Lindemann</code><a class="headerlink" href="#cantera.ctml_writer.Lindemann" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>The Lindemann falloff function.</p>
 <p>This falloff function takes no parameters.</p>
@@ -896,25 +892,24 @@ pure numbers without attached dimensions.</p>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/cti/classes.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/cti/classes.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -923,15 +918,14 @@ pure numbers without attached dimensions.</p>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/cti/classes.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/cti/classes.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/cti/classes.html
+++ b/api-docs/docs-2.4/sphinx/html/cti/classes.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/cython/constants.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/constants.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Physical Constants | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,77 +77,77 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="physical-constants">
-<h1>Physical Constants<a class="headerlink" href="#physical-constants" title="Permalink to this headline">¶</a></h1>
+<h1>Physical Constants<a class="headerlink" href="#physical-constants" title="Permalink to this headline">&#182;</a></h1>
 <p>These values are the same as those in the Cantera C++ header file ct_defs.h.</p>
 <dl class="data">
 <dt id="cantera.avogadro">
-<code class="descclassname">cantera.</code><code class="descname">avogadro</code><a class="headerlink" href="#cantera.avogadro" title="Permalink to this definition">¶</a></dt>
-<dd><p>Avogadro’s Number, kmol<sup>-1</sup></p>
+<code class="descclassname">cantera.</code><code class="descname">avogadro</code><a class="headerlink" href="#cantera.avogadro" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Avogadro&#8217;s Number, kmol<sup>-1</sup></p>
 </dd></dl>
 
 <dl class="data">
 <dt id="cantera.gas_constant">
-<code class="descclassname">cantera.</code><code class="descname">gas_constant</code><a class="headerlink" href="#cantera.gas_constant" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">gas_constant</code><a class="headerlink" href="#cantera.gas_constant" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The ideal gas constant, J kmol<sup>-1</sup> K<sup>-1</sup></p>
 </dd></dl>
 
 <dl class="data">
 <dt id="cantera.one_atm">
-<code class="descclassname">cantera.</code><code class="descname">one_atm</code><a class="headerlink" href="#cantera.one_atm" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">one_atm</code><a class="headerlink" href="#cantera.one_atm" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>One atmosphere, Pa</p>
 </dd></dl>
 
 <dl class="data">
 <dt id="cantera.boltzmann">
-<code class="descclassname">cantera.</code><code class="descname">boltzmann</code><a class="headerlink" href="#cantera.boltzmann" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">boltzmann</code><a class="headerlink" href="#cantera.boltzmann" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Boltzmann constant, m<sup>2</sup> kg s<sup>-2</sup> K<sup>-1</sup></p>
 </dd></dl>
 
 <dl class="data">
 <dt id="cantera.planck">
-<code class="descclassname">cantera.</code><code class="descname">planck</code><a class="headerlink" href="#cantera.planck" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">planck</code><a class="headerlink" href="#cantera.planck" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Planck constant, J s</p>
 </dd></dl>
 
 <dl class="data">
 <dt id="cantera.stefan_boltzmann">
-<code class="descclassname">cantera.</code><code class="descname">stefan_boltzmann</code><a class="headerlink" href="#cantera.stefan_boltzmann" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">stefan_boltzmann</code><a class="headerlink" href="#cantera.stefan_boltzmann" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The Stefan-Boltzmann constant, W m<sup>-2</sup> K<sup>-4</sup></p>
 </dd></dl>
 
 <dl class="data">
 <dt id="cantera.electron_charge">
-<code class="descclassname">cantera.</code><code class="descname">electron_charge</code><a class="headerlink" href="#cantera.electron_charge" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">electron_charge</code><a class="headerlink" href="#cantera.electron_charge" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The charge on an electron, C</p>
 </dd></dl>
 
 <dl class="data">
 <dt id="cantera.electron_mass">
-<code class="descclassname">cantera.</code><code class="descname">electron_mass</code><a class="headerlink" href="#cantera.electron_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">electron_mass</code><a class="headerlink" href="#cantera.electron_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The mass of an electron, kg</p>
 </dd></dl>
 
 <dl class="data">
 <dt id="cantera.faraday">
-<code class="descclassname">cantera.</code><code class="descname">faraday</code><a class="headerlink" href="#cantera.faraday" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">faraday</code><a class="headerlink" href="#cantera.faraday" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Faraday constant, C kmol<sup>-1</sup></p>
 </dd></dl>
 
 <dl class="data">
 <dt id="cantera.light_speed">
-<code class="descclassname">cantera.</code><code class="descname">light_speed</code><a class="headerlink" href="#cantera.light_speed" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">light_speed</code><a class="headerlink" href="#cantera.light_speed" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Speed of Light, m s<sup>-1</sup></p>
 </dd></dl>
 
 <dl class="data">
 <dt id="cantera.permeability_0">
-<code class="descclassname">cantera.</code><code class="descname">permeability_0</code><a class="headerlink" href="#cantera.permeability_0" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">permeability_0</code><a class="headerlink" href="#cantera.permeability_0" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Permeability of free space, m kg s<sup>-2</sup> A<sup>-2</sup></p>
 </dd></dl>
 
 <dl class="data">
 <dt id="cantera.epsilon_0">
-<code class="descclassname">cantera.</code><code class="descname">epsilon_0</code><a class="headerlink" href="#cantera.epsilon_0" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">epsilon_0</code><a class="headerlink" href="#cantera.epsilon_0" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Permittivity of free space, s<sup>4</sup> A<sup>2</sup> m<sup>-3</sup> kg<sup>-1</sup></p>
 </dd></dl>
 
@@ -169,7 +165,7 @@ lang="en">
   <li><a href="../index.html">Documentation overview</a><ul>
   <li><a href="index.html">Python Module Documentation</a><ul>
       <li>Previous: <a href="onedim.html" title="previous chapter">One-dimensional Reacting Flows</a></li>
-      <li>Next: <a href="../matlab/index.html" title="next chapter">Matlab Interface User’s Guide</a></li>
+      <li>Next: <a href="../matlab/index.html" title="next chapter">Matlab Interface User&#8217;s Guide</a></li>
   </ul></li>
   </ul></li>
 </ul>
@@ -177,25 +173,24 @@ lang="en">
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/cython/constants.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/cython/constants.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -204,15 +199,14 @@ lang="en">
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/cython/constants.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/cython/constants.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/cython/constants.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/constants.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/cython/importing.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/importing.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Objects Representing Phases | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,7 +77,7 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="objects-representing-phases">
-<h1>Objects Representing Phases<a class="headerlink" href="#objects-representing-phases" title="Permalink to this headline">¶</a></h1>
+<h1>Objects Representing Phases<a class="headerlink" href="#objects-representing-phases" title="Permalink to this headline">&#182;</a></h1>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#composite-phase-objects" id="id1">Composite Phase Objects</a></li>
@@ -92,15 +88,15 @@ lang="en">
 </ul>
 </div>
 <div class="section" id="composite-phase-objects">
-<h2><a class="toc-backref" href="#id1">Composite Phase Objects</a><a class="headerlink" href="#composite-phase-objects" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id1">Composite Phase Objects</a><a class="headerlink" href="#composite-phase-objects" title="Permalink to this headline">&#182;</a></h2>
 <p>These classes are composite representations of a substance which has
 thermodynamic, chemical kinetic, and (optionally) transport properties.</p>
 <dl class="class">
 <dt id="cantera.Solution">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Solution</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em>, <em>source=None</em>, <em>thermo=None</em>, <em>species=()</em>, <em>kinetics=None</em>, <em>reactions=()</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Solution" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Solution</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em>, <em>source=None</em>, <em>thermo=None</em>, <em>species=()</em>, <em>kinetics=None</em>, <em>reactions=()</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Solution" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.ThermoPhase</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Kinetics</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Transport</span></code></p>
 <p>A class for chemically-reacting solutions. Instances can be created to
-represent any type of solution – a mixture of gases, a liquid solution, or
+represent any type of solution &#8211; a mixture of gases, a liquid solution, or
 a solid solution, for example.</p>
 <p>Class <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> derives from classes <a class="reference internal" href="thermo.html#cantera.ThermoPhase" title="cantera.ThermoPhase"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ThermoPhase</span></code></a>, <a class="reference internal" href="kinetics.html#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a>, and
 <a class="reference internal" href="transport.html#cantera.Transport" title="cantera.Transport"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Transport</span></code></a>.  It defines no methods of its own, and is provided so that a
@@ -110,21 +106,21 @@ properties of a solution.</p>
 <code class="docutils literal notranslate"><span class="pre">transport_model=None</span></code> to the <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> constructor.</p>
 <p>The most common way to instantiate <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> objects is by using a phase
 definition, species and reactions defined in an input file:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;gri30.cti&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">'gri30.cti'</span><span class="p">)</span>
 </pre></div>
 </div>
 <p>If an input file defines multiple phases, the phase <em>name</em> (in CTI) or <em>id</em>
 (in XML) can be used to specify the desired phase:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;diamond.cti&#39;</span><span class="p">,</span> <span class="s1">&#39;gas&#39;</span><span class="p">)</span>
-<span class="n">diamond</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;diamond.cti&#39;</span><span class="p">,</span> <span class="s1">&#39;diamond&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">'diamond.cti'</span><span class="p">,</span> <span class="s1">'gas'</span><span class="p">)</span>
+<span class="n">diamond</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">'diamond.cti'</span><span class="p">,</span> <span class="s1">'diamond'</span><span class="p">)</span>
 </pre></div>
 </div>
 <p><a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> objects can also be constructed using <a class="reference internal" href="thermo.html#cantera.Species" title="cantera.Species"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Species</span></code></a> and <a class="reference internal" href="kinetics.html#cantera.Reaction" title="cantera.Reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reaction</span></code></a>
 objects which can themselves either be imported from input files or defined
 directly in Python:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">spec</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Species</span><span class="o">.</span><span class="n">listFromFile</span><span class="p">(</span><span class="s1">&#39;gri30.cti&#39;</span><span class="p">)</span>
-<span class="n">rxns</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">listFromFile</span><span class="p">(</span><span class="s1">&#39;gri30.cti&#39;</span><span class="p">)</span>
-<span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="n">thermo</span><span class="o">=</span><span class="s1">&#39;IdealGas&#39;</span><span class="p">,</span> <span class="n">kinetics</span><span class="o">=</span><span class="s1">&#39;GasKinetics&#39;</span><span class="p">,</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">spec</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Species</span><span class="o">.</span><span class="n">listFromFile</span><span class="p">(</span><span class="s1">'gri30.cti'</span><span class="p">)</span>
+<span class="n">rxns</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">listFromFile</span><span class="p">(</span><span class="s1">'gri30.cti'</span><span class="p">)</span>
+<span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="n">thermo</span><span class="o">=</span><span class="s1">'IdealGas'</span><span class="p">,</span> <span class="n">kinetics</span><span class="o">=</span><span class="s1">'GasKinetics'</span><span class="p">,</span>
                   <span class="n">species</span><span class="o">=</span><span class="n">spec</span><span class="p">,</span> <span class="n">reactions</span><span class="o">=</span><span class="n">rxns</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -138,12 +134,12 @@ and <a class="reference external" href="https://cantera.org/examples/python/kine
 <p>In addition, <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> objects can be constructed by passing the text of
 the CTI or XML phase definition in directly, using the <code class="docutils literal notranslate"><span class="pre">source</span></code> keyword
 argument:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">cti_def</span> <span class="o">=</span> <span class="s1">&#39;&#39;&#39;</span>
-<span class="s1">    ideal_gas(name=&#39;gas&#39;, elements=&#39;O H Ar&#39;,</span>
-<span class="s1">              species=&#39;gri30: all&#39;,</span>
-<span class="s1">              reactions=&#39;gri30: all&#39;,</span>
-<span class="s1">              options=[&#39;skip_undeclared_elements&#39;, &#39;skip_undeclared_species&#39;, &#39;skip_undeclared_third_bodies&#39;],</span>
-<span class="s1">              initial_state=state(temperature=300, pressure=101325))&#39;&#39;&#39;</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">cti_def</span> <span class="o">=</span> <span class="s1">'''</span>
+<span class="s1">    ideal_gas(name='gas', elements='O H Ar',</span>
+<span class="s1">              species='gri30: all',</span>
+<span class="s1">              reactions='gri30: all',</span>
+<span class="s1">              options=['skip_undeclared_elements', 'skip_undeclared_species', 'skip_undeclared_third_bodies'],</span>
+<span class="s1">              initial_state=state(temperature=300, pressure=101325))'''</span>
 <span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="n">source</span><span class="o">=</span><span class="n">cti_def</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -151,7 +147,7 @@ argument:</p>
 
 <dl class="class">
 <dt id="cantera.Interface">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Interface</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em>, <em>phases=()</em>, <em>thermo=None</em>, <em>species=()</em>, <em>kinetics=None</em>, <em>reactions=()</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Interface" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Interface</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em>, <em>phases=()</em>, <em>thermo=None</em>, <em>species=()</em>, <em>kinetics=None</em>, <em>reactions=()</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Interface" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.InterfacePhase</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.InterfaceKinetics</span></code></p>
 <p>Two-dimensional interfaces.</p>
 <p>Instances of class <a class="reference internal" href="#cantera.Interface" title="cantera.Interface"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Interface</span></code></a> represent reacting 2D interfaces between bulk
@@ -160,16 +156,16 @@ methods derive from either <a class="reference internal" href="thermo.html#cante
 <p>To construct an <a class="reference internal" href="#cantera.Interface" title="cantera.Interface"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Interface</span></code></a> object, adjacent bulk phases which participate
 in reactions need to be created and then passed in as a list in the
 <code class="docutils literal notranslate"><span class="pre">phases</span></code> argument to the constructor:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;diamond.cti&#39;</span><span class="p">,</span> <span class="s1">&#39;gas&#39;</span><span class="p">)</span>
-<span class="n">diamond</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;diamond.cti&#39;</span><span class="p">,</span> <span class="s1">&#39;diamond&#39;</span><span class="p">)</span>
-<span class="n">diamond_surf</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Interface</span><span class="p">(</span><span class="s1">&#39;diamond.cti&#39;</span><span class="p">,</span> <span class="s1">&#39;diamond_100&#39;</span><span class="p">,</span> <span class="p">[</span><span class="n">gas</span><span class="p">,</span> <span class="n">diamond</span><span class="p">])</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">'diamond.cti'</span><span class="p">,</span> <span class="s1">'gas'</span><span class="p">)</span>
+<span class="n">diamond</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">'diamond.cti'</span><span class="p">,</span> <span class="s1">'diamond'</span><span class="p">)</span>
+<span class="n">diamond_surf</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Interface</span><span class="p">(</span><span class="s1">'diamond.cti'</span><span class="p">,</span> <span class="s1">'diamond_100'</span><span class="p">,</span> <span class="p">[</span><span class="n">gas</span><span class="p">,</span> <span class="n">diamond</span><span class="p">])</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="class">
 <dt id="cantera.DustyGas">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">DustyGas</code><span class="sig-paren">(</span><em>infile</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.DustyGas" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">DustyGas</code><span class="sig-paren">(</span><em>infile</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.DustyGas" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.ThermoPhase</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Kinetics</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.DustyGasTransport</span></code></p>
 <p>A composite class which models a gas in a stationary, solid, porous medium.</p>
 <p>The only transport properties computed are the multicomponent diffusion
@@ -178,70 +174,70 @@ coefficients. The model does not compute viscosity or thermal conductivity.</p>
 
 </div>
 <div class="section" id="pure-fluid-phases">
-<h2><a class="toc-backref" href="#id2">Pure Fluid Phases</a><a class="headerlink" href="#pure-fluid-phases" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id2">Pure Fluid Phases</a><a class="headerlink" href="#pure-fluid-phases" title="Permalink to this headline">&#182;</a></h2>
 <p>The following convenience functions can be used to create <a class="reference internal" href="thermo.html#cantera.PureFluid" title="cantera.PureFluid"><code class="xref py py-obj docutils literal notranslate"><span class="pre">PureFluid</span></code></a> objects
 with the indicated equation of state:</p>
 <dl class="function">
 <dt id="cantera.CarbonDioxide">
-<code class="descclassname">cantera.</code><code class="descname">CarbonDioxide</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CarbonDioxide" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">CarbonDioxide</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CarbonDioxide" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a <a class="reference internal" href="thermo.html#cantera.PureFluid" title="cantera.PureFluid"><code class="xref py py-obj docutils literal notranslate"><span class="pre">PureFluid</span></code></a> object using the equation of state for carbon dioxide.</p>
 </dd></dl>
 
 <dl class="function">
 <dt id="cantera.Heptane">
-<code class="descclassname">cantera.</code><code class="descname">Heptane</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Heptane" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">Heptane</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Heptane" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a <a class="reference internal" href="thermo.html#cantera.PureFluid" title="cantera.PureFluid"><code class="xref py py-obj docutils literal notranslate"><span class="pre">PureFluid</span></code></a> object using the equation of state for heptane.</p>
 </dd></dl>
 
 <dl class="function">
 <dt id="cantera.Hfc134a">
-<code class="descclassname">cantera.</code><code class="descname">Hfc134a</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Hfc134a" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">Hfc134a</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Hfc134a" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a <a class="reference internal" href="thermo.html#cantera.PureFluid" title="cantera.PureFluid"><code class="xref py py-obj docutils literal notranslate"><span class="pre">PureFluid</span></code></a> object using the equation of state for HFC-134a.</p>
 </dd></dl>
 
 <dl class="function">
 <dt id="cantera.Hydrogen">
-<code class="descclassname">cantera.</code><code class="descname">Hydrogen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Hydrogen" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">Hydrogen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Hydrogen" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a <a class="reference internal" href="thermo.html#cantera.PureFluid" title="cantera.PureFluid"><code class="xref py py-obj docutils literal notranslate"><span class="pre">PureFluid</span></code></a> object using the equation of state for hydrogen.</p>
 </dd></dl>
 
 <dl class="function">
 <dt id="cantera.Methane">
-<code class="descclassname">cantera.</code><code class="descname">Methane</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Methane" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">Methane</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Methane" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a <a class="reference internal" href="thermo.html#cantera.PureFluid" title="cantera.PureFluid"><code class="xref py py-obj docutils literal notranslate"><span class="pre">PureFluid</span></code></a> object using the equation of state for methane.</p>
 </dd></dl>
 
 <dl class="function">
 <dt id="cantera.Nitrogen">
-<code class="descclassname">cantera.</code><code class="descname">Nitrogen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Nitrogen" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">Nitrogen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Nitrogen" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a <a class="reference internal" href="thermo.html#cantera.PureFluid" title="cantera.PureFluid"><code class="xref py py-obj docutils literal notranslate"><span class="pre">PureFluid</span></code></a> object using the equation of state for nitrogen.</p>
 </dd></dl>
 
 <dl class="function">
 <dt id="cantera.Oxygen">
-<code class="descclassname">cantera.</code><code class="descname">Oxygen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Oxygen" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">Oxygen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Oxygen" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a <a class="reference internal" href="thermo.html#cantera.PureFluid" title="cantera.PureFluid"><code class="xref py py-obj docutils literal notranslate"><span class="pre">PureFluid</span></code></a> object using the equation of state for oxygen.</p>
 </dd></dl>
 
 <dl class="function">
 <dt id="cantera.Water">
-<code class="descclassname">cantera.</code><code class="descname">Water</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Water" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">Water</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Water" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a <a class="reference internal" href="thermo.html#cantera.PureFluid" title="cantera.PureFluid"><code class="xref py py-obj docutils literal notranslate"><span class="pre">PureFluid</span></code></a> object using the equation of state for water.</p>
 </dd></dl>
 
 </div>
 <div class="section" id="representing-quantities-of-phases">
-<h2><a class="toc-backref" href="#id3">Representing Quantities of Phases</a><a class="headerlink" href="#representing-quantities-of-phases" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id3">Representing Quantities of Phases</a><a class="headerlink" href="#representing-quantities-of-phases" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.Quantity">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Quantity</code><span class="sig-paren">(</span><em>phase</em>, <em>mass=None</em>, <em>moles=None</em>, <em>constant='UV'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Quantity" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Quantity</code><span class="sig-paren">(</span><em>phase</em>, <em>mass=None</em>, <em>moles=None</em>, <em>constant='UV'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Quantity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>A class representing a specific quantity of a <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a>. In addition to the
 properties which can be computed for class <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a>, class <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>
 provides several additional capabilities. A <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a> object is created
 from a <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> with either the mass or number of moles specified:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;gri30.xml&#39;</span><span class="p">)</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">TPX</span> <span class="o">=</span> <span class="mi">300</span><span class="p">,</span> <span class="mf">5e5</span><span class="p">,</span> <span class="s1">&#39;O2:1.0, N2:3.76&#39;</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">'gri30.xml'</span><span class="p">)</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">TPX</span> <span class="o">=</span> <span class="mi">300</span><span class="p">,</span> <span class="mf">5e5</span><span class="p">,</span> <span class="s1">'O2:1.0, N2:3.76'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">q1</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Quantity</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span> <span class="n">mass</span><span class="o">=</span><span class="mi">5</span><span class="p">)</span> <span class="c1"># 5 kg of air</span>
 </pre></div>
 </div>
@@ -275,7 +271,7 @@ moles:</p>
 state resulting from mixing two substances:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">q1</span><span class="o">.</span><span class="n">mass</span> <span class="o">=</span> <span class="mi">5</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">q2</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Quantity</span><span class="p">(</span><span class="n">gas</span><span class="p">)</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">q2</span><span class="o">.</span><span class="n">TPX</span> <span class="o">=</span> <span class="mi">300</span><span class="p">,</span> <span class="mi">101325</span><span class="p">,</span> <span class="s1">&#39;CH4:1.0&#39;</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">q2</span><span class="o">.</span><span class="n">TPX</span> <span class="o">=</span> <span class="mi">300</span><span class="p">,</span> <span class="mi">101325</span><span class="p">,</span> <span class="s1">'CH4:1.0'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">q2</span><span class="o">.</span><span class="n">mass</span> <span class="o">=</span> <span class="mi">1</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">q3</span> <span class="o">=</span> <span class="n">q1</span> <span class="o">+</span> <span class="n">q2</span> <span class="c1"># combine at constant UV</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">q3</span><span class="o">.</span><span class="n">T</span>
@@ -283,14 +279,14 @@ state resulting from mixing two substances:</p>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">q3</span><span class="o">.</span><span class="n">P</span>
 <span class="go">97974.9871</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">q3</span><span class="o">.</span><span class="n">mole_fraction_dict</span><span class="p">()</span>
-<span class="go">{&#39;CH4&#39;: 0.26452900448117395,</span>
-<span class="go"> &#39;N2&#39;: 0.5809602821745349,</span>
-<span class="go"> &#39;O2&#39;: 0.1545107133442912}</span>
+<span class="go">{'CH4': 0.26452900448117395,</span>
+<span class="go"> 'N2': 0.5809602821745349,</span>
+<span class="go"> 'O2': 0.1545107133442912}</span>
 </pre></div>
 </div>
 <p>If a different property pair should be held constant when combining, this
 can be specified as follows:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">q1</span><span class="o">.</span><span class="n">constant</span> <span class="o">=</span> <span class="n">q2</span><span class="o">.</span><span class="n">constant</span> <span class="o">=</span> <span class="s1">&#39;HP&#39;</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">q1</span><span class="o">.</span><span class="n">constant</span> <span class="o">=</span> <span class="n">q2</span><span class="o">.</span><span class="n">constant</span> <span class="o">=</span> <span class="s1">'HP'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">q3</span> <span class="o">=</span> <span class="n">q1</span> <span class="o">+</span> <span class="n">q2</span> <span class="c1"># combine at constant HP</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">q3</span><span class="o">.</span><span class="n">T</span>
 <span class="go">436.03320</span>
@@ -300,206 +296,206 @@ can be specified as follows:</p>
 </div>
 <dl class="attribute">
 <dt id="cantera.Quantity.DP">
-<code class="descname">DP</code><a class="headerlink" href="#cantera.Quantity.DP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">DP</code><a class="headerlink" href="#cantera.Quantity.DP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set density [kg/m^3] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.DPX">
-<code class="descname">DPX</code><a class="headerlink" href="#cantera.Quantity.DPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">DPX</code><a class="headerlink" href="#cantera.Quantity.DPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set density [kg/m^3], pressure [Pa], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.DPY">
-<code class="descname">DPY</code><a class="headerlink" href="#cantera.Quantity.DPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">DPY</code><a class="headerlink" href="#cantera.Quantity.DPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set density [kg/m^3], pressure [Pa], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.G">
-<code class="descname">G</code><a class="headerlink" href="#cantera.Quantity.G" title="Permalink to this definition">¶</a></dt>
+<code class="descname">G</code><a class="headerlink" href="#cantera.Quantity.G" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total Gibbs free energy [J] represented by the <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.H">
-<code class="descname">H</code><a class="headerlink" href="#cantera.Quantity.H" title="Permalink to this definition">¶</a></dt>
+<code class="descname">H</code><a class="headerlink" href="#cantera.Quantity.H" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total enthalpy [J] represented by the <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.HP">
-<code class="descname">HP</code><a class="headerlink" href="#cantera.Quantity.HP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">HP</code><a class="headerlink" href="#cantera.Quantity.HP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set enthalpy [J/kg or J/kmol] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.HPX">
-<code class="descname">HPX</code><a class="headerlink" href="#cantera.Quantity.HPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">HPX</code><a class="headerlink" href="#cantera.Quantity.HPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set enthalpy [J/kg or J/kmol], pressure [Pa] and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.HPY">
-<code class="descname">HPY</code><a class="headerlink" href="#cantera.Quantity.HPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">HPY</code><a class="headerlink" href="#cantera.Quantity.HPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set enthalpy [J/kg or J/kmol], pressure [Pa] and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.ID">
-<code class="descname">ID</code><a class="headerlink" href="#cantera.Quantity.ID" title="Permalink to this definition">¶</a></dt>
+<code class="descname">ID</code><a class="headerlink" href="#cantera.Quantity.ID" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The ID of the phase. The default is taken from the CTI/XML input file.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.P">
-<code class="descname">P</code><a class="headerlink" href="#cantera.Quantity.P" title="Permalink to this definition">¶</a></dt>
+<code class="descname">P</code><a class="headerlink" href="#cantera.Quantity.P" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.P_sat">
-<code class="descname">P_sat</code><a class="headerlink" href="#cantera.Quantity.P_sat" title="Permalink to this definition">¶</a></dt>
+<code class="descname">P_sat</code><a class="headerlink" href="#cantera.Quantity.P_sat" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Saturation pressure [Pa] at the current temperature.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.S">
-<code class="descname">S</code><a class="headerlink" href="#cantera.Quantity.S" title="Permalink to this definition">¶</a></dt>
+<code class="descname">S</code><a class="headerlink" href="#cantera.Quantity.S" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total entropy [J/K] represented by the <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.SP">
-<code class="descname">SP</code><a class="headerlink" href="#cantera.Quantity.SP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SP</code><a class="headerlink" href="#cantera.Quantity.SP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.SPX">
-<code class="descname">SPX</code><a class="headerlink" href="#cantera.Quantity.SPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SPX</code><a class="headerlink" href="#cantera.Quantity.SPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], pressure [Pa], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.SPY">
-<code class="descname">SPY</code><a class="headerlink" href="#cantera.Quantity.SPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SPY</code><a class="headerlink" href="#cantera.Quantity.SPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], pressure [Pa], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.SV">
-<code class="descname">SV</code><a class="headerlink" href="#cantera.Quantity.SV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SV</code><a class="headerlink" href="#cantera.Quantity.SV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K] and specific volume [m^3/kg or
 m^3/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.SVX">
-<code class="descname">SVX</code><a class="headerlink" href="#cantera.Quantity.SVX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SVX</code><a class="headerlink" href="#cantera.Quantity.SVX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
 m^3/kmol], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.SVY">
-<code class="descname">SVY</code><a class="headerlink" href="#cantera.Quantity.SVY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SVY</code><a class="headerlink" href="#cantera.Quantity.SVY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
 m^3/kmol], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.T">
-<code class="descname">T</code><a class="headerlink" href="#cantera.Quantity.T" title="Permalink to this definition">¶</a></dt>
+<code class="descname">T</code><a class="headerlink" href="#cantera.Quantity.T" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Temperature [K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.TD">
-<code class="descname">TD</code><a class="headerlink" href="#cantera.Quantity.TD" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TD</code><a class="headerlink" href="#cantera.Quantity.TD" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K] and density [kg/m^3 or kmol/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.TDX">
-<code class="descname">TDX</code><a class="headerlink" href="#cantera.Quantity.TDX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TDX</code><a class="headerlink" href="#cantera.Quantity.TDX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K], density [kg/m^3 or kmol/m^3], and mole
 fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.TDY">
-<code class="descname">TDY</code><a class="headerlink" href="#cantera.Quantity.TDY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TDY</code><a class="headerlink" href="#cantera.Quantity.TDY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K] and density [kg/m^3 or kmol/m^3], and mass
 fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.TP">
-<code class="descname">TP</code><a class="headerlink" href="#cantera.Quantity.TP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TP</code><a class="headerlink" href="#cantera.Quantity.TP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.TPX">
-<code class="descname">TPX</code><a class="headerlink" href="#cantera.Quantity.TPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TPX</code><a class="headerlink" href="#cantera.Quantity.TPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K], pressure [Pa], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.TPY">
-<code class="descname">TPY</code><a class="headerlink" href="#cantera.Quantity.TPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TPY</code><a class="headerlink" href="#cantera.Quantity.TPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K], pressure [Pa], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.T_sat">
-<code class="descname">T_sat</code><a class="headerlink" href="#cantera.Quantity.T_sat" title="Permalink to this definition">¶</a></dt>
+<code class="descname">T_sat</code><a class="headerlink" href="#cantera.Quantity.T_sat" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Saturation temperature [K] at the current pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.U">
-<code class="descname">U</code><a class="headerlink" href="#cantera.Quantity.U" title="Permalink to this definition">¶</a></dt>
+<code class="descname">U</code><a class="headerlink" href="#cantera.Quantity.U" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total internal energy [J] represented by the <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.UV">
-<code class="descname">UV</code><a class="headerlink" href="#cantera.Quantity.UV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UV</code><a class="headerlink" href="#cantera.Quantity.UV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set internal energy [J/kg or J/kmol] and specific volume
 [m^3/kg or m^3/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.UVX">
-<code class="descname">UVX</code><a class="headerlink" href="#cantera.Quantity.UVX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UVX</code><a class="headerlink" href="#cantera.Quantity.UVX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set internal energy [J/kg or J/kmol], specific volume
 [m^3/kg or m^3/kmol], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.UVY">
-<code class="descname">UVY</code><a class="headerlink" href="#cantera.Quantity.UVY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UVY</code><a class="headerlink" href="#cantera.Quantity.UVY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set internal energy [J/kg or J/kmol], specific volume
 [m^3/kg or m^3/kmol], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.V">
-<code class="descname">V</code><a class="headerlink" href="#cantera.Quantity.V" title="Permalink to this definition">¶</a></dt>
+<code class="descname">V</code><a class="headerlink" href="#cantera.Quantity.V" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total volume [m^3] represented by the <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.X">
-<code class="descname">X</code><a class="headerlink" href="#cantera.Quantity.X" title="Permalink to this definition">¶</a></dt>
+<code class="descname">X</code><a class="headerlink" href="#cantera.Quantity.X" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species mole fractions. Can be set as an array, as a dictionary,
 or as a string. Always returns an array:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">[</span><span class="mf">0.1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.4</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">]</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;H2&#39;</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">&#39;O2&#39;</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">&#39;AR&#39;</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">&#39;H2:0.1, O2:0.4, AR:0.5&#39;</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">{</span><span class="s1">'H2'</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">'O2'</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">'AR'</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">'H2:0.1, O2:0.4, AR:0.5'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span>
 <span class="go">array([0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5])</span>
 </pre></div>
@@ -508,12 +504,12 @@ or as a string. Always returns an array:</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.Y">
-<code class="descname">Y</code><a class="headerlink" href="#cantera.Quantity.Y" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Y</code><a class="headerlink" href="#cantera.Quantity.Y" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species mass fractions. Can be set as an array, as a dictionary,
 or as a string. Always returns an array:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">[</span><span class="mf">0.1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.4</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">]</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;H2&#39;</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">&#39;O2&#39;</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">&#39;AR&#39;</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="s1">&#39;H2:0.1, O2:0.4, AR:0.5&#39;</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">{</span><span class="s1">'H2'</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">'O2'</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">'AR'</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="s1">'H2:0.1, O2:0.4, AR:0.5'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span>
 <span class="go">array([0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5])</span>
 </pre></div>
@@ -522,45 +518,45 @@ or as a string. Always returns an array:</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.activities">
-<code class="descname">activities</code><a class="headerlink" href="#cantera.Quantity.activities" title="Permalink to this definition">¶</a></dt>
+<code class="descname">activities</code><a class="headerlink" href="#cantera.Quantity.activities" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional activities. Returns either molar or molal
 activities depending on the convention of the thermodynamic model.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.activity_coefficients">
-<code class="descname">activity_coefficients</code><a class="headerlink" href="#cantera.Quantity.activity_coefficients" title="Permalink to this definition">¶</a></dt>
+<code class="descname">activity_coefficients</code><a class="headerlink" href="#cantera.Quantity.activity_coefficients" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional, molar activity coefficients.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.add_reaction">
-<code class="descname">add_reaction</code><a class="headerlink" href="#cantera.Quantity.add_reaction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">add_reaction</code><a class="headerlink" href="#cantera.Quantity.add_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Add a new reaction to this phase.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.add_species">
-<code class="descname">add_species</code><a class="headerlink" href="#cantera.Quantity.add_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">add_species</code><a class="headerlink" href="#cantera.Quantity.add_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Add a new species to this phase. Missing elements will be added
 automatically.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.atomic_weight">
-<code class="descname">atomic_weight</code><a class="headerlink" href="#cantera.Quantity.atomic_weight" title="Permalink to this definition">¶</a></dt>
+<code class="descname">atomic_weight</code><a class="headerlink" href="#cantera.Quantity.atomic_weight" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Atomic weight [kg/kmol] of element <em>m</em></p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.atomic_weights">
-<code class="descname">atomic_weights</code><a class="headerlink" href="#cantera.Quantity.atomic_weights" title="Permalink to this definition">¶</a></dt>
+<code class="descname">atomic_weights</code><a class="headerlink" href="#cantera.Quantity.atomic_weights" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of atomic weight [kg/kmol] for each element in the mixture.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.basis">
-<code class="descname">basis</code><a class="headerlink" href="#cantera.Quantity.basis" title="Permalink to this definition">¶</a></dt>
+<code class="descname">basis</code><a class="headerlink" href="#cantera.Quantity.basis" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Determines whether intensive thermodynamic properties are treated on a
 <code class="xref py py-obj docutils literal notranslate"><span class="pre">mass</span></code> (per kg) or <code class="xref py py-obj docutils literal notranslate"><span class="pre">molar</span></code> (per kmol) basis. This affects the values
 returned by the properties <a class="reference internal" href="#cantera.Quantity.h" title="cantera.Quantity.h"><code class="xref py py-obj docutils literal notranslate"><span class="pre">h</span></code></a>, <a class="reference internal" href="#cantera.Quantity.u" title="cantera.Quantity.u"><code class="xref py py-obj docutils literal notranslate"><span class="pre">u</span></code></a>, <a class="reference internal" href="#cantera.Quantity.s" title="cantera.Quantity.s"><code class="xref py py-obj docutils literal notranslate"><span class="pre">s</span></code></a>, <a class="reference internal" href="#cantera.Quantity.g" title="cantera.Quantity.g"><code class="xref py py-obj docutils literal notranslate"><span class="pre">g</span></code></a>, <a class="reference internal" href="#cantera.Quantity.v" title="cantera.Quantity.v"><code class="xref py py-obj docutils literal notranslate"><span class="pre">v</span></code></a>, <a class="reference internal" href="#cantera.Quantity.density" title="cantera.Quantity.density"><code class="xref py py-obj docutils literal notranslate"><span class="pre">density</span></code></a>, <a class="reference internal" href="#cantera.Quantity.cv" title="cantera.Quantity.cv"><code class="xref py py-obj docutils literal notranslate"><span class="pre">cv</span></code></a>,
@@ -570,170 +566,170 @@ such as <a class="reference internal" href="#cantera.Quantity.HPX" title="canter
 
 <dl class="attribute">
 <dt id="cantera.Quantity.binary_diff_coeffs">
-<code class="descname">binary_diff_coeffs</code><a class="headerlink" href="#cantera.Quantity.binary_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">binary_diff_coeffs</code><a class="headerlink" href="#cantera.Quantity.binary_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Binary diffusion coefficients [m^2/s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.chemical_potentials">
-<code class="descname">chemical_potentials</code><a class="headerlink" href="#cantera.Quantity.chemical_potentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">chemical_potentials</code><a class="headerlink" href="#cantera.Quantity.chemical_potentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species chemical potentials [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.concentrations">
-<code class="descname">concentrations</code><a class="headerlink" href="#cantera.Quantity.concentrations" title="Permalink to this definition">¶</a></dt>
+<code class="descname">concentrations</code><a class="headerlink" href="#cantera.Quantity.concentrations" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species concentrations [kmol/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.cp">
-<code class="descname">cp</code><a class="headerlink" href="#cantera.Quantity.cp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp</code><a class="headerlink" href="#cantera.Quantity.cp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Heat capacity at constant pressure [J/kg/K or J/kmol/K] depending
 on <a class="reference internal" href="#cantera.Quantity.basis" title="cantera.Quantity.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.cp_mass">
-<code class="descname">cp_mass</code><a class="headerlink" href="#cantera.Quantity.cp_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp_mass</code><a class="headerlink" href="#cantera.Quantity.cp_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific heat capacity at constant pressure [J/kg/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.cp_mole">
-<code class="descname">cp_mole</code><a class="headerlink" href="#cantera.Quantity.cp_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp_mole</code><a class="headerlink" href="#cantera.Quantity.cp_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar heat capacity at constant pressure [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.creation_rates">
-<code class="descname">creation_rates</code><a class="headerlink" href="#cantera.Quantity.creation_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">creation_rates</code><a class="headerlink" href="#cantera.Quantity.creation_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Creation rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.critical_density">
-<code class="descname">critical_density</code><a class="headerlink" href="#cantera.Quantity.critical_density" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critical_density</code><a class="headerlink" href="#cantera.Quantity.critical_density" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Critical density [kg/m^3 or kmol/m^3] depending on <a class="reference internal" href="#cantera.Quantity.basis" title="cantera.Quantity.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.critical_pressure">
-<code class="descname">critical_pressure</code><a class="headerlink" href="#cantera.Quantity.critical_pressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critical_pressure</code><a class="headerlink" href="#cantera.Quantity.critical_pressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Critical pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.critical_temperature">
-<code class="descname">critical_temperature</code><a class="headerlink" href="#cantera.Quantity.critical_temperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critical_temperature</code><a class="headerlink" href="#cantera.Quantity.critical_temperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Critical temperature [K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.cv">
-<code class="descname">cv</code><a class="headerlink" href="#cantera.Quantity.cv" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv</code><a class="headerlink" href="#cantera.Quantity.cv" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Heat capacity at constant volume [J/kg/K or J/kmol/K] depending on
 <a class="reference internal" href="#cantera.Quantity.basis" title="cantera.Quantity.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.cv_mass">
-<code class="descname">cv_mass</code><a class="headerlink" href="#cantera.Quantity.cv_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv_mass</code><a class="headerlink" href="#cantera.Quantity.cv_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific heat capacity at constant volume [J/kg/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.cv_mole">
-<code class="descname">cv_mole</code><a class="headerlink" href="#cantera.Quantity.cv_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv_mole</code><a class="headerlink" href="#cantera.Quantity.cv_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar heat capacity at constant volume [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.delta_enthalpy">
-<code class="descname">delta_enthalpy</code><a class="headerlink" href="#cantera.Quantity.delta_enthalpy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_enthalpy</code><a class="headerlink" href="#cantera.Quantity.delta_enthalpy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in enthalpy for each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.delta_entropy">
-<code class="descname">delta_entropy</code><a class="headerlink" href="#cantera.Quantity.delta_entropy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_entropy</code><a class="headerlink" href="#cantera.Quantity.delta_entropy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in entropy for each reaction [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.delta_gibbs">
-<code class="descname">delta_gibbs</code><a class="headerlink" href="#cantera.Quantity.delta_gibbs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_gibbs</code><a class="headerlink" href="#cantera.Quantity.delta_gibbs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in Gibbs free energy for each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.delta_standard_enthalpy">
-<code class="descname">delta_standard_enthalpy</code><a class="headerlink" href="#cantera.Quantity.delta_standard_enthalpy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_enthalpy</code><a class="headerlink" href="#cantera.Quantity.delta_standard_enthalpy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state enthalpy (independent of composition) for
 each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.delta_standard_entropy">
-<code class="descname">delta_standard_entropy</code><a class="headerlink" href="#cantera.Quantity.delta_standard_entropy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_entropy</code><a class="headerlink" href="#cantera.Quantity.delta_standard_entropy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state entropy (independent of composition) for
 each reaction [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.delta_standard_gibbs">
-<code class="descname">delta_standard_gibbs</code><a class="headerlink" href="#cantera.Quantity.delta_standard_gibbs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_gibbs</code><a class="headerlink" href="#cantera.Quantity.delta_standard_gibbs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state Gibbs free energy (independent of composition)
 for each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.density">
-<code class="descname">density</code><a class="headerlink" href="#cantera.Quantity.density" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density</code><a class="headerlink" href="#cantera.Quantity.density" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Density [kg/m^3 or kmol/m^3] depending on <a class="reference internal" href="#cantera.Quantity.basis" title="cantera.Quantity.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.density_mass">
-<code class="descname">density_mass</code><a class="headerlink" href="#cantera.Quantity.density_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density_mass</code><a class="headerlink" href="#cantera.Quantity.density_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>(Mass) density [kg/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.density_mole">
-<code class="descname">density_mole</code><a class="headerlink" href="#cantera.Quantity.density_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density_mole</code><a class="headerlink" href="#cantera.Quantity.density_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar density [kmol/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.destruction_rates">
-<code class="descname">destruction_rates</code><a class="headerlink" href="#cantera.Quantity.destruction_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">destruction_rates</code><a class="headerlink" href="#cantera.Quantity.destruction_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Destruction rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.electric_potential">
-<code class="descname">electric_potential</code><a class="headerlink" href="#cantera.Quantity.electric_potential" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electric_potential</code><a class="headerlink" href="#cantera.Quantity.electric_potential" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the electric potential [V] for this phase.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.electrical_conductivity">
-<code class="descname">electrical_conductivity</code><a class="headerlink" href="#cantera.Quantity.electrical_conductivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electrical_conductivity</code><a class="headerlink" href="#cantera.Quantity.electrical_conductivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Electrical conductivity. [S/m].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.electrochemical_potentials">
-<code class="descname">electrochemical_potentials</code><a class="headerlink" href="#cantera.Quantity.electrochemical_potentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electrochemical_potentials</code><a class="headerlink" href="#cantera.Quantity.electrochemical_potentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species electrochemical potentials [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.element_index">
-<code class="descname">element_index</code><a class="headerlink" href="#cantera.Quantity.element_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_index</code><a class="headerlink" href="#cantera.Quantity.element_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of element <em>element</em>, which may be specified as a string or
 an integer. In the latter case, the index is checked for validity and
 returned. If no such element is present, an exception is thrown.</p>
@@ -741,19 +737,19 @@ returned. If no such element is present, an exception is thrown.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.element_name">
-<code class="descname">element_name</code><a class="headerlink" href="#cantera.Quantity.element_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_name</code><a class="headerlink" href="#cantera.Quantity.element_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Name of the element with index <em>m</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.element_names">
-<code class="descname">element_names</code><a class="headerlink" href="#cantera.Quantity.element_names" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_names</code><a class="headerlink" href="#cantera.Quantity.element_names" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A list of all the element names.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.element_potentials">
-<code class="descname">element_potentials</code><a class="headerlink" href="#cantera.Quantity.element_potentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_potentials</code><a class="headerlink" href="#cantera.Quantity.element_potentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the array of element potentials. The element potentials are only
 defined for equilibrium states. This method first sets the composition
 to a state of equilibrium at constant T and P, then computes the
@@ -765,7 +761,7 @@ element potentials for this equilibrium state.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.elemental_mass_fraction">
-<code class="descname">elemental_mass_fraction</code><a class="headerlink" href="#cantera.Quantity.elemental_mass_fraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elemental_mass_fraction</code><a class="headerlink" href="#cantera.Quantity.elemental_mass_fraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the elemental mass fraction <span class="math">\(Z_{\mathrm{mass},m}\)</span> of element
 <span class="math">\(m\)</span> as defined by:</p>
 <div class="math">
@@ -777,14 +773,14 @@ species <span class="math">\(k\)</span>, <span class="math">\(M_m\)</span> the a
 <span class="math">\(M_k\)</span> the molecular weight of species <span class="math">\(k\)</span>, and <span class="math">\(Y_k\)</span>
 the mass fraction of species <span class="math">\(k\)</span>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> – Base element, may be specified by name or by index.</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> &#8211; Base element, may be specified by name or by index.</td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mass_fraction</span><span class="p">(</span><span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mass_fraction</span><span class="p">(</span><span class="s1">'H'</span><span class="p">)</span>
 <span class="go">1.0</span>
 </pre></div>
 </div>
@@ -792,7 +788,7 @@ the mass fraction of species <span class="math">\(k\)</span>.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.elemental_mole_fraction">
-<code class="descname">elemental_mole_fraction</code><a class="headerlink" href="#cantera.Quantity.elemental_mole_fraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elemental_mole_fraction</code><a class="headerlink" href="#cantera.Quantity.elemental_mole_fraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the elemental mole fraction <span class="math">\(Z_{\mathrm{mole},m}\)</span> of element
 <span class="math">\(m\)</span> (the number of atoms of element m divided by the total number
 of atoms) as defined by:</p>
@@ -805,14 +801,14 @@ of atoms) as defined by:</p>
 species <span class="math">\(k\)</span>, <span class="math">\(\sum_j\)</span> being a sum over all elements, and
 <span class="math">\(X_k\)</span> being the mole fraction of species <span class="math">\(k\)</span>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> – Base element, may be specified by name or by index.</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> &#8211; Base element, may be specified by name or by index.</td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mole_fraction</span><span class="p">(</span><span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mole_fraction</span><span class="p">(</span><span class="s1">'H'</span><span class="p">)</span>
 <span class="go">1.0</span>
 </pre></div>
 </div>
@@ -820,56 +816,56 @@ species <span class="math">\(k\)</span>, <span class="math">\(\sum_j\)</span> be
 
 <dl class="attribute">
 <dt id="cantera.Quantity.enthalpy">
-<code class="descname">enthalpy</code><a class="headerlink" href="#cantera.Quantity.enthalpy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy</code><a class="headerlink" href="#cantera.Quantity.enthalpy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total enthalpy [J] represented by the <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.enthalpy_mass">
-<code class="descname">enthalpy_mass</code><a class="headerlink" href="#cantera.Quantity.enthalpy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy_mass</code><a class="headerlink" href="#cantera.Quantity.enthalpy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific enthalpy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.enthalpy_mole">
-<code class="descname">enthalpy_mole</code><a class="headerlink" href="#cantera.Quantity.enthalpy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy_mole</code><a class="headerlink" href="#cantera.Quantity.enthalpy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar enthalpy [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.entropy">
-<code class="descname">entropy</code><a class="headerlink" href="#cantera.Quantity.entropy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropy</code><a class="headerlink" href="#cantera.Quantity.entropy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total entropy [J/K] represented by the <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.entropy_mass">
-<code class="descname">entropy_mass</code><a class="headerlink" href="#cantera.Quantity.entropy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropy_mass</code><a class="headerlink" href="#cantera.Quantity.entropy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific entropy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.entropy_mole">
-<code class="descname">entropy_mole</code><a class="headerlink" href="#cantera.Quantity.entropy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropy_mole</code><a class="headerlink" href="#cantera.Quantity.entropy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar entropy [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Quantity.equilibrate">
-<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>XY=None</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Quantity.equilibrate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>XY=None</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Quantity.equilibrate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the state to equilibrium. By default, the property pair
 <code class="xref py py-obj docutils literal notranslate"><span class="pre">self.constant</span></code> is held constant. See <a class="reference internal" href="thermo.html#cantera.ThermoPhase.equilibrate" title="cantera.ThermoPhase.equilibrate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ThermoPhase.equilibrate</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.equilibrium_constants">
-<code class="descname">equilibrium_constants</code><a class="headerlink" href="#cantera.Quantity.equilibrium_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equilibrium_constants</code><a class="headerlink" href="#cantera.Quantity.equilibrium_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Equilibrium constants in concentration units for all reactions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.forward_rate_constants">
-<code class="descname">forward_rate_constants</code><a class="headerlink" href="#cantera.Quantity.forward_rate_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">forward_rate_constants</code><a class="headerlink" href="#cantera.Quantity.forward_rate_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Forward rate constants for all reactions. The computed values include
 all temperature-dependent, pressure-dependent, and third body
 contributions. Units are a combination of kmol, m^3 and s, that depend
@@ -878,46 +874,46 @@ on the rate expression for the reaction.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.forward_rates_of_progress">
-<code class="descname">forward_rates_of_progress</code><a class="headerlink" href="#cantera.Quantity.forward_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">forward_rates_of_progress</code><a class="headerlink" href="#cantera.Quantity.forward_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Forward rates of progress for the reactions. [kmol/m^3/s] for bulk
 phases or [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.g">
-<code class="descname">g</code><a class="headerlink" href="#cantera.Quantity.g" title="Permalink to this definition">¶</a></dt>
+<code class="descname">g</code><a class="headerlink" href="#cantera.Quantity.g" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Gibbs free energy [J/kg or J/kmol] depending on <a class="reference internal" href="#cantera.Quantity.basis" title="cantera.Quantity.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.get_equivalence_ratio">
-<code class="descname">get_equivalence_ratio</code><a class="headerlink" href="#cantera.Quantity.get_equivalence_ratio" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_equivalence_ratio</code><a class="headerlink" href="#cantera.Quantity.get_equivalence_ratio" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the composition of a fuel/oxidizer mixture. This gives the
 equivalence ratio of an unburned mixture. This is not a quantity that is
 conserved after oxidation. Considers the oxidation of C to CO2, H to H2O
 and S to SO2. Other elements are assumed not to participate in oxidation
 (i.e. N ends up as N2).</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>oxidizers</strong> – List of oxidizer species names as strings. Default: with
+<li><strong>oxidizers</strong> &#8211; List of oxidizer species names as strings. Default: with
 <code class="docutils literal notranslate"><span class="pre">oxidizers=[]</span></code>, every species that contains O but does not contain
 H, C, or S is considered to be an oxidizer.</li>
-<li><strong>ignore</strong> – List of species names as strings to ignore.</li>
+<li><strong>ignore</strong> &#8211; List of species names as strings to ignore.</li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">0.5</span><span class="p">,</span> <span class="s1">&#39;CH3:0.5, CH3OH:.5, N2:0.125&#39;</span><span class="p">,</span> <span class="s1">&#39;O2:0.21, N2:0.79, NO:0.01&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">0.5</span><span class="p">,</span> <span class="s1">'CH3:0.5, CH3OH:.5, N2:0.125'</span><span class="p">,</span> <span class="s1">'O2:0.21, N2:0.79, NO:0.01'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">get_equivalence_ratio</span><span class="p">()</span>
 <span class="go">0.50000000000000011</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">get_equivalence_ratio</span><span class="p">([</span><span class="s1">&#39;O2&#39;</span><span class="p">])</span>  <span class="c1"># Only consider O2 as the oxidizer instead of O2 and NO</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">get_equivalence_ratio</span><span class="p">([</span><span class="s1">'O2'</span><span class="p">])</span>  <span class="c1"># Only consider O2 as the oxidizer instead of O2 and NO</span>
 <span class="go">0.48809523809523814</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">&#39;CH4:1, O2:2, NO:0.1&#39;</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">get_equivalence_ratio</span><span class="p">(</span><span class="n">ignore</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;NO&#39;</span><span class="p">])</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">'CH4:1, O2:2, NO:0.1'</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">get_equivalence_ratio</span><span class="p">(</span><span class="n">ignore</span><span class="o">=</span><span class="p">[</span><span class="s1">'NO'</span><span class="p">])</span>
 <span class="go">1.0</span>
 </pre></div>
 </div>
@@ -925,61 +921,61 @@ H, C, or S is considered to be an oxidizer.</li>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.gibbs">
-<code class="descname">gibbs</code><a class="headerlink" href="#cantera.Quantity.gibbs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs</code><a class="headerlink" href="#cantera.Quantity.gibbs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total Gibbs free energy [J] represented by the <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.gibbs_mass">
-<code class="descname">gibbs_mass</code><a class="headerlink" href="#cantera.Quantity.gibbs_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs_mass</code><a class="headerlink" href="#cantera.Quantity.gibbs_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific Gibbs free energy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.gibbs_mole">
-<code class="descname">gibbs_mole</code><a class="headerlink" href="#cantera.Quantity.gibbs_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs_mole</code><a class="headerlink" href="#cantera.Quantity.gibbs_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar Gibbs free energy [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.h">
-<code class="descname">h</code><a class="headerlink" href="#cantera.Quantity.h" title="Permalink to this definition">¶</a></dt>
+<code class="descname">h</code><a class="headerlink" href="#cantera.Quantity.h" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Enthalpy [J/kg or J/kmol] depending on <a class="reference internal" href="#cantera.Quantity.basis" title="cantera.Quantity.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.int_energy">
-<code class="descname">int_energy</code><a class="headerlink" href="#cantera.Quantity.int_energy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">int_energy</code><a class="headerlink" href="#cantera.Quantity.int_energy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total internal energy [J] represented by the <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.int_energy_mass">
-<code class="descname">int_energy_mass</code><a class="headerlink" href="#cantera.Quantity.int_energy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">int_energy_mass</code><a class="headerlink" href="#cantera.Quantity.int_energy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific internal energy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.int_energy_mole">
-<code class="descname">int_energy_mole</code><a class="headerlink" href="#cantera.Quantity.int_energy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">int_energy_mole</code><a class="headerlink" href="#cantera.Quantity.int_energy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar internal energy [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.is_reversible">
-<code class="descname">is_reversible</code><a class="headerlink" href="#cantera.Quantity.is_reversible" title="Permalink to this definition">¶</a></dt>
+<code class="descname">is_reversible</code><a class="headerlink" href="#cantera.Quantity.is_reversible" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>True if reaction <code class="xref py py-obj docutils literal notranslate"><span class="pre">i_reaction</span></code> is reversible.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.isothermal_compressibility">
-<code class="descname">isothermal_compressibility</code><a class="headerlink" href="#cantera.Quantity.isothermal_compressibility" title="Permalink to this definition">¶</a></dt>
+<code class="descname">isothermal_compressibility</code><a class="headerlink" href="#cantera.Quantity.isothermal_compressibility" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Isothermal compressibility [1/Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.kinetics_species_index">
-<code class="descname">kinetics_species_index</code><a class="headerlink" href="#cantera.Quantity.kinetics_species_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">kinetics_species_index</code><a class="headerlink" href="#cantera.Quantity.kinetics_species_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of species <em>species</em> of phase <em>phase</em> within arrays returned
 by methods of class <a class="reference internal" href="kinetics.html#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a>. If <em>species</em> is a string, the <em>phase</em>
 argument is unused.</p>
@@ -987,32 +983,32 @@ argument is unused.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.mass_fraction_dict">
-<code class="descname">mass_fraction_dict</code><a class="headerlink" href="#cantera.Quantity.mass_fraction_dict" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mass_fraction_dict</code><a class="headerlink" href="#cantera.Quantity.mass_fraction_dict" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.max_temp">
-<code class="descname">max_temp</code><a class="headerlink" href="#cantera.Quantity.max_temp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">max_temp</code><a class="headerlink" href="#cantera.Quantity.max_temp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Maximum temperature for which the thermodynamic data for the phase are
 valid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.mean_molecular_weight">
-<code class="descname">mean_molecular_weight</code><a class="headerlink" href="#cantera.Quantity.mean_molecular_weight" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mean_molecular_weight</code><a class="headerlink" href="#cantera.Quantity.mean_molecular_weight" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The mean molecular weight (molar mass) [kg/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.min_temp">
-<code class="descname">min_temp</code><a class="headerlink" href="#cantera.Quantity.min_temp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">min_temp</code><a class="headerlink" href="#cantera.Quantity.min_temp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Minimum temperature for which the thermodynamic data for the phase are
 valid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.mix_diff_coeffs">
-<code class="descname">mix_diff_coeffs</code><a class="headerlink" href="#cantera.Quantity.mix_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs</code><a class="headerlink" href="#cantera.Quantity.mix_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 mass-averaged diffusive fluxes (with respect to the mass averaged
 velocity) to gradients in the species mole fractions.</p>
@@ -1020,21 +1016,21 @@ velocity) to gradients in the species mole fractions.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.mix_diff_coeffs_mass">
-<code class="descname">mix_diff_coeffs_mass</code><a class="headerlink" href="#cantera.Quantity.mix_diff_coeffs_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs_mass</code><a class="headerlink" href="#cantera.Quantity.mix_diff_coeffs_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 diffusive mass fluxes to gradients in the species mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.mix_diff_coeffs_mole">
-<code class="descname">mix_diff_coeffs_mole</code><a class="headerlink" href="#cantera.Quantity.mix_diff_coeffs_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs_mole</code><a class="headerlink" href="#cantera.Quantity.mix_diff_coeffs_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 molar diffusive fluxes to gradients in the species mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.modify_reaction">
-<code class="descname">modify_reaction</code><a class="headerlink" href="#cantera.Quantity.modify_reaction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">modify_reaction</code><a class="headerlink" href="#cantera.Quantity.modify_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Modify the <a class="reference internal" href="kinetics.html#cantera.Reaction" title="cantera.Reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reaction</span></code></a> with index <code class="docutils literal notranslate"><span class="pre">irxn</span></code> to have the same rate
 parameters as <code class="docutils literal notranslate"><span class="pre">rxn</span></code>. <code class="docutils literal notranslate"><span class="pre">rxn</span></code> must have the same reactants and products
 and be of the same type (i.e. <a class="reference internal" href="kinetics.html#cantera.ElementaryReaction" title="cantera.ElementaryReaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ElementaryReaction</span></code></a>, <a class="reference internal" href="kinetics.html#cantera.FalloffReaction" title="cantera.FalloffReaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">FalloffReaction</span></code></a>,
@@ -1045,35 +1041,35 @@ the reaction.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.modify_species">
-<code class="descname">modify_species</code><a class="headerlink" href="#cantera.Quantity.modify_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">modify_species</code><a class="headerlink" href="#cantera.Quantity.modify_species" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.mole_fraction_dict">
-<code class="descname">mole_fraction_dict</code><a class="headerlink" href="#cantera.Quantity.mole_fraction_dict" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mole_fraction_dict</code><a class="headerlink" href="#cantera.Quantity.mole_fraction_dict" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.molecular_weights">
-<code class="descname">molecular_weights</code><a class="headerlink" href="#cantera.Quantity.molecular_weights" title="Permalink to this definition">¶</a></dt>
+<code class="descname">molecular_weights</code><a class="headerlink" href="#cantera.Quantity.molecular_weights" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species molecular weights (molar masses) [kg/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.moles">
-<code class="descname">moles</code><a class="headerlink" href="#cantera.Quantity.moles" title="Permalink to this definition">¶</a></dt>
+<code class="descname">moles</code><a class="headerlink" href="#cantera.Quantity.moles" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the number of moles [kmol] represented by the <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.multi_diff_coeffs">
-<code class="descname">multi_diff_coeffs</code><a class="headerlink" href="#cantera.Quantity.multi_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">multi_diff_coeffs</code><a class="headerlink" href="#cantera.Quantity.multi_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Multicomponent diffusion coefficients [m^2/s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.multiplier">
-<code class="descname">multiplier</code><a class="headerlink" href="#cantera.Quantity.multiplier" title="Permalink to this definition">¶</a></dt>
+<code class="descname">multiplier</code><a class="headerlink" href="#cantera.Quantity.multiplier" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A scaling factor applied to the rate coefficient for reaction
 <em>i_reaction</em>. Can be used to carry out sensitivity analysis or to
 selectively disable a particular reaction. See <a class="reference internal" href="#cantera.Quantity.set_multiplier" title="cantera.Quantity.set_multiplier"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_multiplier</span></code></a>.</p>
@@ -1081,10 +1077,10 @@ selectively disable a particular reaction. See <a class="reference internal" hre
 
 <dl class="attribute">
 <dt id="cantera.Quantity.n_atoms">
-<code class="descname">n_atoms</code><a class="headerlink" href="#cantera.Quantity.n_atoms" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_atoms</code><a class="headerlink" href="#cantera.Quantity.n_atoms" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of atoms of element <em>element</em> in species <em>species</em>. The element
 and species may be specified by name or by index.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">n_atoms</span><span class="p">(</span><span class="s1">&#39;CH4&#39;</span><span class="p">,</span><span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">n_atoms</span><span class="p">(</span><span class="s1">'CH4'</span><span class="p">,</span><span class="s1">'H'</span><span class="p">)</span>
 <span class="go">4</span>
 </pre></div>
 </div>
@@ -1092,110 +1088,110 @@ and species may be specified by name or by index.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.n_elements">
-<code class="descname">n_elements</code><a class="headerlink" href="#cantera.Quantity.n_elements" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_elements</code><a class="headerlink" href="#cantera.Quantity.n_elements" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of elements.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.n_phases">
-<code class="descname">n_phases</code><a class="headerlink" href="#cantera.Quantity.n_phases" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_phases</code><a class="headerlink" href="#cantera.Quantity.n_phases" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of phases in the reaction mechanism.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.n_reactions">
-<code class="descname">n_reactions</code><a class="headerlink" href="#cantera.Quantity.n_reactions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_reactions</code><a class="headerlink" href="#cantera.Quantity.n_reactions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of reactions in the reaction mechanism.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.n_selected_species">
-<code class="descname">n_selected_species</code><a class="headerlink" href="#cantera.Quantity.n_selected_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_selected_species</code><a class="headerlink" href="#cantera.Quantity.n_selected_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of species selected for output (by slicing of Solution object)</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.n_species">
-<code class="descname">n_species</code><a class="headerlink" href="#cantera.Quantity.n_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_species</code><a class="headerlink" href="#cantera.Quantity.n_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of species.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.n_total_species">
-<code class="descname">n_total_species</code><a class="headerlink" href="#cantera.Quantity.n_total_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_total_species</code><a class="headerlink" href="#cantera.Quantity.n_total_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Total number of species in all phases participating in the kinetics
 mechanism.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.name">
-<code class="descname">name</code><a class="headerlink" href="#cantera.Quantity.name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">name</code><a class="headerlink" href="#cantera.Quantity.name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The name assigned to this phase. The default is taken from the CTI/XML
 input file.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.net_production_rates">
-<code class="descname">net_production_rates</code><a class="headerlink" href="#cantera.Quantity.net_production_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">net_production_rates</code><a class="headerlink" href="#cantera.Quantity.net_production_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Net production rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.net_rates_of_progress">
-<code class="descname">net_rates_of_progress</code><a class="headerlink" href="#cantera.Quantity.net_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">net_rates_of_progress</code><a class="headerlink" href="#cantera.Quantity.net_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Net rates of progress for the reactions. [kmol/m^3/s] for bulk phases
 or [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.partial_molar_cp">
-<code class="descname">partial_molar_cp</code><a class="headerlink" href="#cantera.Quantity.partial_molar_cp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_cp</code><a class="headerlink" href="#cantera.Quantity.partial_molar_cp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar specific heat capacities at constant
 pressure [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.partial_molar_enthalpies">
-<code class="descname">partial_molar_enthalpies</code><a class="headerlink" href="#cantera.Quantity.partial_molar_enthalpies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_enthalpies</code><a class="headerlink" href="#cantera.Quantity.partial_molar_enthalpies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar enthalpies [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.partial_molar_entropies">
-<code class="descname">partial_molar_entropies</code><a class="headerlink" href="#cantera.Quantity.partial_molar_entropies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_entropies</code><a class="headerlink" href="#cantera.Quantity.partial_molar_entropies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar entropies [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.partial_molar_int_energies">
-<code class="descname">partial_molar_int_energies</code><a class="headerlink" href="#cantera.Quantity.partial_molar_int_energies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_int_energies</code><a class="headerlink" href="#cantera.Quantity.partial_molar_int_energies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar internal energies [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.partial_molar_volumes">
-<code class="descname">partial_molar_volumes</code><a class="headerlink" href="#cantera.Quantity.partial_molar_volumes" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_volumes</code><a class="headerlink" href="#cantera.Quantity.partial_molar_volumes" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar volumes [m^3/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.phase">
-<code class="descname">phase</code><a class="headerlink" href="#cantera.Quantity.phase" title="Permalink to this definition">¶</a></dt>
+<code class="descname">phase</code><a class="headerlink" href="#cantera.Quantity.phase" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the underlying <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object, with the state set to match the
 wrapping <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a> object.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.product_stoich_coeff">
-<code class="descname">product_stoich_coeff</code><a class="headerlink" href="#cantera.Quantity.product_stoich_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">product_stoich_coeff</code><a class="headerlink" href="#cantera.Quantity.product_stoich_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The stoichiometric coefficient of species <em>k_spec</em> as a product in
 reaction <em>i_reaction</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.product_stoich_coeffs">
-<code class="descname">product_stoich_coeffs</code><a class="headerlink" href="#cantera.Quantity.product_stoich_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">product_stoich_coeffs</code><a class="headerlink" href="#cantera.Quantity.product_stoich_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The array of product stoichiometric coefficients. Element <em>[k,i]</em> of
 this array is the product stoichiometric coefficient of species <em>k</em> in
 reaction <em>i</em>.</p>
@@ -1203,20 +1199,20 @@ reaction <em>i</em>.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.products">
-<code class="descname">products</code><a class="headerlink" href="#cantera.Quantity.products" title="Permalink to this definition">¶</a></dt>
+<code class="descname">products</code><a class="headerlink" href="#cantera.Quantity.products" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The products portion of the reaction equation</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reactant_stoich_coeff">
-<code class="descname">reactant_stoich_coeff</code><a class="headerlink" href="#cantera.Quantity.reactant_stoich_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactant_stoich_coeff</code><a class="headerlink" href="#cantera.Quantity.reactant_stoich_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The stoichiometric coefficient of species <em>k_spec</em> as a reactant in
 reaction <em>i_reaction</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reactant_stoich_coeffs">
-<code class="descname">reactant_stoich_coeffs</code><a class="headerlink" href="#cantera.Quantity.reactant_stoich_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactant_stoich_coeffs</code><a class="headerlink" href="#cantera.Quantity.reactant_stoich_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The array of reactant stoichiometric coefficients. Element <em>[k,i]</em> of
 this array is the reactant stoichiometric coefficient of species <em>k</em> in
 reaction <em>i</em>.</p>
@@ -1224,13 +1220,13 @@ reaction <em>i</em>.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reactants">
-<code class="descname">reactants</code><a class="headerlink" href="#cantera.Quantity.reactants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactants</code><a class="headerlink" href="#cantera.Quantity.reactants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The reactants portion of the reaction equation</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reaction">
-<code class="descname">reaction</code><a class="headerlink" href="#cantera.Quantity.reaction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction</code><a class="headerlink" href="#cantera.Quantity.reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return a <a class="reference internal" href="kinetics.html#cantera.Reaction" title="cantera.Reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reaction</span></code></a> object representing the reaction with index
 <code class="docutils literal notranslate"><span class="pre">i_reaction</span></code>. Changes to this object do not affect the <a class="reference internal" href="kinetics.html#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> or
 <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object until the <a class="reference internal" href="#cantera.Quantity.modify_reaction" title="cantera.Quantity.modify_reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">modify_reaction</span></code></a> function is called.</p>
@@ -1238,20 +1234,20 @@ reaction <em>i</em>.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reaction_equation">
-<code class="descname">reaction_equation</code><a class="headerlink" href="#cantera.Quantity.reaction_equation" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_equation</code><a class="headerlink" href="#cantera.Quantity.reaction_equation" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The equation for the specified reaction. See also <a class="reference internal" href="#cantera.Quantity.reaction_equations" title="cantera.Quantity.reaction_equations"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reaction_equations</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reaction_equations">
-<code class="descname">reaction_equations</code><a class="headerlink" href="#cantera.Quantity.reaction_equations" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_equations</code><a class="headerlink" href="#cantera.Quantity.reaction_equations" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Returns a list containing the reaction equation for all reactions in the
 mechanism (if <em>indices</em> is unspecified) or the equations for each
 reaction in the sequence <em>indices</em>. For example:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">reaction_equations</span><span class="p">()</span>
-<span class="go">[&#39;2 O + M &lt;=&gt; O2 + M&#39;, &#39;O + H + M &lt;=&gt; OH + M&#39;, &#39;O + H2 &lt;=&gt; H + OH&#39;, ...]</span>
+<span class="go">['2 O + M &lt;=&gt; O2 + M', 'O + H + M &lt;=&gt; OH + M', 'O + H2 &lt;=&gt; H + OH', ...]</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">reaction_equations</span><span class="p">([</span><span class="mi">2</span><span class="p">,</span><span class="mi">3</span><span class="p">])</span>
-<span class="go">[&#39;O + H + M &lt;=&gt; OH + M&#39;, &#39;O + H2 &lt;=&gt; H + OH&#39;]</span>
+<span class="go">['O + H + M &lt;=&gt; OH + M', 'O + H2 &lt;=&gt; H + OH']</span>
 </pre></div>
 </div>
 <p>See also <a class="reference internal" href="#cantera.Quantity.reaction_equation" title="cantera.Quantity.reaction_equation"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reaction_equation</span></code></a>.</p>
@@ -1259,19 +1255,19 @@ reaction in the sequence <em>indices</em>. For example:</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reaction_phase_index">
-<code class="descname">reaction_phase_index</code><a class="headerlink" href="#cantera.Quantity.reaction_phase_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_phase_index</code><a class="headerlink" href="#cantera.Quantity.reaction_phase_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of the phase where the reactions occur.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reaction_type">
-<code class="descname">reaction_type</code><a class="headerlink" href="#cantera.Quantity.reaction_type" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_type</code><a class="headerlink" href="#cantera.Quantity.reaction_type" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Type of reaction <em>i_reaction</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reactions">
-<code class="descname">reactions</code><a class="headerlink" href="#cantera.Quantity.reactions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactions</code><a class="headerlink" href="#cantera.Quantity.reactions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return a list of all <a class="reference internal" href="kinetics.html#cantera.Reaction" title="cantera.Reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reaction</span></code></a> objects. Changes to these objects do not
 affect the <a class="reference internal" href="kinetics.html#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> or <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object until the <a class="reference internal" href="#cantera.Quantity.modify_reaction" title="cantera.Quantity.modify_reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">modify_reaction</span></code></a>
 function is called.</p>
@@ -1279,13 +1275,13 @@ function is called.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reference_pressure">
-<code class="descname">reference_pressure</code><a class="headerlink" href="#cantera.Quantity.reference_pressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reference_pressure</code><a class="headerlink" href="#cantera.Quantity.reference_pressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reference state pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.report">
-<code class="descname">report</code><a class="headerlink" href="#cantera.Quantity.report" title="Permalink to this definition">¶</a></dt>
+<code class="descname">report</code><a class="headerlink" href="#cantera.Quantity.report" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Generate a report describing the thermodynamic state of this phase. To
 print the report to the terminal, simply call the phase object. The
 following two statements are equivalent:</p>
@@ -1297,7 +1293,7 @@ following two statements are equivalent:</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reverse_rate_constants">
-<code class="descname">reverse_rate_constants</code><a class="headerlink" href="#cantera.Quantity.reverse_rate_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reverse_rate_constants</code><a class="headerlink" href="#cantera.Quantity.reverse_rate_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reverse rate constants for all reactions. The computed values include
 all temperature-dependent, pressure-dependent, and third body
 contributions. Units are a combination of kmol, m^3 and s, that depend
@@ -1306,47 +1302,47 @@ on the rate expression for the reaction.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.reverse_rates_of_progress">
-<code class="descname">reverse_rates_of_progress</code><a class="headerlink" href="#cantera.Quantity.reverse_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reverse_rates_of_progress</code><a class="headerlink" href="#cantera.Quantity.reverse_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reverse rates of progress for the reactions. [kmol/m^3/s] for bulk
 phases or [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.s">
-<code class="descname">s</code><a class="headerlink" href="#cantera.Quantity.s" title="Permalink to this definition">¶</a></dt>
+<code class="descname">s</code><a class="headerlink" href="#cantera.Quantity.s" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Entropy [J/kg/K or J/kmol/K] depending on <a class="reference internal" href="#cantera.Quantity.basis" title="cantera.Quantity.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.selected_species">
-<code class="descname">selected_species</code><a class="headerlink" href="#cantera.Quantity.selected_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">selected_species</code><a class="headerlink" href="#cantera.Quantity.selected_species" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.set_equivalence_ratio">
-<code class="descname">set_equivalence_ratio</code><a class="headerlink" href="#cantera.Quantity.set_equivalence_ratio" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_equivalence_ratio</code><a class="headerlink" href="#cantera.Quantity.set_equivalence_ratio" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the composition to a mixture of <em>fuel</em> and <em>oxidizer</em> at the
 specified equivalence ratio <em>phi</em>, holding temperature and pressure
 constant. Considers the oxidation of C to CO2, H to H2O and S to SO2.
 Other elements are assumed not to participate in oxidation (i.e. N ends up as
 N2):</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">0.5</span><span class="p">,</span> <span class="s1">&#39;CH4&#39;</span><span class="p">,</span> <span class="s1">&#39;O2:1.0, N2:3.76&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">0.5</span><span class="p">,</span> <span class="s1">'CH4'</span><span class="p">,</span> <span class="s1">'O2:1.0, N2:3.76'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">mole_fraction_dict</span><span class="p">()</span>
-<span class="go">{&#39;CH4&#39;: 0.049900199, &#39;N2&#39;: 0.750499001, &#39;O2&#39;: 0.199600798}</span>
+<span class="go">{'CH4': 0.049900199, 'N2': 0.750499001, 'O2': 0.199600798}</span>
 
-<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">1.2</span><span class="p">,</span> <span class="p">{</span><span class="s1">&#39;NH3;:0.8, &#39;</span><span class="n">CO</span><span class="s1">&#39;:0.2}, &#39;</span><span class="n">O2</span><span class="p">:</span><span class="mf">1.0</span><span class="s1">&#39;)</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">1.2</span><span class="p">,</span> <span class="p">{</span><span class="s1">'NH3;:0.8, '</span><span class="n">CO</span><span class="s1">':0.2}, '</span><span class="n">O2</span><span class="p">:</span><span class="mf">1.0</span><span class="s1">')</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">mole_fraction_dict</span><span class="p">()</span>
-<span class="go">{&#39;CO&#39;: 0.1263157894, &#39;NH3&#39;: 0.505263157, &#39;O2&#39;: 0.36842105}</span>
+<span class="go">{'CO': 0.1263157894, 'NH3': 0.505263157, 'O2': 0.36842105}</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>phi</strong> – Equivalence ratio</li>
-<li><strong>fuel</strong> – Fuel species name or molar composition as string, array, or dict.</li>
-<li><strong>oxidizer</strong> – Oxidizer species name or molar composition as a string, array, or
+<li><strong>phi</strong> &#8211; Equivalence ratio</li>
+<li><strong>fuel</strong> &#8211; Fuel species name or molar composition as string, array, or dict.</li>
+<li><strong>oxidizer</strong> &#8211; Oxidizer species name or molar composition as a string, array, or
 dict.</li>
 </ul>
 </td>
@@ -1357,7 +1353,7 @@ dict.</li>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.set_multiplier">
-<code class="descname">set_multiplier</code><a class="headerlink" href="#cantera.Quantity.set_multiplier" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_multiplier</code><a class="headerlink" href="#cantera.Quantity.set_multiplier" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the multiplier for for reaction <em>i_reaction</em> to <em>value</em>.
 If <em>i_reaction</em> is not specified, then the multiplier for all reactions
 is set to <em>value</em>. See <a class="reference internal" href="#cantera.Quantity.multiplier" title="cantera.Quantity.multiplier"><code class="xref py py-obj docutils literal notranslate"><span class="pre">multiplier</span></code></a>.</p>
@@ -1365,7 +1361,7 @@ is set to <em>value</em>. See <a class="reference internal" href="#cantera.Quant
 
 <dl class="attribute">
 <dt id="cantera.Quantity.set_unnormalized_mass_fractions">
-<code class="descname">set_unnormalized_mass_fractions</code><a class="headerlink" href="#cantera.Quantity.set_unnormalized_mass_fractions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_unnormalized_mass_fractions</code><a class="headerlink" href="#cantera.Quantity.set_unnormalized_mass_fractions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mass fractions without normalizing to force sum(Y) == 1.0.
 Useful primarily when calculating derivatives with respect to Y[k] by
 finite difference.</p>
@@ -1373,7 +1369,7 @@ finite difference.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.set_unnormalized_mole_fractions">
-<code class="descname">set_unnormalized_mole_fractions</code><a class="headerlink" href="#cantera.Quantity.set_unnormalized_mole_fractions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_unnormalized_mole_fractions</code><a class="headerlink" href="#cantera.Quantity.set_unnormalized_mole_fractions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mole fractions without normalizing to force sum(X) == 1.0.
 Useful primarily when calculating derivatives with respect to X[k]
 by finite difference.</p>
@@ -1381,7 +1377,7 @@ by finite difference.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.species">
-<code class="descname">species</code><a class="headerlink" href="#cantera.Quantity.species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species</code><a class="headerlink" href="#cantera.Quantity.species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the <a class="reference internal" href="thermo.html#cantera.Species" title="cantera.Species"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Species</span></code></a> object for species <em>k</em>, where <em>k</em> is either the
 species index or the species name. If <em>k</em> is not specified, a list of
 all species objects is returned. Changes to this object do not affect
@@ -1391,7 +1387,7 @@ function is called.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.species_index">
-<code class="descname">species_index</code><a class="headerlink" href="#cantera.Quantity.species_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_index</code><a class="headerlink" href="#cantera.Quantity.species_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of species <em>species</em>, which may be specified as a string or
 an integer. In the latter case, the index is checked for validity and
 returned. If no such species is present, an exception is thrown.</p>
@@ -1399,79 +1395,79 @@ returned. If no such species is present, an exception is thrown.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.species_name">
-<code class="descname">species_name</code><a class="headerlink" href="#cantera.Quantity.species_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_name</code><a class="headerlink" href="#cantera.Quantity.species_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Name of the species with index <em>k</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.species_names">
-<code class="descname">species_names</code><a class="headerlink" href="#cantera.Quantity.species_names" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_names</code><a class="headerlink" href="#cantera.Quantity.species_names" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A list of all the species names.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.species_viscosities">
-<code class="descname">species_viscosities</code><a class="headerlink" href="#cantera.Quantity.species_viscosities" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_viscosities</code><a class="headerlink" href="#cantera.Quantity.species_viscosities" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Pure species viscosities [Pa-s]</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.standard_cp_R">
-<code class="descname">standard_cp_R</code><a class="headerlink" href="#cantera.Quantity.standard_cp_R" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_cp_R</code><a class="headerlink" href="#cantera.Quantity.standard_cp_R" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state specific heat capacities
 at constant pressure at the current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.standard_enthalpies_RT">
-<code class="descname">standard_enthalpies_RT</code><a class="headerlink" href="#cantera.Quantity.standard_enthalpies_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_enthalpies_RT</code><a class="headerlink" href="#cantera.Quantity.standard_enthalpies_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state enthalpies at the
 current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.standard_entropies_R">
-<code class="descname">standard_entropies_R</code><a class="headerlink" href="#cantera.Quantity.standard_entropies_R" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_entropies_R</code><a class="headerlink" href="#cantera.Quantity.standard_entropies_R" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state entropies at the
 current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.standard_gibbs_RT">
-<code class="descname">standard_gibbs_RT</code><a class="headerlink" href="#cantera.Quantity.standard_gibbs_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_gibbs_RT</code><a class="headerlink" href="#cantera.Quantity.standard_gibbs_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state Gibbs free energies at
 the current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.standard_int_energies_RT">
-<code class="descname">standard_int_energies_RT</code><a class="headerlink" href="#cantera.Quantity.standard_int_energies_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_int_energies_RT</code><a class="headerlink" href="#cantera.Quantity.standard_int_energies_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state internal energies at the
 current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.thermal_conductivity">
-<code class="descname">thermal_conductivity</code><a class="headerlink" href="#cantera.Quantity.thermal_conductivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_conductivity</code><a class="headerlink" href="#cantera.Quantity.thermal_conductivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Thermal conductivity. [W/m/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.thermal_diff_coeffs">
-<code class="descname">thermal_diff_coeffs</code><a class="headerlink" href="#cantera.Quantity.thermal_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_diff_coeffs</code><a class="headerlink" href="#cantera.Quantity.thermal_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return a one-dimensional array of the species thermal diffusion
 coefficients [kg/m/s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.thermal_expansion_coeff">
-<code class="descname">thermal_expansion_coeff</code><a class="headerlink" href="#cantera.Quantity.thermal_expansion_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_expansion_coeff</code><a class="headerlink" href="#cantera.Quantity.thermal_expansion_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Thermal expansion coefficient [1/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.transport_model">
-<code class="descname">transport_model</code><a class="headerlink" href="#cantera.Quantity.transport_model" title="Permalink to this definition">¶</a></dt>
+<code class="descname">transport_model</code><a class="headerlink" href="#cantera.Quantity.transport_model" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the transport model associated with this transport model.</p>
 <p>Setting a new transport model deletes the underlying C++ Transport
 object and replaces it with a new one implementing the specified model.</p>
@@ -1479,37 +1475,37 @@ object and replaces it with a new one implementing the specified model.</p>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.u">
-<code class="descname">u</code><a class="headerlink" href="#cantera.Quantity.u" title="Permalink to this definition">¶</a></dt>
+<code class="descname">u</code><a class="headerlink" href="#cantera.Quantity.u" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Internal energy in [J/kg or J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.v">
-<code class="descname">v</code><a class="headerlink" href="#cantera.Quantity.v" title="Permalink to this definition">¶</a></dt>
+<code class="descname">v</code><a class="headerlink" href="#cantera.Quantity.v" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific volume [m^3/kg or m^3/kmol] depending on <a class="reference internal" href="#cantera.Quantity.basis" title="cantera.Quantity.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.viscosity">
-<code class="descname">viscosity</code><a class="headerlink" href="#cantera.Quantity.viscosity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">viscosity</code><a class="headerlink" href="#cantera.Quantity.viscosity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Viscosity [Pa-s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.volume">
-<code class="descname">volume</code><a class="headerlink" href="#cantera.Quantity.volume" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume</code><a class="headerlink" href="#cantera.Quantity.volume" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total volume [m^3] represented by the <a class="reference internal" href="#cantera.Quantity" title="cantera.Quantity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Quantity</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.volume_mass">
-<code class="descname">volume_mass</code><a class="headerlink" href="#cantera.Quantity.volume_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume_mass</code><a class="headerlink" href="#cantera.Quantity.volume_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific volume [m^3/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Quantity.volume_mole">
-<code class="descname">volume_mole</code><a class="headerlink" href="#cantera.Quantity.volume_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume_mole</code><a class="headerlink" href="#cantera.Quantity.volume_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar volume [m^3/kmol].</p>
 </dd></dl>
 
@@ -1517,10 +1513,10 @@ object and replaces it with a new one implementing the specified model.</p>
 
 </div>
 <div class="section" id="representing-multiple-states">
-<h2><a class="toc-backref" href="#id4">Representing Multiple States</a><a class="headerlink" href="#representing-multiple-states" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id4">Representing Multiple States</a><a class="headerlink" href="#representing-multiple-states" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.SolutionArray">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">SolutionArray</code><span class="sig-paren">(</span><em>phase</em>, <em>shape=(0</em>, <em>)</em>, <em>states=None</em>, <em>extra=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">SolutionArray</code><span class="sig-paren">(</span><em>phase</em>, <em>shape=(0</em>, <em>)</em>, <em>states=None</em>, <em>extra=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>A class providing a convenient interface for representing many thermodynamic
 states using the same <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object and computing properties for that
@@ -1528,16 +1524,16 @@ array of states.</p>
 <p>SolutionArray can represent both 1D and multi-dimensional arrays of states,
 with shapes described in the same way as Numpy arrays. All of the states
 can be set in a single call.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;gri30.cti&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">'gri30.cti'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">states</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">SolutionArray</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span> <span class="p">(</span><span class="mi">6</span><span class="p">,</span> <span class="mi">10</span><span class="p">))</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">T</span> <span class="o">=</span> <span class="n">np</span><span class="o">.</span><span class="n">linspace</span><span class="p">(</span><span class="mi">300</span><span class="p">,</span> <span class="mi">1000</span><span class="p">,</span> <span class="mi">10</span><span class="p">)</span> <span class="c1"># row vector</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">P</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">one_atm</span> <span class="o">*</span> <span class="n">np</span><span class="o">.</span><span class="n">linspace</span><span class="p">(</span><span class="mf">0.1</span><span class="p">,</span> <span class="mf">5.0</span><span class="p">,</span> <span class="mi">6</span><span class="p">)[:,</span><span class="n">np</span><span class="o">.</span><span class="n">newaxis</span><span class="p">]</span> <span class="c1"># column vector</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">X</span> <span class="o">=</span> <span class="s1">&#39;CH4:1.0, O2:1.0, N2:3.76&#39;</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">X</span> <span class="o">=</span> <span class="s1">'CH4:1.0, O2:1.0, N2:3.76'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="o">.</span><span class="n">TPX</span> <span class="o">=</span> <span class="n">T</span><span class="p">,</span> <span class="n">P</span><span class="p">,</span> <span class="n">X</span>
 </pre></div>
 </div>
 <p>Similar to Numpy arrays, input with fewer non-singleton dimensions than the
-SolutionArray is ‘broadcast’ to generate input of the appropriate shape. In
+SolutionArray is &#8216;broadcast&#8217; to generate input of the appropriate shape. In
 the above example, the single value for the mole fraction input is applied
 to each input, while each row has a constant temperature and each column has
 a constant pressure.</p>
@@ -1556,13 +1552,13 @@ scalar output (e.g. per-species or per-reaction properties):</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">states</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">SolutionArray</span><span class="p">(</span><span class="n">gas</span><span class="p">)</span> <span class="c1"># creates an empty SolutionArray</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="k">for</span> <span class="n">phi</span> <span class="ow">in</span> <span class="n">np</span><span class="o">.</span><span class="n">linspace</span><span class="p">(</span><span class="mf">0.5</span><span class="p">,</span> <span class="mf">2.0</span><span class="p">,</span> <span class="mi">20</span><span class="p">):</span>
 <span class="gp">... </span>    <span class="n">states</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">T</span><span class="o">=</span><span class="mi">300</span><span class="p">,</span> <span class="n">P</span><span class="o">=</span><span class="n">ct</span><span class="o">.</span><span class="n">one_atm</span><span class="p">,</span>
-<span class="gp">... </span>                  <span class="n">X</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;CH4&#39;</span><span class="p">:</span> <span class="n">phi</span><span class="p">,</span> <span class="s1">&#39;O2&#39;</span><span class="p">:</span> <span class="mi">2</span><span class="p">,</span> <span class="s1">&#39;N2&#39;</span><span class="p">:</span> <span class="mi">2</span><span class="o">*</span><span class="mf">3.76</span><span class="p">})</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="c1"># &#39;states&#39; now contains 20 elements</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="o">.</span><span class="n">equilibrate</span><span class="p">(</span><span class="s1">&#39;HP&#39;</span><span class="p">)</span>
+<span class="gp">... </span>                  <span class="n">X</span><span class="o">=</span><span class="p">{</span><span class="s1">'CH4'</span><span class="p">:</span> <span class="n">phi</span><span class="p">,</span> <span class="s1">'O2'</span><span class="p">:</span> <span class="mi">2</span><span class="p">,</span> <span class="s1">'N2'</span><span class="p">:</span> <span class="mi">2</span><span class="o">*</span><span class="mf">3.76</span><span class="p">})</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="c1"># 'states' now contains 20 elements</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="o">.</span><span class="n">equilibrate</span><span class="p">(</span><span class="s1">'HP'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="o">.</span><span class="n">T</span> <span class="c1"># -&gt; adiabatic flame temperature at various equivalence ratios</span>
 </pre></div>
 </div>
-<p>SolutionArray objects can also be ‘sliced’ like Numpy arrays, which can be
+<p>SolutionArray objects can also be &#8216;sliced&#8217; like Numpy arrays, which can be
 used both for accessing and setting properties:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">states</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">SolutionArray</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span> <span class="p">(</span><span class="mi">6</span><span class="p">,</span> <span class="mi">10</span><span class="p">))</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="p">[</span><span class="mi">0</span><span class="p">]</span><span class="o">.</span><span class="n">TP</span> <span class="o">=</span> <span class="mi">400</span><span class="p">,</span> <span class="kc">None</span> <span class="c1"># set the temperature of the first row to 400 K</span>
@@ -1580,35 +1576,35 @@ SolutionArray object, e.g.:</p>
 </div>
 <p>Information about a subset of species may also be accessed, using
 parentheses to specify the species:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="p">(</span><span class="s1">&#39;CH4&#39;</span><span class="p">)</span><span class="o">.</span><span class="n">Y</span> <span class="c1"># -&gt; mass fraction of CH4 in each state</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="p">(</span><span class="s1">&#39;H2&#39;</span><span class="p">,</span><span class="s1">&#39;O2&#39;</span><span class="p">)</span><span class="o">.</span><span class="n">partial_molar_cp</span> <span class="c1"># -&gt; cp for H2 and O2</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="p">(</span><span class="s1">'CH4'</span><span class="p">)</span><span class="o">.</span><span class="n">Y</span> <span class="c1"># -&gt; mass fraction of CH4 in each state</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="p">(</span><span class="s1">'H2'</span><span class="p">,</span><span class="s1">'O2'</span><span class="p">)</span><span class="o">.</span><span class="n">partial_molar_cp</span> <span class="c1"># -&gt; cp for H2 and O2</span>
 </pre></div>
 </div>
 <p>Properties and functions which are not dependent on the thermodynamic state
 act as pass-throughs to the underlying <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object, and are not
 converted to arrays:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="o">.</span><span class="n">element_names</span>
-<span class="go">[&#39;O&#39;, &#39;H&#39;, &#39;C&#39;, &#39;N&#39;, &#39;Ar&#39;]</span>
+<span class="go">['O', 'H', 'C', 'N', 'Ar']</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">reaction_equation</span><span class="p">(</span><span class="mi">10</span><span class="p">)</span>
-<span class="go">&#39;CH4 + O &lt;=&gt; CH3 + OH&#39;</span>
+<span class="go">'CH4 + O &lt;=&gt; CH3 + OH'</span>
 </pre></div>
 </div>
 <p>Data represnted by a SolutionArray can be extracted and saved to a CSV file
 using the <a class="reference internal" href="#cantera.SolutionArray.write_csv" title="cantera.SolutionArray.write_csv"><code class="xref py py-obj docutils literal notranslate"><span class="pre">write_csv</span></code></a> method:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="o">.</span><span class="n">write_csv</span><span class="p">(</span><span class="s1">&#39;somefile.csv&#39;</span><span class="p">,</span> <span class="n">cols</span><span class="o">=</span><span class="p">(</span><span class="s1">&#39;T&#39;</span><span class="p">,</span><span class="s1">&#39;P&#39;</span><span class="p">,</span><span class="s1">&#39;X&#39;</span><span class="p">,</span><span class="s1">&#39;net_rates_of_progress&#39;</span><span class="p">))</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">states</span><span class="o">.</span><span class="n">write_csv</span><span class="p">(</span><span class="s1">'somefile.csv'</span><span class="p">,</span> <span class="n">cols</span><span class="o">=</span><span class="p">(</span><span class="s1">'T'</span><span class="p">,</span><span class="s1">'P'</span><span class="p">,</span><span class="s1">'X'</span><span class="p">,</span><span class="s1">'net_rates_of_progress'</span><span class="p">))</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>phase</strong> – The <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object used to compute the thermodynamic,
+<li><strong>phase</strong> &#8211; The <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object used to compute the thermodynamic,
 kinetic, and transport properties</li>
-<li><strong>shape</strong> – A tuple or integer indicating the dimensions of the
+<li><strong>shape</strong> &#8211; A tuple or integer indicating the dimensions of the
 SolutionArray. If the shape is 1D, the array may be extended using the
 <a class="reference internal" href="#cantera.SolutionArray.append" title="cantera.SolutionArray.append"><code class="xref py py-obj docutils literal notranslate"><span class="pre">append</span></code></a> method. Otherwise, the shape is fixed.</li>
-<li><strong>states</strong> – The initial array of states. Used internally to provide
+<li><strong>states</strong> &#8211; The initial array of states. Used internally to provide
 slicing support.</li>
 </ul>
 </td>
@@ -1617,236 +1613,236 @@ slicing support.</li>
 </table>
 <dl class="attribute">
 <dt id="cantera.SolutionArray.DP">
-<code class="descname">DP</code><a class="headerlink" href="#cantera.SolutionArray.DP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">DP</code><a class="headerlink" href="#cantera.SolutionArray.DP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set density [kg/m^3] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.DPX">
-<code class="descname">DPX</code><a class="headerlink" href="#cantera.SolutionArray.DPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">DPX</code><a class="headerlink" href="#cantera.SolutionArray.DPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set density [kg/m^3], pressure [Pa], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.DPY">
-<code class="descname">DPY</code><a class="headerlink" href="#cantera.SolutionArray.DPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">DPY</code><a class="headerlink" href="#cantera.SolutionArray.DPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set density [kg/m^3], pressure [Pa], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.HP">
-<code class="descname">HP</code><a class="headerlink" href="#cantera.SolutionArray.HP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">HP</code><a class="headerlink" href="#cantera.SolutionArray.HP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set enthalpy [J/kg or J/kmol] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.HPX">
-<code class="descname">HPX</code><a class="headerlink" href="#cantera.SolutionArray.HPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">HPX</code><a class="headerlink" href="#cantera.SolutionArray.HPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set enthalpy [J/kg or J/kmol], pressure [Pa] and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.HPY">
-<code class="descname">HPY</code><a class="headerlink" href="#cantera.SolutionArray.HPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">HPY</code><a class="headerlink" href="#cantera.SolutionArray.HPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set enthalpy [J/kg or J/kmol], pressure [Pa] and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.ID">
-<code class="descname">ID</code><a class="headerlink" href="#cantera.SolutionArray.ID" title="Permalink to this definition">¶</a></dt>
+<code class="descname">ID</code><a class="headerlink" href="#cantera.SolutionArray.ID" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The ID of the phase. The default is taken from the CTI/XML input file.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.P">
-<code class="descname">P</code><a class="headerlink" href="#cantera.SolutionArray.P" title="Permalink to this definition">¶</a></dt>
+<code class="descname">P</code><a class="headerlink" href="#cantera.SolutionArray.P" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.PV">
-<code class="descname">PV</code><a class="headerlink" href="#cantera.SolutionArray.PV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">PV</code><a class="headerlink" href="#cantera.SolutionArray.PV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the pressure [Pa] and specific volume [m^3/kg] of
 a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.PX">
-<code class="descname">PX</code><a class="headerlink" href="#cantera.SolutionArray.PX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">PX</code><a class="headerlink" href="#cantera.SolutionArray.PX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the pressure [Pa] and vapor fraction of a two-phase state.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.P_sat">
-<code class="descname">P_sat</code><a class="headerlink" href="#cantera.SolutionArray.P_sat" title="Permalink to this definition">¶</a></dt>
+<code class="descname">P_sat</code><a class="headerlink" href="#cantera.SolutionArray.P_sat" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Saturation pressure [Pa] at the current temperature.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.SH">
-<code class="descname">SH</code><a class="headerlink" href="#cantera.SolutionArray.SH" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SH</code><a class="headerlink" href="#cantera.SolutionArray.SH" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the specific entropy [J/kg/K] and the specific
 enthalpy [J/kg] of a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.SP">
-<code class="descname">SP</code><a class="headerlink" href="#cantera.SolutionArray.SP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SP</code><a class="headerlink" href="#cantera.SolutionArray.SP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.SPX">
-<code class="descname">SPX</code><a class="headerlink" href="#cantera.SolutionArray.SPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SPX</code><a class="headerlink" href="#cantera.SolutionArray.SPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], pressure [Pa], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.SPY">
-<code class="descname">SPY</code><a class="headerlink" href="#cantera.SolutionArray.SPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SPY</code><a class="headerlink" href="#cantera.SolutionArray.SPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], pressure [Pa], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.ST">
-<code class="descname">ST</code><a class="headerlink" href="#cantera.SolutionArray.ST" title="Permalink to this definition">¶</a></dt>
+<code class="descname">ST</code><a class="headerlink" href="#cantera.SolutionArray.ST" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the entropy [J/kg/K] and temperature [K] of a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.SV">
-<code class="descname">SV</code><a class="headerlink" href="#cantera.SolutionArray.SV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SV</code><a class="headerlink" href="#cantera.SolutionArray.SV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K] and specific volume [m^3/kg or
 m^3/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.SVX">
-<code class="descname">SVX</code><a class="headerlink" href="#cantera.SolutionArray.SVX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SVX</code><a class="headerlink" href="#cantera.SolutionArray.SVX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
 m^3/kmol], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.SVY">
-<code class="descname">SVY</code><a class="headerlink" href="#cantera.SolutionArray.SVY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SVY</code><a class="headerlink" href="#cantera.SolutionArray.SVY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
 m^3/kmol], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.T">
-<code class="descname">T</code><a class="headerlink" href="#cantera.SolutionArray.T" title="Permalink to this definition">¶</a></dt>
+<code class="descname">T</code><a class="headerlink" href="#cantera.SolutionArray.T" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Temperature [K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.TD">
-<code class="descname">TD</code><a class="headerlink" href="#cantera.SolutionArray.TD" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TD</code><a class="headerlink" href="#cantera.SolutionArray.TD" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K] and density [kg/m^3 or kmol/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.TDX">
-<code class="descname">TDX</code><a class="headerlink" href="#cantera.SolutionArray.TDX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TDX</code><a class="headerlink" href="#cantera.SolutionArray.TDX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K], density [kg/m^3 or kmol/m^3], and mole
 fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.TDY">
-<code class="descname">TDY</code><a class="headerlink" href="#cantera.SolutionArray.TDY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TDY</code><a class="headerlink" href="#cantera.SolutionArray.TDY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K] and density [kg/m^3 or kmol/m^3], and mass
 fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.TH">
-<code class="descname">TH</code><a class="headerlink" href="#cantera.SolutionArray.TH" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TH</code><a class="headerlink" href="#cantera.SolutionArray.TH" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the temperature [K] and the specific enthalpy [J/kg]
 of a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.TP">
-<code class="descname">TP</code><a class="headerlink" href="#cantera.SolutionArray.TP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TP</code><a class="headerlink" href="#cantera.SolutionArray.TP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.TPX">
-<code class="descname">TPX</code><a class="headerlink" href="#cantera.SolutionArray.TPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TPX</code><a class="headerlink" href="#cantera.SolutionArray.TPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K], pressure [Pa], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.TPY">
-<code class="descname">TPY</code><a class="headerlink" href="#cantera.SolutionArray.TPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TPY</code><a class="headerlink" href="#cantera.SolutionArray.TPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K], pressure [Pa], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.TV">
-<code class="descname">TV</code><a class="headerlink" href="#cantera.SolutionArray.TV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TV</code><a class="headerlink" href="#cantera.SolutionArray.TV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the temperature [K] and specific volume [m^3/kg] of
 a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.TX">
-<code class="descname">TX</code><a class="headerlink" href="#cantera.SolutionArray.TX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TX</code><a class="headerlink" href="#cantera.SolutionArray.TX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the temperature [K] and vapor fraction of a two-phase state.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.T_sat">
-<code class="descname">T_sat</code><a class="headerlink" href="#cantera.SolutionArray.T_sat" title="Permalink to this definition">¶</a></dt>
+<code class="descname">T_sat</code><a class="headerlink" href="#cantera.SolutionArray.T_sat" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Saturation temperature [K] at the current pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.UP">
-<code class="descname">UP</code><a class="headerlink" href="#cantera.SolutionArray.UP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UP</code><a class="headerlink" href="#cantera.SolutionArray.UP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the specific internal energy [J/kg] and the
 pressure [Pa] of a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.UV">
-<code class="descname">UV</code><a class="headerlink" href="#cantera.SolutionArray.UV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UV</code><a class="headerlink" href="#cantera.SolutionArray.UV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set internal energy [J/kg or J/kmol] and specific volume
 [m^3/kg or m^3/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.UVX">
-<code class="descname">UVX</code><a class="headerlink" href="#cantera.SolutionArray.UVX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UVX</code><a class="headerlink" href="#cantera.SolutionArray.UVX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set internal energy [J/kg or J/kmol], specific volume
 [m^3/kg or m^3/kmol], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.UVY">
-<code class="descname">UVY</code><a class="headerlink" href="#cantera.SolutionArray.UVY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UVY</code><a class="headerlink" href="#cantera.SolutionArray.UVY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set internal energy [J/kg or J/kmol], specific volume
 [m^3/kg or m^3/kmol], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.VH">
-<code class="descname">VH</code><a class="headerlink" href="#cantera.SolutionArray.VH" title="Permalink to this definition">¶</a></dt>
+<code class="descname">VH</code><a class="headerlink" href="#cantera.SolutionArray.VH" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the specfic volume [m^3/kg] and the specific
 enthalpy [J/kg] of a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.X">
-<code class="descname">X</code><a class="headerlink" href="#cantera.SolutionArray.X" title="Permalink to this definition">¶</a></dt>
+<code class="descname">X</code><a class="headerlink" href="#cantera.SolutionArray.X" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species mole fractions. Can be set as an array, as a dictionary,
 or as a string. Always returns an array:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">[</span><span class="mf">0.1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.4</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">]</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;H2&#39;</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">&#39;O2&#39;</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">&#39;AR&#39;</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">&#39;H2:0.1, O2:0.4, AR:0.5&#39;</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">{</span><span class="s1">'H2'</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">'O2'</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">'AR'</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">'H2:0.1, O2:0.4, AR:0.5'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span>
 <span class="go">array([0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5])</span>
 </pre></div>
@@ -1855,12 +1851,12 @@ or as a string. Always returns an array:</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.Y">
-<code class="descname">Y</code><a class="headerlink" href="#cantera.SolutionArray.Y" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Y</code><a class="headerlink" href="#cantera.SolutionArray.Y" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species mass fractions. Can be set as an array, as a dictionary,
 or as a string. Always returns an array:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">[</span><span class="mf">0.1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.4</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">]</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;H2&#39;</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">&#39;O2&#39;</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">&#39;AR&#39;</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="s1">&#39;H2:0.1, O2:0.4, AR:0.5&#39;</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">{</span><span class="s1">'H2'</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">'O2'</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">'AR'</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="s1">'H2:0.1, O2:0.4, AR:0.5'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span>
 <span class="go">array([0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5])</span>
 </pre></div>
@@ -1869,7 +1865,7 @@ or as a string. Always returns an array:</p>
 
 <dl class="method">
 <dt id="cantera.SolutionArray.append">
-<code class="descname">append</code><span class="sig-paren">(</span><em>state=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.append" title="Permalink to this definition">¶</a></dt>
+<code class="descname">append</code><span class="sig-paren">(</span><em>state=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.append" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Append an element to the array with the specified state. Elements can
 only be appended in cases where the array of states is one-dimensional.</p>
 <p>The state may be specified in one of three ways:</p>
@@ -1882,13 +1878,13 @@ returned by <code class="xref py py-obj docutils literal notranslate"><span clas
 </li>
 <li><p class="first">as a tuple of three elements that corresponds to any of the full-state
 setters of <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a>, e.g. <a class="reference internal" href="#cantera.SolutionArray.TPY" title="cantera.SolutionArray.TPY"><code class="xref py py-obj docutils literal notranslate"><span class="pre">TPY</span></code></a> or <a class="reference internal" href="#cantera.SolutionArray.HPX" title="cantera.SolutionArray.HPX"><code class="xref py py-obj docutils literal notranslate"><span class="pre">HPX</span></code></a>:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">mystates</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">TPX</span><span class="o">=</span><span class="p">(</span><span class="mi">300</span><span class="p">,</span> <span class="mi">101325</span><span class="p">,</span> <span class="s1">&#39;O2:1.0, N2:3.76&#39;</span><span class="p">))</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">mystates</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">TPX</span><span class="o">=</span><span class="p">(</span><span class="mi">300</span><span class="p">,</span> <span class="mi">101325</span><span class="p">,</span> <span class="s1">'O2:1.0, N2:3.76'</span><span class="p">))</span>
 </pre></div>
 </div>
 </li>
 <li><p class="first">as separate keywords for each of the elements corresponding to one of
 the full-state setters:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">mystates</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">T</span><span class="o">=</span><span class="mi">300</span><span class="p">,</span> <span class="n">P</span><span class="o">=</span><span class="mi">101325</span><span class="p">,</span> <span class="n">X</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;O2&#39;</span><span class="p">:</span><span class="mf">1.0</span><span class="p">,</span> <span class="s1">&#39;N2&#39;</span><span class="p">:</span><span class="mf">3.76</span><span class="p">})</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">mystates</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">T</span><span class="o">=</span><span class="mi">300</span><span class="p">,</span> <span class="n">P</span><span class="o">=</span><span class="mi">101325</span><span class="p">,</span> <span class="n">X</span><span class="o">=</span><span class="p">{</span><span class="s1">'O2'</span><span class="p">:</span><span class="mf">1.0</span><span class="p">,</span> <span class="s1">'N2'</span><span class="p">:</span><span class="mf">3.76</span><span class="p">})</span>
 </pre></div>
 </div>
 </li>
@@ -1897,19 +1893,19 @@ the full-state setters:</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.atomic_weight">
-<code class="descname">atomic_weight</code><a class="headerlink" href="#cantera.SolutionArray.atomic_weight" title="Permalink to this definition">¶</a></dt>
+<code class="descname">atomic_weight</code><a class="headerlink" href="#cantera.SolutionArray.atomic_weight" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Atomic weight [kg/kmol] of element <em>m</em></p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.atomic_weights">
-<code class="descname">atomic_weights</code><a class="headerlink" href="#cantera.SolutionArray.atomic_weights" title="Permalink to this definition">¶</a></dt>
+<code class="descname">atomic_weights</code><a class="headerlink" href="#cantera.SolutionArray.atomic_weights" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of atomic weight [kg/kmol] for each element in the mixture.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.basis">
-<code class="descname">basis</code><a class="headerlink" href="#cantera.SolutionArray.basis" title="Permalink to this definition">¶</a></dt>
+<code class="descname">basis</code><a class="headerlink" href="#cantera.SolutionArray.basis" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Determines whether intensive thermodynamic properties are treated on a
 <code class="xref py py-obj docutils literal notranslate"><span class="pre">mass</span></code> (per kg) or <code class="xref py py-obj docutils literal notranslate"><span class="pre">molar</span></code> (per kmol) basis. This affects the values
 returned by the properties <a class="reference internal" href="#cantera.SolutionArray.h" title="cantera.SolutionArray.h"><code class="xref py py-obj docutils literal notranslate"><span class="pre">h</span></code></a>, <a class="reference internal" href="#cantera.SolutionArray.u" title="cantera.SolutionArray.u"><code class="xref py py-obj docutils literal notranslate"><span class="pre">u</span></code></a>, <a class="reference internal" href="#cantera.SolutionArray.s" title="cantera.SolutionArray.s"><code class="xref py py-obj docutils literal notranslate"><span class="pre">s</span></code></a>, <a class="reference internal" href="#cantera.SolutionArray.g" title="cantera.SolutionArray.g"><code class="xref py py-obj docutils literal notranslate"><span class="pre">g</span></code></a>, <a class="reference internal" href="#cantera.SolutionArray.v" title="cantera.SolutionArray.v"><code class="xref py py-obj docutils literal notranslate"><span class="pre">v</span></code></a>, <a class="reference internal" href="#cantera.SolutionArray.density" title="cantera.SolutionArray.density"><code class="xref py py-obj docutils literal notranslate"><span class="pre">density</span></code></a>, <a class="reference internal" href="#cantera.SolutionArray.cv" title="cantera.SolutionArray.cv"><code class="xref py py-obj docutils literal notranslate"><span class="pre">cv</span></code></a>,
@@ -1919,39 +1915,39 @@ such as <a class="reference internal" href="#cantera.SolutionArray.HPX" title="c
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.binary_diff_coeffs">
-<code class="descname">binary_diff_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.binary_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">binary_diff_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.binary_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Binary diffusion coefficients [m^2/s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.chemical_potentials">
-<code class="descname">chemical_potentials</code><a class="headerlink" href="#cantera.SolutionArray.chemical_potentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">chemical_potentials</code><a class="headerlink" href="#cantera.SolutionArray.chemical_potentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species chemical potentials [J/kmol].</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.SolutionArray.collect_data">
-<code class="descname">collect_data</code><span class="sig-paren">(</span><em>cols=('extra'</em>, <em>'T'</em>, <em>'density'</em>, <em>'Y')</em>, <em>threshold=0</em>, <em>species='Y'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.collect_data" title="Permalink to this definition">¶</a></dt>
+<code class="descname">collect_data</code><span class="sig-paren">(</span><em>cols=('extra'</em>, <em>'T'</em>, <em>'density'</em>, <em>'Y')</em>, <em>threshold=0</em>, <em>species='Y'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.collect_data" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Returns the data specified by <em>cols</em> in a single 2D Numpy array, along
 with a list of column labels.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>cols</strong> – A list of any properties of the solution that are scalars
+<li><strong>cols</strong> &#8211; A list of any properties of the solution that are scalars
 or which have a value for each species or reaction. If species names
 are specified, then either the mass or mole fraction of that species
 will be taken, depending on the value of <em>species</em>. <em>cols</em> may also
-include any arrays which were specified as ‘extra’ variables when
-defining the SolutionArray object. The special value ‘extra’ can be
-used to include all ‘extra’ variables.</li>
-<li><strong>threshold</strong> – Relative tolerance for including a particular column.
+include any arrays which were specified as &#8216;extra&#8217; variables when
+defining the SolutionArray object. The special value &#8216;extra&#8217; can be
+used to include all &#8216;extra&#8217; variables.</li>
+<li><strong>threshold</strong> &#8211; Relative tolerance for including a particular column.
 The tolerance is applied by comparing the maximum absolute value for
 a particular column to the maximum absolute value in all columns for
 the same variable (e.g. mass fraction).</li>
-<li><strong>species</strong> – Specifies whether to use mass (‘Y’) or mole (‘X’)
-fractions for individual species specified in ‘cols’</li>
+<li><strong>species</strong> &#8211; Specifies whether to use mass (&#8216;Y&#8217;) or mole (&#8216;X&#8217;)
+fractions for individual species specified in &#8216;cols&#8217;</li>
 </ul>
 </td>
 </tr>
@@ -1961,164 +1957,164 @@ fractions for individual species specified in ‘cols’</li>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.concentrations">
-<code class="descname">concentrations</code><a class="headerlink" href="#cantera.SolutionArray.concentrations" title="Permalink to this definition">¶</a></dt>
+<code class="descname">concentrations</code><a class="headerlink" href="#cantera.SolutionArray.concentrations" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species concentrations [kmol/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.coverages">
-<code class="descname">coverages</code><a class="headerlink" href="#cantera.SolutionArray.coverages" title="Permalink to this definition">¶</a></dt>
+<code class="descname">coverages</code><a class="headerlink" href="#cantera.SolutionArray.coverages" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the fraction of sites covered by each species.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.cp">
-<code class="descname">cp</code><a class="headerlink" href="#cantera.SolutionArray.cp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp</code><a class="headerlink" href="#cantera.SolutionArray.cp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Heat capacity at constant pressure [J/kg/K or J/kmol/K] depending
 on <a class="reference internal" href="#cantera.SolutionArray.basis" title="cantera.SolutionArray.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.cp_mass">
-<code class="descname">cp_mass</code><a class="headerlink" href="#cantera.SolutionArray.cp_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp_mass</code><a class="headerlink" href="#cantera.SolutionArray.cp_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific heat capacity at constant pressure [J/kg/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.cp_mole">
-<code class="descname">cp_mole</code><a class="headerlink" href="#cantera.SolutionArray.cp_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp_mole</code><a class="headerlink" href="#cantera.SolutionArray.cp_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar heat capacity at constant pressure [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.creation_rates">
-<code class="descname">creation_rates</code><a class="headerlink" href="#cantera.SolutionArray.creation_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">creation_rates</code><a class="headerlink" href="#cantera.SolutionArray.creation_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Creation rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.critical_density">
-<code class="descname">critical_density</code><a class="headerlink" href="#cantera.SolutionArray.critical_density" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critical_density</code><a class="headerlink" href="#cantera.SolutionArray.critical_density" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Critical density [kg/m^3 or kmol/m^3] depending on <a class="reference internal" href="#cantera.SolutionArray.basis" title="cantera.SolutionArray.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.critical_pressure">
-<code class="descname">critical_pressure</code><a class="headerlink" href="#cantera.SolutionArray.critical_pressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critical_pressure</code><a class="headerlink" href="#cantera.SolutionArray.critical_pressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Critical pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.critical_temperature">
-<code class="descname">critical_temperature</code><a class="headerlink" href="#cantera.SolutionArray.critical_temperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critical_temperature</code><a class="headerlink" href="#cantera.SolutionArray.critical_temperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Critical temperature [K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.cv">
-<code class="descname">cv</code><a class="headerlink" href="#cantera.SolutionArray.cv" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv</code><a class="headerlink" href="#cantera.SolutionArray.cv" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Heat capacity at constant volume [J/kg/K or J/kmol/K] depending on
 <a class="reference internal" href="#cantera.SolutionArray.basis" title="cantera.SolutionArray.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.cv_mass">
-<code class="descname">cv_mass</code><a class="headerlink" href="#cantera.SolutionArray.cv_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv_mass</code><a class="headerlink" href="#cantera.SolutionArray.cv_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific heat capacity at constant volume [J/kg/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.cv_mole">
-<code class="descname">cv_mole</code><a class="headerlink" href="#cantera.SolutionArray.cv_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv_mole</code><a class="headerlink" href="#cantera.SolutionArray.cv_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar heat capacity at constant volume [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.delta_enthalpy">
-<code class="descname">delta_enthalpy</code><a class="headerlink" href="#cantera.SolutionArray.delta_enthalpy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_enthalpy</code><a class="headerlink" href="#cantera.SolutionArray.delta_enthalpy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in enthalpy for each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.delta_entropy">
-<code class="descname">delta_entropy</code><a class="headerlink" href="#cantera.SolutionArray.delta_entropy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_entropy</code><a class="headerlink" href="#cantera.SolutionArray.delta_entropy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in entropy for each reaction [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.delta_gibbs">
-<code class="descname">delta_gibbs</code><a class="headerlink" href="#cantera.SolutionArray.delta_gibbs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_gibbs</code><a class="headerlink" href="#cantera.SolutionArray.delta_gibbs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in Gibbs free energy for each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.delta_standard_enthalpy">
-<code class="descname">delta_standard_enthalpy</code><a class="headerlink" href="#cantera.SolutionArray.delta_standard_enthalpy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_enthalpy</code><a class="headerlink" href="#cantera.SolutionArray.delta_standard_enthalpy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state enthalpy (independent of composition) for
 each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.delta_standard_entropy">
-<code class="descname">delta_standard_entropy</code><a class="headerlink" href="#cantera.SolutionArray.delta_standard_entropy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_entropy</code><a class="headerlink" href="#cantera.SolutionArray.delta_standard_entropy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state entropy (independent of composition) for
 each reaction [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.delta_standard_gibbs">
-<code class="descname">delta_standard_gibbs</code><a class="headerlink" href="#cantera.SolutionArray.delta_standard_gibbs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_gibbs</code><a class="headerlink" href="#cantera.SolutionArray.delta_standard_gibbs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state Gibbs free energy (independent of composition)
 for each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.density">
-<code class="descname">density</code><a class="headerlink" href="#cantera.SolutionArray.density" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density</code><a class="headerlink" href="#cantera.SolutionArray.density" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Density [kg/m^3 or kmol/m^3] depending on <a class="reference internal" href="#cantera.SolutionArray.basis" title="cantera.SolutionArray.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.density_mass">
-<code class="descname">density_mass</code><a class="headerlink" href="#cantera.SolutionArray.density_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density_mass</code><a class="headerlink" href="#cantera.SolutionArray.density_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>(Mass) density [kg/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.density_mole">
-<code class="descname">density_mole</code><a class="headerlink" href="#cantera.SolutionArray.density_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density_mole</code><a class="headerlink" href="#cantera.SolutionArray.density_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar density [kmol/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.destruction_rates">
-<code class="descname">destruction_rates</code><a class="headerlink" href="#cantera.SolutionArray.destruction_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">destruction_rates</code><a class="headerlink" href="#cantera.SolutionArray.destruction_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Destruction rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.electric_potential">
-<code class="descname">electric_potential</code><a class="headerlink" href="#cantera.SolutionArray.electric_potential" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electric_potential</code><a class="headerlink" href="#cantera.SolutionArray.electric_potential" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the electric potential [V] for this phase.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.electrical_conductivity">
-<code class="descname">electrical_conductivity</code><a class="headerlink" href="#cantera.SolutionArray.electrical_conductivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electrical_conductivity</code><a class="headerlink" href="#cantera.SolutionArray.electrical_conductivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Electrical conductivity. [S/m].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.electrochemical_potentials">
-<code class="descname">electrochemical_potentials</code><a class="headerlink" href="#cantera.SolutionArray.electrochemical_potentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electrochemical_potentials</code><a class="headerlink" href="#cantera.SolutionArray.electrochemical_potentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species electrochemical potentials [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.element_index">
-<code class="descname">element_index</code><a class="headerlink" href="#cantera.SolutionArray.element_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_index</code><a class="headerlink" href="#cantera.SolutionArray.element_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of element <em>element</em>, which may be specified as a string or
 an integer. In the latter case, the index is checked for validity and
 returned. If no such element is present, an exception is thrown.</p>
@@ -2126,65 +2122,65 @@ returned. If no such element is present, an exception is thrown.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.element_name">
-<code class="descname">element_name</code><a class="headerlink" href="#cantera.SolutionArray.element_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_name</code><a class="headerlink" href="#cantera.SolutionArray.element_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Name of the element with index <em>m</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.element_names">
-<code class="descname">element_names</code><a class="headerlink" href="#cantera.SolutionArray.element_names" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_names</code><a class="headerlink" href="#cantera.SolutionArray.element_names" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A list of all the element names.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.SolutionArray.elemental_mass_fraction">
-<code class="descname">elemental_mass_fraction</code><span class="sig-paren">(</span><em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.elemental_mass_fraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elemental_mass_fraction</code><span class="sig-paren">(</span><em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.elemental_mass_fraction" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.SolutionArray.elemental_mole_fraction">
-<code class="descname">elemental_mole_fraction</code><span class="sig-paren">(</span><em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.elemental_mole_fraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elemental_mole_fraction</code><span class="sig-paren">(</span><em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.elemental_mole_fraction" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.enthalpy_mass">
-<code class="descname">enthalpy_mass</code><a class="headerlink" href="#cantera.SolutionArray.enthalpy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy_mass</code><a class="headerlink" href="#cantera.SolutionArray.enthalpy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific enthalpy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.enthalpy_mole">
-<code class="descname">enthalpy_mole</code><a class="headerlink" href="#cantera.SolutionArray.enthalpy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy_mole</code><a class="headerlink" href="#cantera.SolutionArray.enthalpy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar enthalpy [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.entropy_mass">
-<code class="descname">entropy_mass</code><a class="headerlink" href="#cantera.SolutionArray.entropy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropy_mass</code><a class="headerlink" href="#cantera.SolutionArray.entropy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific entropy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.entropy_mole">
-<code class="descname">entropy_mole</code><a class="headerlink" href="#cantera.SolutionArray.entropy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropy_mole</code><a class="headerlink" href="#cantera.SolutionArray.entropy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar entropy [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.SolutionArray.equilibrate">
-<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.equilibrate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.equilibrate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>See <a class="reference internal" href="thermo.html#cantera.ThermoPhase.equilibrate" title="cantera.ThermoPhase.equilibrate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ThermoPhase.equilibrate</span></code></a></p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.equilibrium_constants">
-<code class="descname">equilibrium_constants</code><a class="headerlink" href="#cantera.SolutionArray.equilibrium_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equilibrium_constants</code><a class="headerlink" href="#cantera.SolutionArray.equilibrium_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Equilibrium constants in concentration units for all reactions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.forward_rate_constants">
-<code class="descname">forward_rate_constants</code><a class="headerlink" href="#cantera.SolutionArray.forward_rate_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">forward_rate_constants</code><a class="headerlink" href="#cantera.SolutionArray.forward_rate_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Forward rate constants for all reactions. The computed values include
 all temperature-dependent, pressure-dependent, and third body
 contributions. Units are a combination of kmol, m^3 and s, that depend
@@ -2193,62 +2189,62 @@ on the rate expression for the reaction.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.forward_rates_of_progress">
-<code class="descname">forward_rates_of_progress</code><a class="headerlink" href="#cantera.SolutionArray.forward_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">forward_rates_of_progress</code><a class="headerlink" href="#cantera.SolutionArray.forward_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Forward rates of progress for the reactions. [kmol/m^3/s] for bulk
 phases or [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.g">
-<code class="descname">g</code><a class="headerlink" href="#cantera.SolutionArray.g" title="Permalink to this definition">¶</a></dt>
+<code class="descname">g</code><a class="headerlink" href="#cantera.SolutionArray.g" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Gibbs free energy [J/kg or J/kmol] depending on <a class="reference internal" href="#cantera.SolutionArray.basis" title="cantera.SolutionArray.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.gibbs_mass">
-<code class="descname">gibbs_mass</code><a class="headerlink" href="#cantera.SolutionArray.gibbs_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs_mass</code><a class="headerlink" href="#cantera.SolutionArray.gibbs_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific Gibbs free energy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.gibbs_mole">
-<code class="descname">gibbs_mole</code><a class="headerlink" href="#cantera.SolutionArray.gibbs_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs_mole</code><a class="headerlink" href="#cantera.SolutionArray.gibbs_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar Gibbs free energy [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.h">
-<code class="descname">h</code><a class="headerlink" href="#cantera.SolutionArray.h" title="Permalink to this definition">¶</a></dt>
+<code class="descname">h</code><a class="headerlink" href="#cantera.SolutionArray.h" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Enthalpy [J/kg or J/kmol] depending on <a class="reference internal" href="#cantera.SolutionArray.basis" title="cantera.SolutionArray.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.int_energy_mass">
-<code class="descname">int_energy_mass</code><a class="headerlink" href="#cantera.SolutionArray.int_energy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">int_energy_mass</code><a class="headerlink" href="#cantera.SolutionArray.int_energy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific internal energy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.int_energy_mole">
-<code class="descname">int_energy_mole</code><a class="headerlink" href="#cantera.SolutionArray.int_energy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">int_energy_mole</code><a class="headerlink" href="#cantera.SolutionArray.int_energy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar internal energy [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.is_reversible">
-<code class="descname">is_reversible</code><a class="headerlink" href="#cantera.SolutionArray.is_reversible" title="Permalink to this definition">¶</a></dt>
+<code class="descname">is_reversible</code><a class="headerlink" href="#cantera.SolutionArray.is_reversible" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>True if reaction <code class="xref py py-obj docutils literal notranslate"><span class="pre">i_reaction</span></code> is reversible.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.isothermal_compressibility">
-<code class="descname">isothermal_compressibility</code><a class="headerlink" href="#cantera.SolutionArray.isothermal_compressibility" title="Permalink to this definition">¶</a></dt>
+<code class="descname">isothermal_compressibility</code><a class="headerlink" href="#cantera.SolutionArray.isothermal_compressibility" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Isothermal compressibility [1/Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.kinetics_species_index">
-<code class="descname">kinetics_species_index</code><a class="headerlink" href="#cantera.SolutionArray.kinetics_species_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">kinetics_species_index</code><a class="headerlink" href="#cantera.SolutionArray.kinetics_species_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of species <em>species</em> of phase <em>phase</em> within arrays returned
 by methods of class <a class="reference internal" href="kinetics.html#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a>. If <em>species</em> is a string, the <em>phase</em>
 argument is unused.</p>
@@ -2256,27 +2252,27 @@ argument is unused.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.max_temp">
-<code class="descname">max_temp</code><a class="headerlink" href="#cantera.SolutionArray.max_temp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">max_temp</code><a class="headerlink" href="#cantera.SolutionArray.max_temp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Maximum temperature for which the thermodynamic data for the phase are
 valid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.mean_molecular_weight">
-<code class="descname">mean_molecular_weight</code><a class="headerlink" href="#cantera.SolutionArray.mean_molecular_weight" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mean_molecular_weight</code><a class="headerlink" href="#cantera.SolutionArray.mean_molecular_weight" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The mean molecular weight (molar mass) [kg/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.min_temp">
-<code class="descname">min_temp</code><a class="headerlink" href="#cantera.SolutionArray.min_temp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">min_temp</code><a class="headerlink" href="#cantera.SolutionArray.min_temp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Minimum temperature for which the thermodynamic data for the phase are
 valid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.mix_diff_coeffs">
-<code class="descname">mix_diff_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.mix_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.mix_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 mass-averaged diffusive fluxes (with respect to the mass averaged
 velocity) to gradients in the species mole fractions.</p>
@@ -2284,21 +2280,21 @@ velocity) to gradients in the species mole fractions.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.mix_diff_coeffs_mass">
-<code class="descname">mix_diff_coeffs_mass</code><a class="headerlink" href="#cantera.SolutionArray.mix_diff_coeffs_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs_mass</code><a class="headerlink" href="#cantera.SolutionArray.mix_diff_coeffs_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 diffusive mass fluxes to gradients in the species mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.mix_diff_coeffs_mole">
-<code class="descname">mix_diff_coeffs_mole</code><a class="headerlink" href="#cantera.SolutionArray.mix_diff_coeffs_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs_mole</code><a class="headerlink" href="#cantera.SolutionArray.mix_diff_coeffs_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 molar diffusive fluxes to gradients in the species mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.modify_reaction">
-<code class="descname">modify_reaction</code><a class="headerlink" href="#cantera.SolutionArray.modify_reaction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">modify_reaction</code><a class="headerlink" href="#cantera.SolutionArray.modify_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Modify the <a class="reference internal" href="kinetics.html#cantera.Reaction" title="cantera.Reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reaction</span></code></a> with index <code class="docutils literal notranslate"><span class="pre">irxn</span></code> to have the same rate
 parameters as <code class="docutils literal notranslate"><span class="pre">rxn</span></code>. <code class="docutils literal notranslate"><span class="pre">rxn</span></code> must have the same reactants and products
 and be of the same type (i.e. <a class="reference internal" href="kinetics.html#cantera.ElementaryReaction" title="cantera.ElementaryReaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ElementaryReaction</span></code></a>, <a class="reference internal" href="kinetics.html#cantera.FalloffReaction" title="cantera.FalloffReaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">FalloffReaction</span></code></a>,
@@ -2309,19 +2305,19 @@ the reaction.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.molecular_weights">
-<code class="descname">molecular_weights</code><a class="headerlink" href="#cantera.SolutionArray.molecular_weights" title="Permalink to this definition">¶</a></dt>
+<code class="descname">molecular_weights</code><a class="headerlink" href="#cantera.SolutionArray.molecular_weights" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species molecular weights (molar masses) [kg/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.multi_diff_coeffs">
-<code class="descname">multi_diff_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.multi_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">multi_diff_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.multi_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Multicomponent diffusion coefficients [m^2/s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.multiplier">
-<code class="descname">multiplier</code><a class="headerlink" href="#cantera.SolutionArray.multiplier" title="Permalink to this definition">¶</a></dt>
+<code class="descname">multiplier</code><a class="headerlink" href="#cantera.SolutionArray.multiplier" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A scaling factor applied to the rate coefficient for reaction
 <em>i_reaction</em>. Can be used to carry out sensitivity analysis or to
 selectively disable a particular reaction. See <a class="reference internal" href="#cantera.SolutionArray.set_multiplier" title="cantera.SolutionArray.set_multiplier"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_multiplier</span></code></a>.</p>
@@ -2329,10 +2325,10 @@ selectively disable a particular reaction. See <a class="reference internal" hre
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.n_atoms">
-<code class="descname">n_atoms</code><a class="headerlink" href="#cantera.SolutionArray.n_atoms" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_atoms</code><a class="headerlink" href="#cantera.SolutionArray.n_atoms" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of atoms of element <em>element</em> in species <em>species</em>. The element
 and species may be specified by name or by index.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">n_atoms</span><span class="p">(</span><span class="s1">&#39;CH4&#39;</span><span class="p">,</span><span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">n_atoms</span><span class="p">(</span><span class="s1">'CH4'</span><span class="p">,</span><span class="s1">'H'</span><span class="p">)</span>
 <span class="go">4</span>
 </pre></div>
 </div>
@@ -2340,97 +2336,97 @@ and species may be specified by name or by index.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.n_elements">
-<code class="descname">n_elements</code><a class="headerlink" href="#cantera.SolutionArray.n_elements" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_elements</code><a class="headerlink" href="#cantera.SolutionArray.n_elements" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of elements.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.n_phases">
-<code class="descname">n_phases</code><a class="headerlink" href="#cantera.SolutionArray.n_phases" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_phases</code><a class="headerlink" href="#cantera.SolutionArray.n_phases" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of phases in the reaction mechanism.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.n_reactions">
-<code class="descname">n_reactions</code><a class="headerlink" href="#cantera.SolutionArray.n_reactions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_reactions</code><a class="headerlink" href="#cantera.SolutionArray.n_reactions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of reactions in the reaction mechanism.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.n_species">
-<code class="descname">n_species</code><a class="headerlink" href="#cantera.SolutionArray.n_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_species</code><a class="headerlink" href="#cantera.SolutionArray.n_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of species.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.n_total_species">
-<code class="descname">n_total_species</code><a class="headerlink" href="#cantera.SolutionArray.n_total_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_total_species</code><a class="headerlink" href="#cantera.SolutionArray.n_total_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Total number of species in all phases participating in the kinetics
 mechanism.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.name">
-<code class="descname">name</code><a class="headerlink" href="#cantera.SolutionArray.name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">name</code><a class="headerlink" href="#cantera.SolutionArray.name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The name assigned to this phase. The default is taken from the CTI/XML
 input file.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.net_production_rates">
-<code class="descname">net_production_rates</code><a class="headerlink" href="#cantera.SolutionArray.net_production_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">net_production_rates</code><a class="headerlink" href="#cantera.SolutionArray.net_production_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Net production rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.net_rates_of_progress">
-<code class="descname">net_rates_of_progress</code><a class="headerlink" href="#cantera.SolutionArray.net_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">net_rates_of_progress</code><a class="headerlink" href="#cantera.SolutionArray.net_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Net rates of progress for the reactions. [kmol/m^3/s] for bulk phases
 or [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.partial_molar_cp">
-<code class="descname">partial_molar_cp</code><a class="headerlink" href="#cantera.SolutionArray.partial_molar_cp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_cp</code><a class="headerlink" href="#cantera.SolutionArray.partial_molar_cp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar specific heat capacities at constant
 pressure [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.partial_molar_enthalpies">
-<code class="descname">partial_molar_enthalpies</code><a class="headerlink" href="#cantera.SolutionArray.partial_molar_enthalpies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_enthalpies</code><a class="headerlink" href="#cantera.SolutionArray.partial_molar_enthalpies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar enthalpies [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.partial_molar_entropies">
-<code class="descname">partial_molar_entropies</code><a class="headerlink" href="#cantera.SolutionArray.partial_molar_entropies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_entropies</code><a class="headerlink" href="#cantera.SolutionArray.partial_molar_entropies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar entropies [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.partial_molar_int_energies">
-<code class="descname">partial_molar_int_energies</code><a class="headerlink" href="#cantera.SolutionArray.partial_molar_int_energies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_int_energies</code><a class="headerlink" href="#cantera.SolutionArray.partial_molar_int_energies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar internal energies [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.partial_molar_volumes">
-<code class="descname">partial_molar_volumes</code><a class="headerlink" href="#cantera.SolutionArray.partial_molar_volumes" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_volumes</code><a class="headerlink" href="#cantera.SolutionArray.partial_molar_volumes" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar volumes [m^3/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.product_stoich_coeff">
-<code class="descname">product_stoich_coeff</code><a class="headerlink" href="#cantera.SolutionArray.product_stoich_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">product_stoich_coeff</code><a class="headerlink" href="#cantera.SolutionArray.product_stoich_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The stoichiometric coefficient of species <em>k_spec</em> as a product in
 reaction <em>i_reaction</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.product_stoich_coeffs">
-<code class="descname">product_stoich_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.product_stoich_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">product_stoich_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.product_stoich_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The array of product stoichiometric coefficients. Element <em>[k,i]</em> of
 this array is the product stoichiometric coefficient of species <em>k</em> in
 reaction <em>i</em>.</p>
@@ -2438,20 +2434,20 @@ reaction <em>i</em>.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.products">
-<code class="descname">products</code><a class="headerlink" href="#cantera.SolutionArray.products" title="Permalink to this definition">¶</a></dt>
+<code class="descname">products</code><a class="headerlink" href="#cantera.SolutionArray.products" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The products portion of the reaction equation</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reactant_stoich_coeff">
-<code class="descname">reactant_stoich_coeff</code><a class="headerlink" href="#cantera.SolutionArray.reactant_stoich_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactant_stoich_coeff</code><a class="headerlink" href="#cantera.SolutionArray.reactant_stoich_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The stoichiometric coefficient of species <em>k_spec</em> as a reactant in
 reaction <em>i_reaction</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reactant_stoich_coeffs">
-<code class="descname">reactant_stoich_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.reactant_stoich_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactant_stoich_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.reactant_stoich_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The array of reactant stoichiometric coefficients. Element <em>[k,i]</em> of
 this array is the reactant stoichiometric coefficient of species <em>k</em> in
 reaction <em>i</em>.</p>
@@ -2459,13 +2455,13 @@ reaction <em>i</em>.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reactants">
-<code class="descname">reactants</code><a class="headerlink" href="#cantera.SolutionArray.reactants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactants</code><a class="headerlink" href="#cantera.SolutionArray.reactants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The reactants portion of the reaction equation</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reaction">
-<code class="descname">reaction</code><a class="headerlink" href="#cantera.SolutionArray.reaction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction</code><a class="headerlink" href="#cantera.SolutionArray.reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return a <a class="reference internal" href="kinetics.html#cantera.Reaction" title="cantera.Reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reaction</span></code></a> object representing the reaction with index
 <code class="docutils literal notranslate"><span class="pre">i_reaction</span></code>. Changes to this object do not affect the <a class="reference internal" href="kinetics.html#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> or
 <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object until the <a class="reference internal" href="#cantera.SolutionArray.modify_reaction" title="cantera.SolutionArray.modify_reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">modify_reaction</span></code></a> function is called.</p>
@@ -2473,20 +2469,20 @@ reaction <em>i</em>.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reaction_equation">
-<code class="descname">reaction_equation</code><a class="headerlink" href="#cantera.SolutionArray.reaction_equation" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_equation</code><a class="headerlink" href="#cantera.SolutionArray.reaction_equation" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The equation for the specified reaction. See also <a class="reference internal" href="#cantera.SolutionArray.reaction_equations" title="cantera.SolutionArray.reaction_equations"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reaction_equations</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reaction_equations">
-<code class="descname">reaction_equations</code><a class="headerlink" href="#cantera.SolutionArray.reaction_equations" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_equations</code><a class="headerlink" href="#cantera.SolutionArray.reaction_equations" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Returns a list containing the reaction equation for all reactions in the
 mechanism (if <em>indices</em> is unspecified) or the equations for each
 reaction in the sequence <em>indices</em>. For example:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">reaction_equations</span><span class="p">()</span>
-<span class="go">[&#39;2 O + M &lt;=&gt; O2 + M&#39;, &#39;O + H + M &lt;=&gt; OH + M&#39;, &#39;O + H2 &lt;=&gt; H + OH&#39;, ...]</span>
+<span class="go">['2 O + M &lt;=&gt; O2 + M', 'O + H + M &lt;=&gt; OH + M', 'O + H2 &lt;=&gt; H + OH', ...]</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">reaction_equations</span><span class="p">([</span><span class="mi">2</span><span class="p">,</span><span class="mi">3</span><span class="p">])</span>
-<span class="go">[&#39;O + H + M &lt;=&gt; OH + M&#39;, &#39;O + H2 &lt;=&gt; H + OH&#39;]</span>
+<span class="go">['O + H + M &lt;=&gt; OH + M', 'O + H2 &lt;=&gt; H + OH']</span>
 </pre></div>
 </div>
 <p>See also <a class="reference internal" href="#cantera.SolutionArray.reaction_equation" title="cantera.SolutionArray.reaction_equation"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reaction_equation</span></code></a>.</p>
@@ -2494,19 +2490,19 @@ reaction in the sequence <em>indices</em>. For example:</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reaction_phase_index">
-<code class="descname">reaction_phase_index</code><a class="headerlink" href="#cantera.SolutionArray.reaction_phase_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_phase_index</code><a class="headerlink" href="#cantera.SolutionArray.reaction_phase_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of the phase where the reactions occur.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reaction_type">
-<code class="descname">reaction_type</code><a class="headerlink" href="#cantera.SolutionArray.reaction_type" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_type</code><a class="headerlink" href="#cantera.SolutionArray.reaction_type" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Type of reaction <em>i_reaction</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reactions">
-<code class="descname">reactions</code><a class="headerlink" href="#cantera.SolutionArray.reactions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactions</code><a class="headerlink" href="#cantera.SolutionArray.reactions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return a list of all <a class="reference internal" href="kinetics.html#cantera.Reaction" title="cantera.Reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reaction</span></code></a> objects. Changes to these objects do not
 affect the <a class="reference internal" href="kinetics.html#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> or <a class="reference internal" href="#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object until the <a class="reference internal" href="#cantera.SolutionArray.modify_reaction" title="cantera.SolutionArray.modify_reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">modify_reaction</span></code></a>
 function is called.</p>
@@ -2514,13 +2510,13 @@ function is called.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reference_pressure">
-<code class="descname">reference_pressure</code><a class="headerlink" href="#cantera.SolutionArray.reference_pressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reference_pressure</code><a class="headerlink" href="#cantera.SolutionArray.reference_pressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reference state pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reverse_rate_constants">
-<code class="descname">reverse_rate_constants</code><a class="headerlink" href="#cantera.SolutionArray.reverse_rate_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reverse_rate_constants</code><a class="headerlink" href="#cantera.SolutionArray.reverse_rate_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reverse rate constants for all reactions. The computed values include
 all temperature-dependent, pressure-dependent, and third body
 contributions. Units are a combination of kmol, m^3 and s, that depend
@@ -2529,20 +2525,20 @@ on the rate expression for the reaction.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.reverse_rates_of_progress">
-<code class="descname">reverse_rates_of_progress</code><a class="headerlink" href="#cantera.SolutionArray.reverse_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reverse_rates_of_progress</code><a class="headerlink" href="#cantera.SolutionArray.reverse_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reverse rates of progress for the reactions. [kmol/m^3/s] for bulk
 phases or [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.s">
-<code class="descname">s</code><a class="headerlink" href="#cantera.SolutionArray.s" title="Permalink to this definition">¶</a></dt>
+<code class="descname">s</code><a class="headerlink" href="#cantera.SolutionArray.s" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Entropy [J/kg/K or J/kmol/K] depending on <a class="reference internal" href="#cantera.SolutionArray.basis" title="cantera.SolutionArray.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.set_multiplier">
-<code class="descname">set_multiplier</code><a class="headerlink" href="#cantera.SolutionArray.set_multiplier" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_multiplier</code><a class="headerlink" href="#cantera.SolutionArray.set_multiplier" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the multiplier for for reaction <em>i_reaction</em> to <em>value</em>.
 If <em>i_reaction</em> is not specified, then the multiplier for all reactions
 is set to <em>value</em>. See <a class="reference internal" href="#cantera.SolutionArray.multiplier" title="cantera.SolutionArray.multiplier"><code class="xref py py-obj docutils literal notranslate"><span class="pre">multiplier</span></code></a>.</p>
@@ -2550,14 +2546,14 @@ is set to <em>value</em>. See <a class="reference internal" href="#cantera.Solut
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.site_density">
-<code class="descname">site_density</code><a class="headerlink" href="#cantera.SolutionArray.site_density" title="Permalink to this definition">¶</a></dt>
+<code class="descname">site_density</code><a class="headerlink" href="#cantera.SolutionArray.site_density" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the site density. [kmol/m^2] for surface phases; [kmol/m] for
 edge phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.species">
-<code class="descname">species</code><a class="headerlink" href="#cantera.SolutionArray.species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species</code><a class="headerlink" href="#cantera.SolutionArray.species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the <a class="reference internal" href="thermo.html#cantera.Species" title="cantera.Species"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Species</span></code></a> object for species <em>k</em>, where <em>k</em> is either the
 species index or the species name. If <em>k</em> is not specified, a list of
 all species objects is returned. Changes to this object do not affect
@@ -2567,7 +2563,7 @@ function is called.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.species_index">
-<code class="descname">species_index</code><a class="headerlink" href="#cantera.SolutionArray.species_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_index</code><a class="headerlink" href="#cantera.SolutionArray.species_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of species <em>species</em>, which may be specified as a string or
 an integer. In the latter case, the index is checked for validity and
 returned. If no such species is present, an exception is thrown.</p>
@@ -2575,73 +2571,73 @@ returned. If no such species is present, an exception is thrown.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.species_name">
-<code class="descname">species_name</code><a class="headerlink" href="#cantera.SolutionArray.species_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_name</code><a class="headerlink" href="#cantera.SolutionArray.species_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Name of the species with index <em>k</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.species_names">
-<code class="descname">species_names</code><a class="headerlink" href="#cantera.SolutionArray.species_names" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_names</code><a class="headerlink" href="#cantera.SolutionArray.species_names" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A list of all the species names.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.standard_cp_R">
-<code class="descname">standard_cp_R</code><a class="headerlink" href="#cantera.SolutionArray.standard_cp_R" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_cp_R</code><a class="headerlink" href="#cantera.SolutionArray.standard_cp_R" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state specific heat capacities
 at constant pressure at the current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.standard_enthalpies_RT">
-<code class="descname">standard_enthalpies_RT</code><a class="headerlink" href="#cantera.SolutionArray.standard_enthalpies_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_enthalpies_RT</code><a class="headerlink" href="#cantera.SolutionArray.standard_enthalpies_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state enthalpies at the
 current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.standard_entropies_R">
-<code class="descname">standard_entropies_R</code><a class="headerlink" href="#cantera.SolutionArray.standard_entropies_R" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_entropies_R</code><a class="headerlink" href="#cantera.SolutionArray.standard_entropies_R" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state entropies at the
 current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.standard_gibbs_RT">
-<code class="descname">standard_gibbs_RT</code><a class="headerlink" href="#cantera.SolutionArray.standard_gibbs_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_gibbs_RT</code><a class="headerlink" href="#cantera.SolutionArray.standard_gibbs_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state Gibbs free energies at
 the current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.standard_int_energies_RT">
-<code class="descname">standard_int_energies_RT</code><a class="headerlink" href="#cantera.SolutionArray.standard_int_energies_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_int_energies_RT</code><a class="headerlink" href="#cantera.SolutionArray.standard_int_energies_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state internal energies at the
 current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.thermal_conductivity">
-<code class="descname">thermal_conductivity</code><a class="headerlink" href="#cantera.SolutionArray.thermal_conductivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_conductivity</code><a class="headerlink" href="#cantera.SolutionArray.thermal_conductivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Thermal conductivity. [W/m/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.thermal_diff_coeffs">
-<code class="descname">thermal_diff_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.thermal_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_diff_coeffs</code><a class="headerlink" href="#cantera.SolutionArray.thermal_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return a one-dimensional array of the species thermal diffusion
 coefficients [kg/m/s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.thermal_expansion_coeff">
-<code class="descname">thermal_expansion_coeff</code><a class="headerlink" href="#cantera.SolutionArray.thermal_expansion_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_expansion_coeff</code><a class="headerlink" href="#cantera.SolutionArray.thermal_expansion_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Thermal expansion coefficient [1/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.transport_model">
-<code class="descname">transport_model</code><a class="headerlink" href="#cantera.SolutionArray.transport_model" title="Permalink to this definition">¶</a></dt>
+<code class="descname">transport_model</code><a class="headerlink" href="#cantera.SolutionArray.transport_model" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the transport model associated with this transport model.</p>
 <p>Setting a new transport model deletes the underlying C++ Transport
 object and replaces it with a new one implementing the specified model.</p>
@@ -2649,37 +2645,37 @@ object and replaces it with a new one implementing the specified model.</p>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.u">
-<code class="descname">u</code><a class="headerlink" href="#cantera.SolutionArray.u" title="Permalink to this definition">¶</a></dt>
+<code class="descname">u</code><a class="headerlink" href="#cantera.SolutionArray.u" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Internal energy in [J/kg or J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.v">
-<code class="descname">v</code><a class="headerlink" href="#cantera.SolutionArray.v" title="Permalink to this definition">¶</a></dt>
+<code class="descname">v</code><a class="headerlink" href="#cantera.SolutionArray.v" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific volume [m^3/kg or m^3/kmol] depending on <a class="reference internal" href="#cantera.SolutionArray.basis" title="cantera.SolutionArray.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.viscosity">
-<code class="descname">viscosity</code><a class="headerlink" href="#cantera.SolutionArray.viscosity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">viscosity</code><a class="headerlink" href="#cantera.SolutionArray.viscosity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Viscosity [Pa-s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.volume_mass">
-<code class="descname">volume_mass</code><a class="headerlink" href="#cantera.SolutionArray.volume_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume_mass</code><a class="headerlink" href="#cantera.SolutionArray.volume_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific volume [m^3/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SolutionArray.volume_mole">
-<code class="descname">volume_mole</code><a class="headerlink" href="#cantera.SolutionArray.volume_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume_mole</code><a class="headerlink" href="#cantera.SolutionArray.volume_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar volume [m^3/kmol].</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.SolutionArray.write_csv">
-<code class="descname">write_csv</code><span class="sig-paren">(</span><em>filename</em>, <em>cols=('extra'</em>, <em>'T'</em>, <em>'density'</em>, <em>'Y')</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.write_csv" title="Permalink to this definition">¶</a></dt>
+<code class="descname">write_csv</code><span class="sig-paren">(</span><em>filename</em>, <em>cols=('extra'</em>, <em>'T'</em>, <em>'density'</em>, <em>'Y')</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SolutionArray.write_csv" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Write a CSV file named <em>filename</em> containing the data specified by
 <em>cols</em>. The first row of the CSV file will contain column labels.</p>
 <p>Additional arguments are passed on to <a class="reference internal" href="#cantera.SolutionArray.collect_data" title="cantera.SolutionArray.collect_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">collect_data</span></code></a>. This method works
@@ -2690,16 +2686,16 @@ only with 1D SolutionArray objects.</p>
 
 </div>
 <div class="section" id="utility-functions">
-<h2><a class="toc-backref" href="#id5">Utility Functions</a><a class="headerlink" href="#utility-functions" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id5">Utility Functions</a><a class="headerlink" href="#utility-functions" title="Permalink to this headline">&#182;</a></h2>
 <dl class="function">
 <dt id="cantera.add_directory">
-<code class="descclassname">cantera.</code><code class="descname">add_directory</code><span class="sig-paren">(</span><em>directory</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.add_directory" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">add_directory</code><span class="sig-paren">(</span><em>directory</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.add_directory" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Add a directory to search for Cantera data files.</p>
 </dd></dl>
 
 <dl class="function">
 <dt id="cantera.get_data_directories">
-<code class="descclassname">cantera.</code><code class="descname">get_data_directories</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.get_data_directories" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">cantera.</code><code class="descname">get_data_directories</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.get_data_directories" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get a list of the directories Cantera searches for data files.</p>
 </dd></dl>
 
@@ -2738,25 +2734,24 @@ only with 1D SolutionArray objects.</p>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/cython/importing.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/cython/importing.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -2765,15 +2760,14 @@ only with 1D SolutionArray objects.</p>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/cython/importing.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/cython/importing.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/cython/importing.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/importing.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/cython/index.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/index.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Python Module Documentation | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,7 +77,7 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="python-module-documentation">
-<span id="sec-cython-documentation"></span><h1>Python Module Documentation<a class="headerlink" href="#python-module-documentation" title="Permalink to this headline">¶</a></h1>
+<span id="sec-cython-documentation"></span><h1>Python Module Documentation<a class="headerlink" href="#python-module-documentation" title="Permalink to this headline">&#182;</a></h1>
 <p>Contents:</p>
 <div class="toctree-wrapper compound">
 <ul>
@@ -152,25 +148,24 @@ lang="en">
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/cython/index.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/cython/index.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -179,15 +174,14 @@ lang="en">
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/cython/index.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/cython/index.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/cython/index.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/index.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/cython/kinetics.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/kinetics.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Chemical Kinetics | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,7 +77,7 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="chemical-kinetics">
-<h1>Chemical Kinetics<a class="headerlink" href="#chemical-kinetics" title="Permalink to this headline">¶</a></h1>
+<h1>Chemical Kinetics<a class="headerlink" href="#chemical-kinetics" title="Permalink to this headline">&#182;</a></h1>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#kinetics-managers" id="id1">Kinetics Managers</a><ul>
@@ -114,84 +110,84 @@ lang="en">
 </ul>
 </div>
 <div class="section" id="kinetics-managers">
-<h2><a class="toc-backref" href="#id1">Kinetics Managers</a><a class="headerlink" href="#kinetics-managers" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id1">Kinetics Managers</a><a class="headerlink" href="#kinetics-managers" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="kinetics">
-<h3><a class="toc-backref" href="#id2">Kinetics</a><a class="headerlink" href="#kinetics" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id2">Kinetics</a><a class="headerlink" href="#kinetics" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Kinetics">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Kinetics</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em>, <em>phases=()</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Kinetics</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em>, <em>phases=()</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera._SolutionBase</span></code></p>
 <p>Instances of class <a class="reference internal" href="#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> are responsible for evaluating reaction rates
 of progress, species production rates, and other quantities pertaining to
 a reaction mechanism.</p>
 <dl class="method">
 <dt id="cantera.Kinetics.add_reaction">
-<code class="descname">add_reaction</code><span class="sig-paren">(</span><em>self</em>, <em>Reaction rxn</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.add_reaction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">add_reaction</code><span class="sig-paren">(</span><em>self</em>, <em>Reaction rxn</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.add_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Add a new reaction to this phase.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.creation_rates">
-<code class="descname">creation_rates</code><a class="headerlink" href="#cantera.Kinetics.creation_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">creation_rates</code><a class="headerlink" href="#cantera.Kinetics.creation_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Creation rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.delta_enthalpy">
-<code class="descname">delta_enthalpy</code><a class="headerlink" href="#cantera.Kinetics.delta_enthalpy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_enthalpy</code><a class="headerlink" href="#cantera.Kinetics.delta_enthalpy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in enthalpy for each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.delta_entropy">
-<code class="descname">delta_entropy</code><a class="headerlink" href="#cantera.Kinetics.delta_entropy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_entropy</code><a class="headerlink" href="#cantera.Kinetics.delta_entropy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in entropy for each reaction [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.delta_gibbs">
-<code class="descname">delta_gibbs</code><a class="headerlink" href="#cantera.Kinetics.delta_gibbs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_gibbs</code><a class="headerlink" href="#cantera.Kinetics.delta_gibbs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in Gibbs free energy for each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.delta_standard_enthalpy">
-<code class="descname">delta_standard_enthalpy</code><a class="headerlink" href="#cantera.Kinetics.delta_standard_enthalpy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_enthalpy</code><a class="headerlink" href="#cantera.Kinetics.delta_standard_enthalpy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state enthalpy (independent of composition) for
 each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.delta_standard_entropy">
-<code class="descname">delta_standard_entropy</code><a class="headerlink" href="#cantera.Kinetics.delta_standard_entropy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_entropy</code><a class="headerlink" href="#cantera.Kinetics.delta_standard_entropy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state entropy (independent of composition) for
 each reaction [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.delta_standard_gibbs">
-<code class="descname">delta_standard_gibbs</code><a class="headerlink" href="#cantera.Kinetics.delta_standard_gibbs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_gibbs</code><a class="headerlink" href="#cantera.Kinetics.delta_standard_gibbs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state Gibbs free energy (independent of composition)
 for each reaction [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.destruction_rates">
-<code class="descname">destruction_rates</code><a class="headerlink" href="#cantera.Kinetics.destruction_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">destruction_rates</code><a class="headerlink" href="#cantera.Kinetics.destruction_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Destruction rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.equilibrium_constants">
-<code class="descname">equilibrium_constants</code><a class="headerlink" href="#cantera.Kinetics.equilibrium_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equilibrium_constants</code><a class="headerlink" href="#cantera.Kinetics.equilibrium_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Equilibrium constants in concentration units for all reactions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.forward_rate_constants">
-<code class="descname">forward_rate_constants</code><a class="headerlink" href="#cantera.Kinetics.forward_rate_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">forward_rate_constants</code><a class="headerlink" href="#cantera.Kinetics.forward_rate_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Forward rate constants for all reactions. The computed values include
 all temperature-dependent, pressure-dependent, and third body
 contributions. Units are a combination of kmol, m^3 and s, that depend
@@ -200,20 +196,20 @@ on the rate expression for the reaction.</p>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.forward_rates_of_progress">
-<code class="descname">forward_rates_of_progress</code><a class="headerlink" href="#cantera.Kinetics.forward_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">forward_rates_of_progress</code><a class="headerlink" href="#cantera.Kinetics.forward_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Forward rates of progress for the reactions. [kmol/m^3/s] for bulk
 phases or [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Kinetics.is_reversible">
-<code class="descname">is_reversible</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.is_reversible" title="Permalink to this definition">¶</a></dt>
+<code class="descname">is_reversible</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.is_reversible" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>True if reaction <code class="xref py py-obj docutils literal notranslate"><span class="pre">i_reaction</span></code> is reversible.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Kinetics.kinetics_species_index">
-<code class="descname">kinetics_species_index</code><span class="sig-paren">(</span><em>self</em>, <em>species</em>, <em>int phase=0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.kinetics_species_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">kinetics_species_index</code><span class="sig-paren">(</span><em>self</em>, <em>species</em>, <em>int phase=0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.kinetics_species_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of species <em>species</em> of phase <em>phase</em> within arrays returned
 by methods of class <a class="reference internal" href="#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a>. If <em>species</em> is a string, the <em>phase</em>
 argument is unused.</p>
@@ -221,7 +217,7 @@ argument is unused.</p>
 
 <dl class="method">
 <dt id="cantera.Kinetics.modify_reaction">
-<code class="descname">modify_reaction</code><span class="sig-paren">(</span><em>self</em>, <em>int irxn</em>, <em>Reaction rxn</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.modify_reaction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">modify_reaction</code><span class="sig-paren">(</span><em>self</em>, <em>int irxn</em>, <em>Reaction rxn</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.modify_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Modify the <a class="reference internal" href="#cantera.Reaction" title="cantera.Reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reaction</span></code></a> with index <code class="docutils literal notranslate"><span class="pre">irxn</span></code> to have the same rate
 parameters as <code class="docutils literal notranslate"><span class="pre">rxn</span></code>. <code class="docutils literal notranslate"><span class="pre">rxn</span></code> must have the same reactants and products
 and be of the same type (i.e. <a class="reference internal" href="#cantera.ElementaryReaction" title="cantera.ElementaryReaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ElementaryReaction</span></code></a>, <a class="reference internal" href="#cantera.FalloffReaction" title="cantera.FalloffReaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">FalloffReaction</span></code></a>,
@@ -232,7 +228,7 @@ the reaction.</p>
 
 <dl class="method">
 <dt id="cantera.Kinetics.multiplier">
-<code class="descname">multiplier</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.multiplier" title="Permalink to this definition">¶</a></dt>
+<code class="descname">multiplier</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.multiplier" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A scaling factor applied to the rate coefficient for reaction
 <em>i_reaction</em>. Can be used to carry out sensitivity analysis or to
 selectively disable a particular reaction. See <a class="reference internal" href="#cantera.Kinetics.set_multiplier" title="cantera.Kinetics.set_multiplier"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_multiplier</span></code></a>.</p>
@@ -240,47 +236,47 @@ selectively disable a particular reaction. See <a class="reference internal" hre
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.n_phases">
-<code class="descname">n_phases</code><a class="headerlink" href="#cantera.Kinetics.n_phases" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_phases</code><a class="headerlink" href="#cantera.Kinetics.n_phases" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of phases in the reaction mechanism.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.n_reactions">
-<code class="descname">n_reactions</code><a class="headerlink" href="#cantera.Kinetics.n_reactions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_reactions</code><a class="headerlink" href="#cantera.Kinetics.n_reactions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of reactions in the reaction mechanism.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.n_total_species">
-<code class="descname">n_total_species</code><a class="headerlink" href="#cantera.Kinetics.n_total_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_total_species</code><a class="headerlink" href="#cantera.Kinetics.n_total_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Total number of species in all phases participating in the kinetics
 mechanism.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.net_production_rates">
-<code class="descname">net_production_rates</code><a class="headerlink" href="#cantera.Kinetics.net_production_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">net_production_rates</code><a class="headerlink" href="#cantera.Kinetics.net_production_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Net production rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.net_rates_of_progress">
-<code class="descname">net_rates_of_progress</code><a class="headerlink" href="#cantera.Kinetics.net_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">net_rates_of_progress</code><a class="headerlink" href="#cantera.Kinetics.net_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Net rates of progress for the reactions. [kmol/m^3/s] for bulk phases
 or [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Kinetics.product_stoich_coeff">
-<code class="descname">product_stoich_coeff</code><span class="sig-paren">(</span><em>self</em>, <em>k_spec</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.product_stoich_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">product_stoich_coeff</code><span class="sig-paren">(</span><em>self</em>, <em>k_spec</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.product_stoich_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The stoichiometric coefficient of species <em>k_spec</em> as a product in
 reaction <em>i_reaction</em>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Kinetics.product_stoich_coeffs">
-<code class="descname">product_stoich_coeffs</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.product_stoich_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">product_stoich_coeffs</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.product_stoich_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The array of product stoichiometric coefficients. Element <em>[k,i]</em> of
 this array is the product stoichiometric coefficient of species <em>k</em> in
 reaction <em>i</em>.</p>
@@ -288,20 +284,20 @@ reaction <em>i</em>.</p>
 
 <dl class="method">
 <dt id="cantera.Kinetics.products">
-<code class="descname">products</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.products" title="Permalink to this definition">¶</a></dt>
+<code class="descname">products</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.products" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The products portion of the reaction equation</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Kinetics.reactant_stoich_coeff">
-<code class="descname">reactant_stoich_coeff</code><span class="sig-paren">(</span><em>self</em>, <em>k_spec</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reactant_stoich_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactant_stoich_coeff</code><span class="sig-paren">(</span><em>self</em>, <em>k_spec</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reactant_stoich_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The stoichiometric coefficient of species <em>k_spec</em> as a reactant in
 reaction <em>i_reaction</em>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Kinetics.reactant_stoich_coeffs">
-<code class="descname">reactant_stoich_coeffs</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reactant_stoich_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactant_stoich_coeffs</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reactant_stoich_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The array of reactant stoichiometric coefficients. Element <em>[k,i]</em> of
 this array is the reactant stoichiometric coefficient of species <em>k</em> in
 reaction <em>i</em>.</p>
@@ -309,13 +305,13 @@ reaction <em>i</em>.</p>
 
 <dl class="method">
 <dt id="cantera.Kinetics.reactants">
-<code class="descname">reactants</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reactants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactants</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reactants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The reactants portion of the reaction equation</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Kinetics.reaction">
-<code class="descname">reaction</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reaction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return a <a class="reference internal" href="#cantera.Reaction" title="cantera.Reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reaction</span></code></a> object representing the reaction with index
 <code class="docutils literal notranslate"><span class="pre">i_reaction</span></code>. Changes to this object do not affect the <a class="reference internal" href="#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> or
 <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object until the <a class="reference internal" href="#cantera.Kinetics.modify_reaction" title="cantera.Kinetics.modify_reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">modify_reaction</span></code></a> function is called.</p>
@@ -323,20 +319,20 @@ reaction <em>i</em>.</p>
 
 <dl class="method">
 <dt id="cantera.Kinetics.reaction_equation">
-<code class="descname">reaction_equation</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reaction_equation" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_equation</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reaction_equation" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The equation for the specified reaction. See also <a class="reference internal" href="#cantera.Kinetics.reaction_equations" title="cantera.Kinetics.reaction_equations"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reaction_equations</span></code></a>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Kinetics.reaction_equations">
-<code class="descname">reaction_equations</code><span class="sig-paren">(</span><em>self</em>, <em>indices=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reaction_equations" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_equations</code><span class="sig-paren">(</span><em>self</em>, <em>indices=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reaction_equations" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Returns a list containing the reaction equation for all reactions in the
 mechanism (if <em>indices</em> is unspecified) or the equations for each
 reaction in the sequence <em>indices</em>. For example:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">reaction_equations</span><span class="p">()</span>
-<span class="go">[&#39;2 O + M &lt;=&gt; O2 + M&#39;, &#39;O + H + M &lt;=&gt; OH + M&#39;, &#39;O + H2 &lt;=&gt; H + OH&#39;, ...]</span>
+<span class="go">['2 O + M &lt;=&gt; O2 + M', 'O + H + M &lt;=&gt; OH + M', 'O + H2 &lt;=&gt; H + OH', ...]</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">reaction_equations</span><span class="p">([</span><span class="mi">2</span><span class="p">,</span><span class="mi">3</span><span class="p">])</span>
-<span class="go">[&#39;O + H + M &lt;=&gt; OH + M&#39;, &#39;O + H2 &lt;=&gt; H + OH&#39;]</span>
+<span class="go">['O + H + M &lt;=&gt; OH + M', 'O + H2 &lt;=&gt; H + OH']</span>
 </pre></div>
 </div>
 <p>See also <a class="reference internal" href="#cantera.Kinetics.reaction_equation" title="cantera.Kinetics.reaction_equation"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reaction_equation</span></code></a>.</p>
@@ -344,19 +340,19 @@ reaction in the sequence <em>indices</em>. For example:</p>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.reaction_phase_index">
-<code class="descname">reaction_phase_index</code><a class="headerlink" href="#cantera.Kinetics.reaction_phase_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_phase_index</code><a class="headerlink" href="#cantera.Kinetics.reaction_phase_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of the phase where the reactions occur.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Kinetics.reaction_type">
-<code class="descname">reaction_type</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reaction_type" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reaction_type</code><span class="sig-paren">(</span><em>self</em>, <em>int i_reaction</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reaction_type" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Type of reaction <em>i_reaction</em>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Kinetics.reactions">
-<code class="descname">reactions</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reactions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactions</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.reactions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return a list of all <a class="reference internal" href="#cantera.Reaction" title="cantera.Reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reaction</span></code></a> objects. Changes to these objects do not
 affect the <a class="reference internal" href="#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> or <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object until the <a class="reference internal" href="#cantera.Kinetics.modify_reaction" title="cantera.Kinetics.modify_reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">modify_reaction</span></code></a>
 function is called.</p>
@@ -364,7 +360,7 @@ function is called.</p>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.reverse_rate_constants">
-<code class="descname">reverse_rate_constants</code><a class="headerlink" href="#cantera.Kinetics.reverse_rate_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reverse_rate_constants</code><a class="headerlink" href="#cantera.Kinetics.reverse_rate_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reverse rate constants for all reactions. The computed values include
 all temperature-dependent, pressure-dependent, and third body
 contributions. Units are a combination of kmol, m^3 and s, that depend
@@ -373,14 +369,14 @@ on the rate expression for the reaction.</p>
 
 <dl class="attribute">
 <dt id="cantera.Kinetics.reverse_rates_of_progress">
-<code class="descname">reverse_rates_of_progress</code><a class="headerlink" href="#cantera.Kinetics.reverse_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reverse_rates_of_progress</code><a class="headerlink" href="#cantera.Kinetics.reverse_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reverse rates of progress for the reactions. [kmol/m^3/s] for bulk
 phases or [kmol/m^2/s] for surface phases.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Kinetics.set_multiplier">
-<code class="descname">set_multiplier</code><span class="sig-paren">(</span><em>self</em>, <em>double value</em>, <em>int i_reaction=-1</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.set_multiplier" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_multiplier</code><span class="sig-paren">(</span><em>self</em>, <em>double value</em>, <em>int i_reaction=-1</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Kinetics.set_multiplier" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the multiplier for for reaction <em>i_reaction</em> to <em>value</em>.
 If <em>i_reaction</em> is not specified, then the multiplier for all reactions
 is set to <em>value</em>. See <a class="reference internal" href="#cantera.Kinetics.multiplier" title="cantera.Kinetics.multiplier"><code class="xref py py-obj docutils literal notranslate"><span class="pre">multiplier</span></code></a>.</p>
@@ -390,23 +386,23 @@ is set to <em>value</em>. See <a class="reference internal" href="#cantera.Kinet
 
 </div>
 <div class="section" id="interfacekinetics">
-<h3><a class="toc-backref" href="#id3">InterfaceKinetics</a><a class="headerlink" href="#interfacekinetics" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id3">InterfaceKinetics</a><a class="headerlink" href="#interfacekinetics" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.InterfaceKinetics">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">InterfaceKinetics</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em>, <em>phases=()</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">InterfaceKinetics</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em>, <em>phases=()</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Kinetics</span></code></p>
 <p>A kinetics manager for heterogeneous reaction mechanisms. The
 reactions are assumed to occur at an interface between bulk phases.</p>
 <dl class="method">
 <dt id="cantera.InterfaceKinetics.advance_coverages">
-<code class="descname">advance_coverages</code><span class="sig-paren">(</span><em>self</em>, <em>double dt</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics.advance_coverages" title="Permalink to this definition">¶</a></dt>
+<code class="descname">advance_coverages</code><span class="sig-paren">(</span><em>self</em>, <em>double dt</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics.advance_coverages" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>This method carries out a time-accurate advancement of the surface
 coverages for a specified amount of time.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.InterfaceKinetics.get_creation_rates">
-<code class="descname">get_creation_rates</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics.get_creation_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_creation_rates</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics.get_creation_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Creation rates for each species in phase <em>phase</em>. Use the
 <code class="xref py py-obj docutils literal notranslate"><span class="pre">creation_rates</span></code> property to get the creation rates for species in all
 phases.</p>
@@ -414,7 +410,7 @@ phases.</p>
 
 <dl class="method">
 <dt id="cantera.InterfaceKinetics.get_destruction_rates">
-<code class="descname">get_destruction_rates</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics.get_destruction_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_destruction_rates</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics.get_destruction_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Destruction rates for each species in phase <em>phase</em>. Use the
 <code class="xref py py-obj docutils literal notranslate"><span class="pre">destruction_rates</span></code> property to get the destruction rates for species
 in all phases.</p>
@@ -422,7 +418,7 @@ in all phases.</p>
 
 <dl class="method">
 <dt id="cantera.InterfaceKinetics.get_net_production_rates">
-<code class="descname">get_net_production_rates</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics.get_net_production_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_net_production_rates</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics.get_net_production_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Net production rates for each species in phase <em>phase</em>. Use the
 <code class="xref py py-obj docutils literal notranslate"><span class="pre">net_production_rates</span></code> property to get the net_production rates for
 species in all phases.</p>
@@ -430,7 +426,7 @@ species in all phases.</p>
 
 <dl class="method">
 <dt id="cantera.InterfaceKinetics.phase_index">
-<code class="descname">phase_index</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics.phase_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">phase_index</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceKinetics.phase_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the index of the phase <em>phase</em>, where <em>phase</em> may specified using
 the phase object, the name, or the index itself.</p>
 </dd></dl>
@@ -440,24 +436,24 @@ the phase object, the name, or the index itself.</p>
 </div>
 </div>
 <div class="section" id="reactions">
-<h2><a class="toc-backref" href="#id4">Reactions</a><a class="headerlink" href="#reactions" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id4">Reactions</a><a class="headerlink" href="#reactions" title="Permalink to this headline">&#182;</a></h2>
 <p>These classes contain the definition of a single reaction and its associated
 rate expression, independent of a specific <a class="reference internal" href="#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> object.</p>
 <div class="section" id="reaction">
-<h3><a class="toc-backref" href="#id5">Reaction</a><a class="headerlink" href="#reaction" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id5">Reaction</a><a class="headerlink" href="#reaction" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Reaction">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Reaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Reaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>A class which stores data about a reaction and its rate parameterization so
 that it can be added to a <a class="reference internal" href="#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> object.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>reactants</strong> – Value used to set <a class="reference internal" href="#cantera.Reaction.reactants" title="cantera.Reaction.reactants"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reactants</span></code></a></li>
-<li><strong>products</strong> – Value used to set <a class="reference internal" href="#cantera.Reaction.products" title="cantera.Reaction.products"><code class="xref py py-obj docutils literal notranslate"><span class="pre">products</span></code></a></li>
+<li><strong>reactants</strong> &#8211; Value used to set <a class="reference internal" href="#cantera.Reaction.reactants" title="cantera.Reaction.reactants"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reactants</span></code></a></li>
+<li><strong>products</strong> &#8211; Value used to set <a class="reference internal" href="#cantera.Reaction.products" title="cantera.Reaction.products"><code class="xref py py-obj docutils literal notranslate"><span class="pre">products</span></code></a></li>
 </ul>
 </td>
 </tr>
@@ -467,9 +463,9 @@ that it can be added to a <a class="reference internal" href="#cantera.Kinetics"
 used to create lists of <a class="reference internal" href="#cantera.Reaction" title="cantera.Reaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reaction</span></code></a> objects from existing definitions in the
 CTI or XML format. All of the following will produce a list of the 325
 reactions which make up the GRI 3.0 mechanism:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">R</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">listFromFile</span><span class="p">(</span><span class="s1">&#39;gri30.cti&#39;</span><span class="p">)</span>
-<span class="n">R</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">listFromCti</span><span class="p">(</span><span class="nb">open</span><span class="p">(</span><span class="s1">&#39;path/to/gri30.cti&#39;</span><span class="p">)</span><span class="o">.</span><span class="n">read</span><span class="p">())</span>
-<span class="n">R</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">listFromXml</span><span class="p">(</span><span class="nb">open</span><span class="p">(</span><span class="s1">&#39;path/to/gri30.xml&#39;</span><span class="p">)</span><span class="o">.</span><span class="n">read</span><span class="p">())</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">R</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">listFromFile</span><span class="p">(</span><span class="s1">'gri30.cti'</span><span class="p">)</span>
+<span class="n">R</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">listFromCti</span><span class="p">(</span><span class="nb">open</span><span class="p">(</span><span class="s1">'path/to/gri30.cti'</span><span class="p">)</span><span class="o">.</span><span class="n">read</span><span class="p">())</span>
+<span class="n">R</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">listFromXml</span><span class="p">(</span><span class="nb">open</span><span class="p">(</span><span class="s1">'path/to/gri30.xml'</span><span class="p">)</span><span class="o">.</span><span class="n">read</span><span class="p">())</span>
 </pre></div>
 </div>
 <p>The methods <a class="reference internal" href="#cantera.Reaction.fromCti" title="cantera.Reaction.fromCti"><code class="xref py py-obj docutils literal notranslate"><span class="pre">fromCti</span></code></a> and <a class="reference internal" href="#cantera.Reaction.fromXml" title="cantera.Reaction.fromXml"><code class="xref py py-obj docutils literal notranslate"><span class="pre">fromXml</span></code></a> can be used to create individual
@@ -477,73 +473,73 @@ reactions which make up the GRI 3.0 mechanism:</p>
 CTI definitions, it is important to verify that either the pre-exponential
 factor and activation energy are supplied in SI units, or that they have
 their units specified:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">R</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">fromCti</span><span class="p">(</span><span class="s1">&#39;&#39;&#39;reaction(&#39;O + H2 &lt;=&gt; H + OH&#39;,</span>
-<span class="s1">        [3.87e1, 2.7, 2.619184e7])&#39;&#39;&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">R</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">fromCti</span><span class="p">(</span><span class="s1">'''reaction('O + H2 &lt;=&gt; H + OH',</span>
+<span class="s1">        [3.87e1, 2.7, 2.619184e7])'''</span><span class="p">)</span>
 
-<span class="n">R</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">fromCti</span><span class="p">(</span><span class="s1">&#39;&#39;&#39;reaction(&#39;O + H2 &lt;=&gt; H + OH&#39;,</span>
-<span class="s1">                [(3.87e4, &#39;cm3/mol/s&#39;), 2.7, (6260, &#39;cal/mol&#39;)])&#39;&#39;&#39;</span><span class="p">)</span>
+<span class="n">R</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Reaction</span><span class="o">.</span><span class="n">fromCti</span><span class="p">(</span><span class="s1">'''reaction('O + H2 &lt;=&gt; H + OH',</span>
+<span class="s1">                [(3.87e4, 'cm3/mol/s'), 2.7, (6260, 'cal/mol')])'''</span><span class="p">)</span>
 </pre></div>
 </div>
 <dl class="attribute">
 <dt id="cantera.Reaction.ID">
-<code class="descname">ID</code><a class="headerlink" href="#cantera.Reaction.ID" title="Permalink to this definition">¶</a></dt>
+<code class="descname">ID</code><a class="headerlink" href="#cantera.Reaction.ID" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the identification string for the reaction, which can be used in
 filtering operations.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Reaction.allow_negative_orders">
-<code class="descname">allow_negative_orders</code><a class="headerlink" href="#cantera.Reaction.allow_negative_orders" title="Permalink to this definition">¶</a></dt>
+<code class="descname">allow_negative_orders</code><a class="headerlink" href="#cantera.Reaction.allow_negative_orders" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set a flag which is <code class="xref py py-obj docutils literal notranslate"><span class="pre">True</span></code> if negative reaction orders are allowed.
 Default is <code class="xref py py-obj docutils literal notranslate"><span class="pre">False</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Reaction.allow_nonreactant_orders">
-<code class="descname">allow_nonreactant_orders</code><a class="headerlink" href="#cantera.Reaction.allow_nonreactant_orders" title="Permalink to this definition">¶</a></dt>
+<code class="descname">allow_nonreactant_orders</code><a class="headerlink" href="#cantera.Reaction.allow_nonreactant_orders" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set a flag which is <code class="xref py py-obj docutils literal notranslate"><span class="pre">True</span></code> if reaction orders can be specified for
 non-reactant species. Default is <code class="xref py py-obj docutils literal notranslate"><span class="pre">False</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Reaction.duplicate">
-<code class="descname">duplicate</code><a class="headerlink" href="#cantera.Reaction.duplicate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">duplicate</code><a class="headerlink" href="#cantera.Reaction.duplicate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set a flag which is <code class="xref py py-obj docutils literal notranslate"><span class="pre">True</span></code> if this reaction is marked as a duplicate
 or <code class="xref py py-obj docutils literal notranslate"><span class="pre">False</span></code> otherwise.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Reaction.equation">
-<code class="descname">equation</code><a class="headerlink" href="#cantera.Reaction.equation" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equation</code><a class="headerlink" href="#cantera.Reaction.equation" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A string giving the chemical equation for this reaction. Determined
 automatically based on <a class="reference internal" href="#cantera.Reaction.reactants" title="cantera.Reaction.reactants"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reactants</span></code></a> and <a class="reference internal" href="#cantera.Reaction.products" title="cantera.Reaction.products"><code class="xref py py-obj docutils literal notranslate"><span class="pre">products</span></code></a>.</p>
 </dd></dl>
 
 <dl class="staticmethod">
 <dt id="cantera.Reaction.fromCti">
-<em class="property">static </em><code class="descname">fromCti</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction.fromCti" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">fromCti</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction.fromCti" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a Reaction object from its CTI string representation.</p>
 </dd></dl>
 
 <dl class="staticmethod">
 <dt id="cantera.Reaction.fromXml">
-<em class="property">static </em><code class="descname">fromXml</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction.fromXml" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">fromXml</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction.fromXml" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a Reaction object from its XML string representation.</p>
 </dd></dl>
 
 <dl class="staticmethod">
 <dt id="cantera.Reaction.listFromCti">
-<em class="property">static </em><code class="descname">listFromCti</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction.listFromCti" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">listFromCti</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction.listFromCti" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a list of Species objects from all the species defined in a CTI
 string.</p>
 </dd></dl>
 
 <dl class="staticmethod">
 <dt id="cantera.Reaction.listFromFile">
-<em class="property">static </em><code class="descname">listFromFile</code><span class="sig-paren">(</span><em>filename</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction.listFromFile" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">listFromFile</code><span class="sig-paren">(</span><em>filename</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction.listFromFile" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a list of Reaction objects from all of the reactions defined in a
 CTI or XML file.</p>
-<p>Directories on Cantera’s input file path will be searched for the
+<p>Directories on Cantera&#8217;s input file path will be searched for the
 specified file.</p>
 <p>In the case of an XML file, the <code class="docutils literal notranslate"><span class="pre">&lt;reactions&gt;</span></code> nodes are assumed to be
 children of the <code class="docutils literal notranslate"><span class="pre">&lt;reactionsData&gt;</span></code> node in a document with a <code class="docutils literal notranslate"><span class="pre">&lt;ctml&gt;</span></code>
@@ -552,7 +548,7 @@ root node, as in the XML files produced by conversion from CTI files.</p>
 
 <dl class="staticmethod">
 <dt id="cantera.Reaction.listFromXml">
-<em class="property">static </em><code class="descname">listFromXml</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction.listFromXml" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">listFromXml</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reaction.listFromXml" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a list of Reaction objects from all the reaction defined in an
 XML string. The <code class="docutils literal notranslate"><span class="pre">&lt;reaction&gt;</span></code> nodes are assumed to be children of the
 <code class="docutils literal notranslate"><span class="pre">&lt;reactionData&gt;</span></code> node in a document with a <code class="docutils literal notranslate"><span class="pre">&lt;ctml&gt;</span></code> root node, as in
@@ -561,7 +557,7 @@ the XML files produced by conversion from CTI files.</p>
 
 <dl class="attribute">
 <dt id="cantera.Reaction.orders">
-<code class="descname">orders</code><a class="headerlink" href="#cantera.Reaction.orders" title="Permalink to this definition">¶</a></dt>
+<code class="descname">orders</code><a class="headerlink" href="#cantera.Reaction.orders" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the reaction order with respect to specific species as a dict
 with species names as the keys and orders as the values, or as a
 composition string. By default, mass-action kinetics is assumed, with
@@ -571,14 +567,14 @@ stoichiometric coefficient.</p>
 
 <dl class="attribute">
 <dt id="cantera.Reaction.product_string">
-<code class="descname">product_string</code><a class="headerlink" href="#cantera.Reaction.product_string" title="Permalink to this definition">¶</a></dt>
+<code class="descname">product_string</code><a class="headerlink" href="#cantera.Reaction.product_string" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A string representing the products side of the chemical equation for
 this reaction. Determined automatically based on <a class="reference internal" href="#cantera.Reaction.products" title="cantera.Reaction.products"><code class="xref py py-obj docutils literal notranslate"><span class="pre">products</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Reaction.products">
-<code class="descname">products</code><a class="headerlink" href="#cantera.Reaction.products" title="Permalink to this definition">¶</a></dt>
+<code class="descname">products</code><a class="headerlink" href="#cantera.Reaction.products" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the products in this reaction as a dict where the keys are
 species names and the values, are the stoichiometric coefficients, e.g.
 <code class="docutils literal notranslate"><span class="pre">{'CH3':1,</span> <span class="pre">'H2O':1}</span></code>, or as a composition string, e.g.
@@ -587,14 +583,14 @@ species names and the values, are the stoichiometric coefficients, e.g.
 
 <dl class="attribute">
 <dt id="cantera.Reaction.reactant_string">
-<code class="descname">reactant_string</code><a class="headerlink" href="#cantera.Reaction.reactant_string" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactant_string</code><a class="headerlink" href="#cantera.Reaction.reactant_string" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A string representing the reactants side of the chemical equation for
 this reaction. Determined automatically based on <a class="reference internal" href="#cantera.Reaction.reactants" title="cantera.Reaction.reactants"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reactants</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Reaction.reactants">
-<code class="descname">reactants</code><a class="headerlink" href="#cantera.Reaction.reactants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactants</code><a class="headerlink" href="#cantera.Reaction.reactants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the reactants in this reaction as a dict where the keys are
 species names and the values, are the stoichiometric coefficients, e.g.
 <code class="docutils literal notranslate"><span class="pre">{'CH4':1,</span> <span class="pre">'OH':1}</span></code>, or as a composition string, e.g.
@@ -603,7 +599,7 @@ species names and the values, are the stoichiometric coefficients, e.g.
 
 <dl class="attribute">
 <dt id="cantera.Reaction.reversible">
-<code class="descname">reversible</code><a class="headerlink" href="#cantera.Reaction.reversible" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reversible</code><a class="headerlink" href="#cantera.Reaction.reversible" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set a flag which is <code class="xref py py-obj docutils literal notranslate"><span class="pre">True</span></code> if this reaction is reversible or <code class="xref py py-obj docutils literal notranslate"><span class="pre">False</span></code>
 otherwise.</p>
 </dd></dl>
@@ -612,23 +608,23 @@ otherwise.</p>
 
 </div>
 <div class="section" id="elementaryreaction">
-<h3><a class="toc-backref" href="#id6">ElementaryReaction</a><a class="headerlink" href="#elementaryreaction" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id6">ElementaryReaction</a><a class="headerlink" href="#elementaryreaction" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ElementaryReaction">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ElementaryReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ElementaryReaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ElementaryReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ElementaryReaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Reaction</span></code></p>
 <p>A reaction which follows mass-action kinetics with a modified Arrhenius
 reaction rate.</p>
 <dl class="attribute">
 <dt id="cantera.ElementaryReaction.allow_negative_pre_exponential_factor">
-<code class="descname">allow_negative_pre_exponential_factor</code><a class="headerlink" href="#cantera.ElementaryReaction.allow_negative_pre_exponential_factor" title="Permalink to this definition">¶</a></dt>
+<code class="descname">allow_negative_pre_exponential_factor</code><a class="headerlink" href="#cantera.ElementaryReaction.allow_negative_pre_exponential_factor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set whether the rate coefficient is allowed to have a negative
 pre-exponential factor.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ElementaryReaction.rate">
-<code class="descname">rate</code><a class="headerlink" href="#cantera.ElementaryReaction.rate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">rate</code><a class="headerlink" href="#cantera.ElementaryReaction.rate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the <a class="reference internal" href="#cantera.Arrhenius" title="cantera.Arrhenius"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Arrhenius</span></code></a> rate coefficient for this reaction.</p>
 </dd></dl>
 
@@ -636,23 +632,23 @@ pre-exponential factor.</p>
 
 </div>
 <div class="section" id="threebodyreaction">
-<h3><a class="toc-backref" href="#id7">ThreeBodyReaction</a><a class="headerlink" href="#threebodyreaction" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id7">ThreeBodyReaction</a><a class="headerlink" href="#threebodyreaction" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ThreeBodyReaction">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ThreeBodyReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThreeBodyReaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ThreeBodyReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThreeBodyReaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.ElementaryReaction</span></code></p>
-<p>A reaction with a non-reacting third body “M” that acts to add or remove
+<p>A reaction with a non-reacting third body &#8220;M&#8221; that acts to add or remove
 energy from the reacting species.</p>
 <dl class="attribute">
 <dt id="cantera.ThreeBodyReaction.default_efficiency">
-<code class="descname">default_efficiency</code><a class="headerlink" href="#cantera.ThreeBodyReaction.default_efficiency" title="Permalink to this definition">¶</a></dt>
+<code class="descname">default_efficiency</code><a class="headerlink" href="#cantera.ThreeBodyReaction.default_efficiency" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the default third-body efficiency for this reaction, used for
 species used for species not in <a class="reference internal" href="#cantera.ThreeBodyReaction.efficiencies" title="cantera.ThreeBodyReaction.efficiencies"><code class="xref py py-obj docutils literal notranslate"><span class="pre">efficiencies</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThreeBodyReaction.efficiencies">
-<code class="descname">efficiencies</code><a class="headerlink" href="#cantera.ThreeBodyReaction.efficiencies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">efficiencies</code><a class="headerlink" href="#cantera.ThreeBodyReaction.efficiencies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set a <code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code> defining non-default third-body efficiencies for this
 reaction, where the keys are the species names and the values are the
 efficiencies.</p>
@@ -660,7 +656,7 @@ efficiencies.</p>
 
 <dl class="method">
 <dt id="cantera.ThreeBodyReaction.efficiency">
-<code class="descname">efficiency</code><span class="sig-paren">(</span><em>self</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThreeBodyReaction.efficiency" title="Permalink to this definition">¶</a></dt>
+<code class="descname">efficiency</code><span class="sig-paren">(</span><em>self</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThreeBodyReaction.efficiency" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the efficiency of the third body named <em>species</em> considering both
 the default efficiency and species-specific efficiencies.</p>
 </dd></dl>
@@ -669,23 +665,23 @@ the default efficiency and species-specific efficiencies.</p>
 
 </div>
 <div class="section" id="falloffreaction">
-<h3><a class="toc-backref" href="#id8">FalloffReaction</a><a class="headerlink" href="#falloffreaction" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id8">FalloffReaction</a><a class="headerlink" href="#falloffreaction" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.FalloffReaction">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FalloffReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FalloffReaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FalloffReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FalloffReaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Reaction</span></code></p>
 <p>A reaction that is first-order in [M] at low pressure, like a third-body
 reaction, but zeroth-order in [M] as pressure increases.</p>
 <dl class="attribute">
 <dt id="cantera.FalloffReaction.default_efficiency">
-<code class="descname">default_efficiency</code><a class="headerlink" href="#cantera.FalloffReaction.default_efficiency" title="Permalink to this definition">¶</a></dt>
+<code class="descname">default_efficiency</code><a class="headerlink" href="#cantera.FalloffReaction.default_efficiency" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the default third-body efficiency for this reaction, used for
 species used for species not in <a class="reference internal" href="#cantera.FalloffReaction.efficiencies" title="cantera.FalloffReaction.efficiencies"><code class="xref py py-obj docutils literal notranslate"><span class="pre">efficiencies</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FalloffReaction.efficiencies">
-<code class="descname">efficiencies</code><a class="headerlink" href="#cantera.FalloffReaction.efficiencies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">efficiencies</code><a class="headerlink" href="#cantera.FalloffReaction.efficiencies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set a <code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code> defining non-default third-body efficiencies for this
 reaction, where the keys are the species names and the values are the
 efficiencies.</p>
@@ -693,27 +689,27 @@ efficiencies.</p>
 
 <dl class="method">
 <dt id="cantera.FalloffReaction.efficiency">
-<code class="descname">efficiency</code><span class="sig-paren">(</span><em>self</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FalloffReaction.efficiency" title="Permalink to this definition">¶</a></dt>
+<code class="descname">efficiency</code><span class="sig-paren">(</span><em>self</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FalloffReaction.efficiency" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the efficiency of the third body named <em>species</em> considering both
 the default efficiency and species-specific efficiencies.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FalloffReaction.falloff">
-<code class="descname">falloff</code><a class="headerlink" href="#cantera.FalloffReaction.falloff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">falloff</code><a class="headerlink" href="#cantera.FalloffReaction.falloff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the <a class="reference internal" href="#cantera.Falloff" title="cantera.Falloff"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Falloff</span></code></a> function used to blend the high- and low-pressure
 rate coefficients</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FalloffReaction.high_rate">
-<code class="descname">high_rate</code><a class="headerlink" href="#cantera.FalloffReaction.high_rate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">high_rate</code><a class="headerlink" href="#cantera.FalloffReaction.high_rate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the <a class="reference internal" href="#cantera.Arrhenius" title="cantera.Arrhenius"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Arrhenius</span></code></a> rate constant in the high-pressure limit</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FalloffReaction.low_rate">
-<code class="descname">low_rate</code><a class="headerlink" href="#cantera.FalloffReaction.low_rate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">low_rate</code><a class="headerlink" href="#cantera.FalloffReaction.low_rate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the <a class="reference internal" href="#cantera.Arrhenius" title="cantera.Arrhenius"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Arrhenius</span></code></a> rate constant in the low-pressure limit</p>
 </dd></dl>
 
@@ -721,10 +717,10 @@ rate coefficients</p>
 
 </div>
 <div class="section" id="chemicallyactivatedreaction">
-<h3><a class="toc-backref" href="#id9">ChemicallyActivatedReaction</a><a class="headerlink" href="#chemicallyactivatedreaction" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id9">ChemicallyActivatedReaction</a><a class="headerlink" href="#chemicallyactivatedreaction" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ChemicallyActivatedReaction">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ChemicallyActivatedReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ChemicallyActivatedReaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ChemicallyActivatedReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ChemicallyActivatedReaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.FalloffReaction</span></code></p>
 <p>A reaction where the rate decreases as pressure increases due to collisional
 stabilization of a reaction intermediate. Like a <a class="reference internal" href="#cantera.FalloffReaction" title="cantera.FalloffReaction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">FalloffReaction</span></code></a>, except
@@ -734,16 +730,16 @@ pressure rate constant.</p>
 
 </div>
 <div class="section" id="plogreaction">
-<h3><a class="toc-backref" href="#id10">PlogReaction</a><a class="headerlink" href="#plogreaction" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id10">PlogReaction</a><a class="headerlink" href="#plogreaction" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.PlogReaction">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">PlogReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.PlogReaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">PlogReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.PlogReaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Reaction</span></code></p>
 <p>A pressure-dependent reaction parameterized by logarithmically interpolating
 between Arrhenius rate expressions at various pressures.</p>
 <dl class="attribute">
 <dt id="cantera.PlogReaction.rates">
-<code class="descname">rates</code><a class="headerlink" href="#cantera.PlogReaction.rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">rates</code><a class="headerlink" href="#cantera.PlogReaction.rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the rate coefficients for this reaction, which are given as a
 list of (pressure, <a class="reference internal" href="#cantera.Arrhenius" title="cantera.Arrhenius"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Arrhenius</span></code></a>) tuples.</p>
 </dd></dl>
@@ -752,58 +748,58 @@ list of (pressure, <a class="reference internal" href="#cantera.Arrhenius" title
 
 </div>
 <div class="section" id="chebyshevreaction">
-<h3><a class="toc-backref" href="#id11">ChebyshevReaction</a><a class="headerlink" href="#chebyshevreaction" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id11">ChebyshevReaction</a><a class="headerlink" href="#chebyshevreaction" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ChebyshevReaction">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ChebyshevReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ChebyshevReaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ChebyshevReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ChebyshevReaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Reaction</span></code></p>
 <p>A pressure-dependent reaction parameterized by a bivariate Chebyshev
 polynomial in temperature and pressure.</p>
 <dl class="attribute">
 <dt id="cantera.ChebyshevReaction.Pmax">
-<code class="descname">Pmax</code><a class="headerlink" href="#cantera.ChebyshevReaction.Pmax" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Pmax</code><a class="headerlink" href="#cantera.ChebyshevReaction.Pmax" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Maximum pressure [Pa] for the Chebyshev fit</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ChebyshevReaction.Pmin">
-<code class="descname">Pmin</code><a class="headerlink" href="#cantera.ChebyshevReaction.Pmin" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Pmin</code><a class="headerlink" href="#cantera.ChebyshevReaction.Pmin" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Minimum pressure [Pa] for the Chebyshev fit</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ChebyshevReaction.Tmax">
-<code class="descname">Tmax</code><a class="headerlink" href="#cantera.ChebyshevReaction.Tmax" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Tmax</code><a class="headerlink" href="#cantera.ChebyshevReaction.Tmax" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Maximum temperature [K] for the Chebyshev fit</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ChebyshevReaction.Tmin">
-<code class="descname">Tmin</code><a class="headerlink" href="#cantera.ChebyshevReaction.Tmin" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Tmin</code><a class="headerlink" href="#cantera.ChebyshevReaction.Tmin" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Minimum temperature [K] for the Chebyshev fit</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ChebyshevReaction.coeffs">
-<code class="descname">coeffs</code><a class="headerlink" href="#cantera.ChebyshevReaction.coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">coeffs</code><a class="headerlink" href="#cantera.ChebyshevReaction.coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>2D array of Chebyshev coefficients of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">(nTemperature,</span> <span class="pre">nPressure)</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ChebyshevReaction.nPressure">
-<code class="descname">nPressure</code><a class="headerlink" href="#cantera.ChebyshevReaction.nPressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nPressure</code><a class="headerlink" href="#cantera.ChebyshevReaction.nPressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of pressures over which the Chebyshev fit is computed</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ChebyshevReaction.nTemperature">
-<code class="descname">nTemperature</code><a class="headerlink" href="#cantera.ChebyshevReaction.nTemperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nTemperature</code><a class="headerlink" href="#cantera.ChebyshevReaction.nTemperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of temperatures over which the Chebyshev fit is computed</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ChebyshevReaction.set_parameters">
-<code class="descname">set_parameters</code><span class="sig-paren">(</span><em>self</em>, <em>Tmin</em>, <em>Tmax</em>, <em>Pmin</em>, <em>Pmax</em>, <em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ChebyshevReaction.set_parameters" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_parameters</code><span class="sig-paren">(</span><em>self</em>, <em>Tmin</em>, <em>Tmax</em>, <em>Pmin</em>, <em>Pmax</em>, <em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ChebyshevReaction.set_parameters" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Simultaneously set values for <a class="reference internal" href="#cantera.ChebyshevReaction.Tmin" title="cantera.ChebyshevReaction.Tmin"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Tmin</span></code></a>, <a class="reference internal" href="#cantera.ChebyshevReaction.Tmax" title="cantera.ChebyshevReaction.Tmax"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Tmax</span></code></a>, <a class="reference internal" href="#cantera.ChebyshevReaction.Pmin" title="cantera.ChebyshevReaction.Pmin"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Pmin</span></code></a>, <a class="reference internal" href="#cantera.ChebyshevReaction.Pmax" title="cantera.ChebyshevReaction.Pmax"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Pmax</span></code></a>, and
 <a class="reference internal" href="#cantera.ChebyshevReaction.coeffs" title="cantera.ChebyshevReaction.coeffs"><code class="xref py py-obj docutils literal notranslate"><span class="pre">coeffs</span></code></a>.</p>
 </dd></dl>
@@ -812,15 +808,15 @@ polynomial in temperature and pressure.</p>
 
 </div>
 <div class="section" id="interfacereaction">
-<h3><a class="toc-backref" href="#id12">InterfaceReaction</a><a class="headerlink" href="#interfacereaction" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id12">InterfaceReaction</a><a class="headerlink" href="#interfacereaction" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.InterfaceReaction">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">InterfaceReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceReaction" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">InterfaceReaction</code><span class="sig-paren">(</span><em>reactants=''</em>, <em>products=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfaceReaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.ElementaryReaction</span></code></p>
 <p>A reaction occurring on an <a class="reference internal" href="importing.html#cantera.Interface" title="cantera.Interface"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Interface</span></code></a> (i.e. a surface or an edge)</p>
 <dl class="attribute">
 <dt id="cantera.InterfaceReaction.coverage_deps">
-<code class="descname">coverage_deps</code><a class="headerlink" href="#cantera.InterfaceReaction.coverage_deps" title="Permalink to this definition">¶</a></dt>
+<code class="descname">coverage_deps</code><a class="headerlink" href="#cantera.InterfaceReaction.coverage_deps" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set a dict containing adjustments to the Arrhenius rate expression
 dependent on surface species coverages. The keys of the dict are species
 names, and the values are tuples specifying the three coverage
@@ -831,7 +827,7 @@ and the activation energy [J/kmol], respectively.</p>
 
 <dl class="attribute">
 <dt id="cantera.InterfaceReaction.is_sticking_coefficient">
-<code class="descname">is_sticking_coefficient</code><a class="headerlink" href="#cantera.InterfaceReaction.is_sticking_coefficient" title="Permalink to this definition">¶</a></dt>
+<code class="descname">is_sticking_coefficient</code><a class="headerlink" href="#cantera.InterfaceReaction.is_sticking_coefficient" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set a boolean indicating if the rate coefficient for this reaction
 is expressed as a sticking coefficient rather than the forward rate
 constant.</p>
@@ -839,7 +835,7 @@ constant.</p>
 
 <dl class="attribute">
 <dt id="cantera.InterfaceReaction.sticking_species">
-<code class="descname">sticking_species</code><a class="headerlink" href="#cantera.InterfaceReaction.sticking_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">sticking_species</code><a class="headerlink" href="#cantera.InterfaceReaction.sticking_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The name of the sticking species. Needed only for reactions with
 multiple non-surface reactant species, where the sticking species is
 ambiguous.</p>
@@ -847,7 +843,7 @@ ambiguous.</p>
 
 <dl class="attribute">
 <dt id="cantera.InterfaceReaction.use_motz_wise_correction">
-<code class="descname">use_motz_wise_correction</code><a class="headerlink" href="#cantera.InterfaceReaction.use_motz_wise_correction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">use_motz_wise_correction</code><a class="headerlink" href="#cantera.InterfaceReaction.use_motz_wise_correction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set a boolean indicating whether to use the correction factor
 developed by Motz &amp; Wise for reactions with high (near-unity) sticking
 coefficients when converting the sticking coefficient to a rate
@@ -859,12 +855,12 @@ coefficient.</p>
 </div>
 </div>
 <div class="section" id="auxilliary-reaction-data">
-<h2><a class="toc-backref" href="#id13">Auxilliary Reaction Data</a><a class="headerlink" href="#auxilliary-reaction-data" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id13">Auxilliary Reaction Data</a><a class="headerlink" href="#auxilliary-reaction-data" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="arrhenius">
-<h3><a class="toc-backref" href="#id14">Arrhenius</a><a class="headerlink" href="#arrhenius" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id14">Arrhenius</a><a class="headerlink" href="#arrhenius" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Arrhenius">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Arrhenius</code><span class="sig-paren">(</span><em>A</em>, <em>b</em>, <em>E</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Arrhenius" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Arrhenius</code><span class="sig-paren">(</span><em>A</em>, <em>b</em>, <em>E</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Arrhenius" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>A reaction rate coefficient which depends on temperature only and follows
 the modified Arrhenius form:</p>
@@ -874,20 +870,20 @@ the modified Arrhenius form:</p>
 and <em>E</em> is the <a class="reference internal" href="#cantera.Arrhenius.activation_energy" title="cantera.Arrhenius.activation_energy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">activation_energy</span></code></a>.</p>
 <dl class="attribute">
 <dt id="cantera.Arrhenius.activation_energy">
-<code class="descname">activation_energy</code><a class="headerlink" href="#cantera.Arrhenius.activation_energy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">activation_energy</code><a class="headerlink" href="#cantera.Arrhenius.activation_energy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The activation energy <em>E</em> [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Arrhenius.pre_exponential_factor">
-<code class="descname">pre_exponential_factor</code><a class="headerlink" href="#cantera.Arrhenius.pre_exponential_factor" title="Permalink to this definition">¶</a></dt>
+<code class="descname">pre_exponential_factor</code><a class="headerlink" href="#cantera.Arrhenius.pre_exponential_factor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The pre-exponential factor <em>A</em> in units of m, kmol, and s raised to
 powers depending on the reaction order.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Arrhenius.temperature_exponent">
-<code class="descname">temperature_exponent</code><a class="headerlink" href="#cantera.Arrhenius.temperature_exponent" title="Permalink to this definition">¶</a></dt>
+<code class="descname">temperature_exponent</code><a class="headerlink" href="#cantera.Arrhenius.temperature_exponent" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The temperature exponent <em>b</em>.</p>
 </dd></dl>
 
@@ -895,10 +891,10 @@ powers depending on the reaction order.</p>
 
 </div>
 <div class="section" id="falloff">
-<h3><a class="toc-backref" href="#id15">Falloff</a><a class="headerlink" href="#falloff" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id15">Falloff</a><a class="headerlink" href="#falloff" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Falloff">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Falloff</code><span class="sig-paren">(</span><em>coeffs=()</em>, <em>init=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Falloff" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Falloff</code><span class="sig-paren">(</span><em>coeffs=()</em>, <em>init=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Falloff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>A parameterization used to describe the fall-off in reaction rate constants
 due to intermolecular energy transfer. These functions are used by reactions
@@ -907,12 +903,12 @@ classes.</p>
 <p>This base class implements the simple falloff function
 <span class="math">\(F(T,P_r) = 1.0\)</span>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>params</strong> – Not used for the “simple” falloff parameterization.</li>
-<li><strong>init</strong> – Used internally when wrapping <a class="reference external" href="../../../doxygen/html/d3/d3a/classCantera_1_1Falloff.html">Falloff</a> objects returned from C++.</li>
+<li><strong>params</strong> &#8211; Not used for the &#8220;simple&#8221; falloff parameterization.</li>
+<li><strong>init</strong> &#8211; Used internally when wrapping <a class="reference external" href="../../../doxygen/html/d3/d3a/classCantera_1_1Falloff.html">Falloff</a> objects returned from C++.</li>
 </ul>
 </td>
 </tr>
@@ -920,13 +916,13 @@ classes.</p>
 </table>
 <dl class="attribute">
 <dt id="cantera.Falloff.parameters">
-<code class="descname">parameters</code><a class="headerlink" href="#cantera.Falloff.parameters" title="Permalink to this definition">¶</a></dt>
+<code class="descname">parameters</code><a class="headerlink" href="#cantera.Falloff.parameters" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The array of parameters used to define this falloff function.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Falloff.type">
-<code class="descname">type</code><a class="headerlink" href="#cantera.Falloff.type" title="Permalink to this definition">¶</a></dt>
+<code class="descname">type</code><a class="headerlink" href="#cantera.Falloff.type" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A string defining the type of the falloff parameterization</p>
 </dd></dl>
 
@@ -934,17 +930,17 @@ classes.</p>
 
 </div>
 <div class="section" id="troefalloff">
-<h3><a class="toc-backref" href="#id16">TroeFalloff</a><a class="headerlink" href="#troefalloff" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id16">TroeFalloff</a><a class="headerlink" href="#troefalloff" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.TroeFalloff">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">TroeFalloff</code><span class="sig-paren">(</span><em>coeffs=()</em>, <em>init=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.TroeFalloff" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">TroeFalloff</code><span class="sig-paren">(</span><em>coeffs=()</em>, <em>init=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.TroeFalloff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Falloff</span></code></p>
 <p>The 3- or 4-parameter Troe falloff function.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>params</strong> – An array of 3 or 4 parameters: <span class="math">\([a, T^{***}, T^*, T^{**}]\)</span> where
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>params</strong> &#8211; An array of 3 or 4 parameters: <span class="math">\([a, T^{***}, T^*, T^{**}]\)</span> where
 the final parameter is optional (with a default value of 0).</td>
 </tr>
 </tbody>
@@ -953,17 +949,17 @@ the final parameter is optional (with a default value of 0).</td>
 
 </div>
 <div class="section" id="srifalloff">
-<h3><a class="toc-backref" href="#id17">SriFalloff</a><a class="headerlink" href="#srifalloff" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id17">SriFalloff</a><a class="headerlink" href="#srifalloff" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.SriFalloff">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">SriFalloff</code><span class="sig-paren">(</span><em>coeffs=()</em>, <em>init=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SriFalloff" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">SriFalloff</code><span class="sig-paren">(</span><em>coeffs=()</em>, <em>init=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SriFalloff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Falloff</span></code></p>
 <p>The 3- or 5-parameter SRI falloff function.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>params</strong> – An array of 3 or 5 parameters: <span class="math">\([a, b, c, d, e]\)</span> where the last
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>params</strong> &#8211; An array of 3 or 5 parameters: <span class="math">\([a, b, c, d, e]\)</span> where the last
 two parameters are optional (with default values of 1 and 0,
 respectively).</td>
 </tr>
@@ -974,12 +970,12 @@ respectively).</td>
 </div>
 </div>
 <div class="section" id="reaction-path-analysis">
-<h2><a class="toc-backref" href="#id18">Reaction Path Analysis</a><a class="headerlink" href="#reaction-path-analysis" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id18">Reaction Path Analysis</a><a class="headerlink" href="#reaction-path-analysis" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="reactionpathdiagram">
-<h3><a class="toc-backref" href="#id19">ReactionPathDiagram</a><a class="headerlink" href="#reactionpathdiagram" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id19">ReactionPathDiagram</a><a class="headerlink" href="#reactionpathdiagram" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ReactionPathDiagram">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ReactionPathDiagram</code><span class="sig-paren">(</span><em>Kinetics kin</em>, <em>str element</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ReactionPathDiagram</code><span class="sig-paren">(</span><em>Kinetics kin</em>, <em>str element</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>ReactionPathDiagram(Kinetics kin, str element)</p>
 <p>Create a reaction path diagram for the fluxes of the element <em>element</em>
@@ -987,133 +983,133 @@ according the the net reaction rates determined by the Kinetics object
 <em>kin</em>.</p>
 <dl class="method">
 <dt id="cantera.ReactionPathDiagram.add">
-<code class="descname">add</code><span class="sig-paren">(</span><em>self</em>, <em>ReactionPathDiagram other</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.add" title="Permalink to this definition">¶</a></dt>
+<code class="descname">add</code><span class="sig-paren">(</span><em>self</em>, <em>ReactionPathDiagram other</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.add" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Add fluxes from <code class="xref py py-obj docutils literal notranslate"><span class="pre">other</span></code> to this diagram</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.arrow_width">
-<code class="descname">arrow_width</code><a class="headerlink" href="#cantera.ReactionPathDiagram.arrow_width" title="Permalink to this definition">¶</a></dt>
+<code class="descname">arrow_width</code><a class="headerlink" href="#cantera.ReactionPathDiagram.arrow_width" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the arrow width. If &lt; 0, then scale with flux value.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.bold_color">
-<code class="descname">bold_color</code><a class="headerlink" href="#cantera.ReactionPathDiagram.bold_color" title="Permalink to this definition">¶</a></dt>
+<code class="descname">bold_color</code><a class="headerlink" href="#cantera.ReactionPathDiagram.bold_color" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the color for bold lines</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.bold_threshold">
-<code class="descname">bold_threshold</code><a class="headerlink" href="#cantera.ReactionPathDiagram.bold_threshold" title="Permalink to this definition">¶</a></dt>
+<code class="descname">bold_threshold</code><a class="headerlink" href="#cantera.ReactionPathDiagram.bold_threshold" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the minimum relative flux for bold lines</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactionPathDiagram.build">
-<code class="descname">build</code><span class="sig-paren">(</span><em>self</em>, <em>verbose=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.build" title="Permalink to this definition">¶</a></dt>
+<code class="descname">build</code><span class="sig-paren">(</span><em>self</em>, <em>verbose=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.build" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Build the reaction path diagram. Called automatically by methods which
 return representations of the diagram, e.g. write_dot().</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.dashed_color">
-<code class="descname">dashed_color</code><a class="headerlink" href="#cantera.ReactionPathDiagram.dashed_color" title="Permalink to this definition">¶</a></dt>
+<code class="descname">dashed_color</code><a class="headerlink" href="#cantera.ReactionPathDiagram.dashed_color" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the color for dashed lines</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactionPathDiagram.display_only">
-<code class="descname">display_only</code><span class="sig-paren">(</span><em>self</em>, <em>int k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.display_only" title="Permalink to this definition">¶</a></dt>
+<code class="descname">display_only</code><span class="sig-paren">(</span><em>self</em>, <em>int k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.display_only" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.dot_options">
-<code class="descname">dot_options</code><a class="headerlink" href="#cantera.ReactionPathDiagram.dot_options" title="Permalink to this definition">¶</a></dt>
-<dd><p>Get/Set options for the ‘dot’ program</p>
+<code class="descname">dot_options</code><a class="headerlink" href="#cantera.ReactionPathDiagram.dot_options" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Get/Set options for the &#8216;dot&#8217; program</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.flow_type">
-<code class="descname">flow_type</code><a class="headerlink" href="#cantera.ReactionPathDiagram.flow_type" title="Permalink to this definition">¶</a></dt>
-<dd><p>Get/Set the way flows are drawn. Either ‘NetFlow’ or ‘OneWayFlow’</p>
+<code class="descname">flow_type</code><a class="headerlink" href="#cantera.ReactionPathDiagram.flow_type" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Get/Set the way flows are drawn. Either &#8216;NetFlow&#8217; or &#8216;OneWayFlow&#8217;</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.font">
-<code class="descname">font</code><a class="headerlink" href="#cantera.ReactionPathDiagram.font" title="Permalink to this definition">¶</a></dt>
+<code class="descname">font</code><a class="headerlink" href="#cantera.ReactionPathDiagram.font" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the name of the font used</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactionPathDiagram.get_data">
-<code class="descname">get_data</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.get_data" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_data</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.get_data" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get a (roughly) human-readable representation of the reaction path
 diagram.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactionPathDiagram.get_dot">
-<code class="descname">get_dot</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.get_dot" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_dot</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.get_dot" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return a string containing the reaction path diagram formatted for use
-by Graphviz’s ‘dot’ program.</p>
+by Graphviz&#8217;s &#8216;dot&#8217; program.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.label_threshold">
-<code class="descname">label_threshold</code><a class="headerlink" href="#cantera.ReactionPathDiagram.label_threshold" title="Permalink to this definition">¶</a></dt>
+<code class="descname">label_threshold</code><a class="headerlink" href="#cantera.ReactionPathDiagram.label_threshold" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the minimum relative flux for labels</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.log">
-<code class="descname">log</code><a class="headerlink" href="#cantera.ReactionPathDiagram.log" title="Permalink to this definition">¶</a></dt>
+<code class="descname">log</code><a class="headerlink" href="#cantera.ReactionPathDiagram.log" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Logging messages generated while building the reaction path diagram</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.normal_color">
-<code class="descname">normal_color</code><a class="headerlink" href="#cantera.ReactionPathDiagram.normal_color" title="Permalink to this definition">¶</a></dt>
+<code class="descname">normal_color</code><a class="headerlink" href="#cantera.ReactionPathDiagram.normal_color" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the color for normal-weight lines</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.normal_threshold">
-<code class="descname">normal_threshold</code><a class="headerlink" href="#cantera.ReactionPathDiagram.normal_threshold" title="Permalink to this definition">¶</a></dt>
+<code class="descname">normal_threshold</code><a class="headerlink" href="#cantera.ReactionPathDiagram.normal_threshold" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the maximum relative flux for dashed lines</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.scale">
-<code class="descname">scale</code><a class="headerlink" href="#cantera.ReactionPathDiagram.scale" title="Permalink to this definition">¶</a></dt>
+<code class="descname">scale</code><a class="headerlink" href="#cantera.ReactionPathDiagram.scale" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the scaling factor for the fluxes. Set to -1 to normalize by the
 maximum net flux.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.show_details">
-<code class="descname">show_details</code><a class="headerlink" href="#cantera.ReactionPathDiagram.show_details" title="Permalink to this definition">¶</a></dt>
+<code class="descname">show_details</code><a class="headerlink" href="#cantera.ReactionPathDiagram.show_details" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set whether to show the details of which reactions contribute to the
 flux.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.threshold">
-<code class="descname">threshold</code><a class="headerlink" href="#cantera.ReactionPathDiagram.threshold" title="Permalink to this definition">¶</a></dt>
+<code class="descname">threshold</code><a class="headerlink" href="#cantera.ReactionPathDiagram.threshold" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the threshold for the minimum flux relative value that will be
 plotted.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactionPathDiagram.title">
-<code class="descname">title</code><a class="headerlink" href="#cantera.ReactionPathDiagram.title" title="Permalink to this definition">¶</a></dt>
+<code class="descname">title</code><a class="headerlink" href="#cantera.ReactionPathDiagram.title" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the diagram title</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactionPathDiagram.write_dot">
-<code class="descname">write_dot</code><span class="sig-paren">(</span><em>self</em>, <em>filename</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.write_dot" title="Permalink to this definition">¶</a></dt>
-<dd><p>Write the reaction path diagram formatted for use by Graphviz’s ‘dot’
+<code class="descname">write_dot</code><span class="sig-paren">(</span><em>self</em>, <em>filename</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactionPathDiagram.write_dot" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Write the reaction path diagram formatted for use by Graphviz&#8217;s &#8216;dot&#8217;
 program to the file named <em>filename</em>.</p>
 </dd></dl>
 
@@ -1177,25 +1173,24 @@ program to the file named <em>filename</em>.</p>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/cython/kinetics.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/cython/kinetics.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -1204,15 +1199,14 @@ program to the file named <em>filename</em>.</p>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/cython/kinetics.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/cython/kinetics.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/cython/kinetics.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/kinetics.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/cython/onedim.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/onedim.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>One-dimensional Reacting Flows | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,7 +77,7 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="one-dimensional-reacting-flows">
-<span id="sec-cython-onedim"></span><h1>One-dimensional Reacting Flows<a class="headerlink" href="#one-dimensional-reacting-flows" title="Permalink to this headline">¶</a></h1>
+<span id="sec-cython-onedim"></span><h1>One-dimensional Reacting Flows<a class="headerlink" href="#one-dimensional-reacting-flows" title="Permalink to this headline">&#182;</a></h1>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#composite-domains" id="id21">Composite Domains</a><ul>
@@ -120,26 +116,26 @@ lang="en">
 </ul>
 </div>
 <div class="section" id="composite-domains">
-<h2><a class="toc-backref" href="#id21">Composite Domains</a><a class="headerlink" href="#composite-domains" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id21">Composite Domains</a><a class="headerlink" href="#composite-domains" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="freeflame">
-<h3><a class="toc-backref" href="#id22">FreeFlame</a><a class="headerlink" href="#freeflame" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id22">FreeFlame</a><a class="headerlink" href="#freeflame" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.FreeFlame">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FreeFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FreeFlame" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FreeFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FreeFlame" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.onedim.FlameBase</span></code></p>
 <p>A freely-propagating flat flame.</p>
-<p>A domain of type IdealGasFlow named ‘flame’ will be created to represent
+<p>A domain of type IdealGasFlow named &#8216;flame&#8217; will be created to represent
 the flame and set to free flow. The three domains comprising the stack
 are stored as <code class="docutils literal notranslate"><span class="pre">self.inlet</span></code>, <code class="docutils literal notranslate"><span class="pre">self.flame</span></code>, and <code class="docutils literal notranslate"><span class="pre">self.outlet</span></code>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>grid</strong> – A list of points to be used as the initial grid. Not recommended
+<li><strong>grid</strong> &#8211; A list of points to be used as the initial grid. Not recommended
 unless solving only on a fixed grid; Use the <code class="xref py py-obj docutils literal notranslate"><span class="pre">width</span></code> parameter
 instead.</li>
-<li><strong>width</strong> – Defines a grid on the interval [0, width] with internal points
+<li><strong>width</strong> &#8211; Defines a grid on the interval [0, width] with internal points
 determined automatically by the solver.</li>
 </ul>
 </td>
@@ -148,12 +144,12 @@ determined automatically by the solver.</li>
 </table>
 <dl class="attribute">
 <dt id="cantera.FreeFlame.flame">
-<code class="descname">flame</code><a class="headerlink" href="#cantera.FreeFlame.flame" title="Permalink to this definition">¶</a></dt>
+<code class="descname">flame</code><a class="headerlink" href="#cantera.FreeFlame.flame" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.FreeFlame.get_flame_speed_reaction_sensitivities">
-<code class="descname">get_flame_speed_reaction_sensitivities</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FreeFlame.get_flame_speed_reaction_sensitivities" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_flame_speed_reaction_sensitivities</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FreeFlame.get_flame_speed_reaction_sensitivities" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Compute the normalized sensitivities of the laminar flame speed
 <span class="math">\(S_u\)</span> with respect to the reaction rate constants <span class="math">\(k_i\)</span>:</p>
 <div class="math">
@@ -162,25 +158,25 @@ determined automatically by the solver.</li>
 
 <dl class="attribute">
 <dt id="cantera.FreeFlame.inlet">
-<code class="descname">inlet</code><a class="headerlink" href="#cantera.FreeFlame.inlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">inlet</code><a class="headerlink" href="#cantera.FreeFlame.inlet" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FreeFlame.outlet">
-<code class="descname">outlet</code><a class="headerlink" href="#cantera.FreeFlame.outlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">outlet</code><a class="headerlink" href="#cantera.FreeFlame.outlet" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.FreeFlame.set_initial_guess">
-<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><em>locs=[0.0, 0.3, 0.5, 1.0]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FreeFlame.set_initial_guess" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><em>locs=[0.0, 0.3, 0.5, 1.0]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FreeFlame.set_initial_guess" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the initial guess for the solution. The adiabatic flame
 temperature and equilibrium composition are computed for the inlet gas
 composition.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>locs</strong> – A list of four locations to define the temperature and mass fraction profiles.
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>locs</strong> &#8211; A list of four locations to define the temperature and mass fraction profiles.
 Profiles rise linearly between the second and third location.
 Locations are given as a fraction of the entire domain</td>
 </tr>
@@ -190,17 +186,17 @@ Locations are given as a fraction of the entire domain</td>
 
 <dl class="method">
 <dt id="cantera.FreeFlame.solve">
-<code class="descname">solve</code><span class="sig-paren">(</span><em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FreeFlame.solve" title="Permalink to this definition">¶</a></dt>
+<code class="descname">solve</code><span class="sig-paren">(</span><em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FreeFlame.solve" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Solve the problem.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>loglevel</strong> – integer flag controlling the amount of diagnostic output. Zero
+<li><strong>loglevel</strong> &#8211; integer flag controlling the amount of diagnostic output. Zero
 suppresses all output, and 5 produces very verbose output.</li>
-<li><strong>refine_grid</strong> – if True, enable grid refinement.</li>
-<li><strong>auto</strong> – if True, sequentially execute the different solution stages
+<li><strong>refine_grid</strong> &#8211; if True, enable grid refinement.</li>
+<li><strong>auto</strong> &#8211; if True, sequentially execute the different solution stages
 and attempt to automatically recover from errors. Attempts to first
 solve on the initial grid with energy enabled. If that does not
 succeed, a fixed-temperature solution will be tried followed by
@@ -219,23 +215,23 @@ will be calculated.</li>
 
 </div>
 <div class="section" id="burnerflame">
-<h3><a class="toc-backref" href="#id23">BurnerFlame</a><a class="headerlink" href="#burnerflame" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id23">BurnerFlame</a><a class="headerlink" href="#burnerflame" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.BurnerFlame">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">BurnerFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.BurnerFlame" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">BurnerFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.BurnerFlame" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.onedim.FlameBase</span></code></p>
 <p>A burner-stabilized flat flame.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>gas</strong> – <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> (using the IdealGas thermodynamic model) used to
+<li><strong>gas</strong> &#8211; <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> (using the IdealGas thermodynamic model) used to
 evaluate all gas properties and reaction rates.</li>
-<li><strong>grid</strong> – A list of points to be used as the initial grid. Not recommended
+<li><strong>grid</strong> &#8211; A list of points to be used as the initial grid. Not recommended
 unless solving only on a fixed grid; Use the <code class="xref py py-obj docutils literal notranslate"><span class="pre">width</span></code> parameter
 instead.</li>
-<li><strong>width</strong> – Defines a grid on the interval [0, width] with internal points
+<li><strong>width</strong> &#8211; Defines a grid on the interval [0, width] with internal points
 determined automatically by the solver.</li>
 </ul>
 </td>
@@ -248,22 +244,22 @@ domains comprising the stack are stored as <code class="docutils literal notrans
 <code class="docutils literal notranslate"><span class="pre">self.flame</span></code>, and <code class="docutils literal notranslate"><span class="pre">self.outlet</span></code>.</p>
 <dl class="attribute">
 <dt id="cantera.BurnerFlame.burner">
-<code class="descname">burner</code><a class="headerlink" href="#cantera.BurnerFlame.burner" title="Permalink to this definition">¶</a></dt>
+<code class="descname">burner</code><a class="headerlink" href="#cantera.BurnerFlame.burner" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.BurnerFlame.flame">
-<code class="descname">flame</code><a class="headerlink" href="#cantera.BurnerFlame.flame" title="Permalink to this definition">¶</a></dt>
+<code class="descname">flame</code><a class="headerlink" href="#cantera.BurnerFlame.flame" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.BurnerFlame.outlet">
-<code class="descname">outlet</code><a class="headerlink" href="#cantera.BurnerFlame.outlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">outlet</code><a class="headerlink" href="#cantera.BurnerFlame.outlet" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.BurnerFlame.set_initial_guess">
-<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.BurnerFlame.set_initial_guess" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.BurnerFlame.set_initial_guess" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the initial guess for the solution. The adiabatic flame
 temperature and equilibrium composition are computed for the burner
 gas composition. The temperature profile rises linearly in the first
@@ -273,17 +269,17 @@ set similarly.</p>
 
 <dl class="method">
 <dt id="cantera.BurnerFlame.solve">
-<code class="descname">solve</code><span class="sig-paren">(</span><em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.BurnerFlame.solve" title="Permalink to this definition">¶</a></dt>
+<code class="descname">solve</code><span class="sig-paren">(</span><em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.BurnerFlame.solve" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Solve the problem.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>loglevel</strong> – integer flag controlling the amount of diagnostic output. Zero
+<li><strong>loglevel</strong> &#8211; integer flag controlling the amount of diagnostic output. Zero
 suppresses all output, and 5 produces very verbose output.</li>
-<li><strong>refine_grid</strong> – if True, enable grid refinement.</li>
-<li><strong>auto</strong> – if True, sequentially execute the different solution stages
+<li><strong>refine_grid</strong> &#8211; if True, enable grid refinement.</li>
+<li><strong>auto</strong> &#8211; if True, sequentially execute the different solution stages
 and attempt to automatically recover from errors. Attempts to first
 solve on the initial grid with energy enabled. If that does not
 succeed, a fixed-temperature solution will be tried followed by
@@ -302,23 +298,23 @@ will be calculated.</li>
 
 </div>
 <div class="section" id="counterflowdiffusionflame">
-<h3><a class="toc-backref" href="#id24">CounterflowDiffusionFlame</a><a class="headerlink" href="#counterflowdiffusionflame" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id24">CounterflowDiffusionFlame</a><a class="headerlink" href="#counterflowdiffusionflame" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.CounterflowDiffusionFlame">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">CounterflowDiffusionFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">CounterflowDiffusionFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.onedim.FlameBase</span></code></p>
 <p>A counterflow diffusion flame</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>gas</strong> – <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> (using the IdealGas thermodynamic model) used to
+<li><strong>gas</strong> &#8211; <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> (using the IdealGas thermodynamic model) used to
 evaluate all gas properties and reaction rates.</li>
-<li><strong>grid</strong> – A list of points to be used as the initial grid. Not recommended
+<li><strong>grid</strong> &#8211; A list of points to be used as the initial grid. Not recommended
 unless solving only on a fixed grid; Use the <code class="xref py py-obj docutils literal notranslate"><span class="pre">width</span></code> parameter
 instead.</li>
-<li><strong>width</strong> – Defines a grid on the interval [0, width] with internal points
+<li><strong>width</strong> &#8211; Defines a grid on the interval [0, width] with internal points
 determined automatically by the solver.</li>
 </ul>
 </td>
@@ -331,24 +327,24 @@ domains comprising the stack are stored as <code class="docutils literal notrans
 <code class="docutils literal notranslate"><span class="pre">self.flame</span></code>, and <code class="docutils literal notranslate"><span class="pre">self.oxidizer_inlet</span></code>.</p>
 <dl class="method">
 <dt id="cantera.CounterflowDiffusionFlame.extinct">
-<code class="descname">extinct</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.extinct" title="Permalink to this definition">¶</a></dt>
+<code class="descname">extinct</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.extinct" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Method overloaded for some flame types to indicate if the flame has been
-extinguished. Base class method always returns ‘False’</p>
+extinguished. Base class method always returns &#8216;False&#8217;</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.CounterflowDiffusionFlame.flame">
-<code class="descname">flame</code><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.flame" title="Permalink to this definition">¶</a></dt>
+<code class="descname">flame</code><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.flame" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.CounterflowDiffusionFlame.fuel_inlet">
-<code class="descname">fuel_inlet</code><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.fuel_inlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">fuel_inlet</code><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.fuel_inlet" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.CounterflowDiffusionFlame.mixture_fraction">
-<code class="descname">mixture_fraction</code><span class="sig-paren">(</span><em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.mixture_fraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mixture_fraction</code><span class="sig-paren">(</span><em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.mixture_fraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Compute the mixture fraction based on element <em>m</em></p>
 <p>The mixture fraction is computed from the elemental mass fraction of
 element <em>m</em>, normalized by its values on the fuel and oxidizer
@@ -361,44 +357,44 @@ inlets:</p>
 
 \]</div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> – The element based on which the mixture fraction is computed,
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> &#8211; The element based on which the mixture fraction is computed,
 may be specified by name or by index</td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">f</span><span class="o">.</span><span class="n">mixture_fraction</span><span class="p">(</span><span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">f</span><span class="o">.</span><span class="n">mixture_fraction</span><span class="p">(</span><span class="s1">'H'</span><span class="p">)</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.CounterflowDiffusionFlame.oxidizer_inlet">
-<code class="descname">oxidizer_inlet</code><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.oxidizer_inlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">oxidizer_inlet</code><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.oxidizer_inlet" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.CounterflowDiffusionFlame.set_initial_guess">
-<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.set_initial_guess" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.set_initial_guess" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the initial guess for the solution. The initial guess is generated
 by assuming infinitely-fast chemistry.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.CounterflowDiffusionFlame.solve">
-<code class="descname">solve</code><span class="sig-paren">(</span><em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.solve" title="Permalink to this definition">¶</a></dt>
+<code class="descname">solve</code><span class="sig-paren">(</span><em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.solve" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Solve the problem.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>loglevel</strong> – integer flag controlling the amount of diagnostic output. Zero
+<li><strong>loglevel</strong> &#8211; integer flag controlling the amount of diagnostic output. Zero
 suppresses all output, and 5 produces very verbose output.</li>
-<li><strong>refine_grid</strong> – if True, enable grid refinement.</li>
-<li><strong>auto</strong> – if True, sequentially execute the different solution stages
+<li><strong>refine_grid</strong> &#8211; if True, enable grid refinement.</li>
+<li><strong>auto</strong> &#8211; if True, sequentially execute the different solution stages
 and attempt to automatically recover from errors. Attempts to first
 solve on the initial grid with energy enabled. If that does not
 succeed, a fixed-temperature solution will be tried followed by
@@ -415,21 +411,21 @@ will be calculated.</li>
 
 <dl class="method">
 <dt id="cantera.CounterflowDiffusionFlame.strain_rate">
-<code class="descname">strain_rate</code><span class="sig-paren">(</span><em>definition</em>, <em>fuel=None</em>, <em>oxidizer='O2'</em>, <em>stoich=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.strain_rate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">strain_rate</code><span class="sig-paren">(</span><em>definition</em>, <em>fuel=None</em>, <em>oxidizer='O2'</em>, <em>stoich=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowDiffusionFlame.strain_rate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the axial strain rate of the counterflow diffusion flame in 1/s.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>definition</strong> – The definition of the strain rate to be calculated. Options are:
+<li><strong>definition</strong> &#8211; The definition of the strain rate to be calculated. Options are:
 <code class="docutils literal notranslate"><span class="pre">mean</span></code>, <code class="docutils literal notranslate"><span class="pre">max</span></code>, <code class="docutils literal notranslate"><span class="pre">stoichiometric</span></code>, <code class="docutils literal notranslate"><span class="pre">potential_flow_fuel</span></code>, and
 <code class="docutils literal notranslate"><span class="pre">potential_flow_oxidizer</span></code>.</li>
-<li><strong>fuel</strong> – The fuel species. Used only if <em>definition</em> is
+<li><strong>fuel</strong> &#8211; The fuel species. Used only if <em>definition</em> is
 <code class="docutils literal notranslate"><span class="pre">stoichiometric</span></code>.</li>
-<li><strong>oxidizer</strong> – The oxidizer species, default <code class="docutils literal notranslate"><span class="pre">O2</span></code>. Used only if
+<li><strong>oxidizer</strong> &#8211; The oxidizer species, default <code class="docutils literal notranslate"><span class="pre">O2</span></code>. Used only if
 <em>definition</em> is <code class="docutils literal notranslate"><span class="pre">stoichiometric</span></code>.</li>
-<li><strong>stoich</strong> – The molar stoichiometric oxidizer-to-fuel ratio.
+<li><strong>stoich</strong> &#8211; The molar stoichiometric oxidizer-to-fuel ratio.
 Can be omitted if the oxidizer is <code class="docutils literal notranslate"><span class="pre">O2</span></code>. Used only if <em>definition</em>
 is <code class="docutils literal notranslate"><span class="pre">stoichiometric</span></code>.</li>
 </ul>
@@ -462,7 +458,7 @@ Possible options are:</p>
 \right|_{\phi=1} \right|\]</div>
 <p>This method uses the additional keyword arguments <em>fuel</em>,
 <em>oxidizer</em>, and <em>stoich</em>.</p>
-<div class="last highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">f</span><span class="o">.</span><span class="n">strain_rate</span><span class="p">(</span><span class="s1">&#39;stoichiometric&#39;</span><span class="p">,</span> <span class="n">fuel</span><span class="o">=</span><span class="s1">&#39;H2&#39;</span><span class="p">,</span> <span class="n">oxidizer</span><span class="o">=</span><span class="s1">&#39;O2&#39;</span><span class="p">,</span>
+<div class="last highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">f</span><span class="o">.</span><span class="n">strain_rate</span><span class="p">(</span><span class="s1">'stoichiometric'</span><span class="p">,</span> <span class="n">fuel</span><span class="o">=</span><span class="s1">'H2'</span><span class="p">,</span> <span class="n">oxidizer</span><span class="o">=</span><span class="s1">'O2'</span><span class="p">,</span>
 <span class="go">                  stoich=0.5)</span>
 </pre></div>
 </div>
@@ -490,22 +486,22 @@ condition at the oxidizer inlet.</p>
 
 </div>
 <div class="section" id="counterflowpremixedflame">
-<h3><a class="toc-backref" href="#id25">CounterflowPremixedFlame</a><a class="headerlink" href="#counterflowpremixedflame" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id25">CounterflowPremixedFlame</a><a class="headerlink" href="#counterflowpremixedflame" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.CounterflowPremixedFlame">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">CounterflowPremixedFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowPremixedFlame" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">CounterflowPremixedFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowPremixedFlame" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.onedim.FlameBase</span></code></p>
 <p>A premixed counterflow flame</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>gas</strong> – <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> (using the IdealGas thermodynamic model) used to
+<li><strong>gas</strong> &#8211; <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> (using the IdealGas thermodynamic model) used to
 evaluate all gas properties and reaction rates.</li>
-<li><strong>grid</strong> – Array of initial grid points. Not recommended unless solving only on
+<li><strong>grid</strong> &#8211; Array of initial grid points. Not recommended unless solving only on
 a fixed grid; Use the <code class="xref py py-obj docutils literal notranslate"><span class="pre">width</span></code> parameter instead.</li>
-<li><strong>width</strong> – Defines a grid on the interval [0, width] with internal points
+<li><strong>width</strong> &#8211; Defines a grid on the interval [0, width] with internal points
 determined automatically by the solver.</li>
 </ul>
 </td>
@@ -518,22 +514,22 @@ domains comprising the stack are stored as <code class="docutils literal notrans
 <code class="docutils literal notranslate"><span class="pre">self.flame</span></code>, and <code class="docutils literal notranslate"><span class="pre">self.products</span></code>.</p>
 <dl class="attribute">
 <dt id="cantera.CounterflowPremixedFlame.flame">
-<code class="descname">flame</code><a class="headerlink" href="#cantera.CounterflowPremixedFlame.flame" title="Permalink to this definition">¶</a></dt>
+<code class="descname">flame</code><a class="headerlink" href="#cantera.CounterflowPremixedFlame.flame" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.CounterflowPremixedFlame.products">
-<code class="descname">products</code><a class="headerlink" href="#cantera.CounterflowPremixedFlame.products" title="Permalink to this definition">¶</a></dt>
+<code class="descname">products</code><a class="headerlink" href="#cantera.CounterflowPremixedFlame.products" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.CounterflowPremixedFlame.reactants">
-<code class="descname">reactants</code><a class="headerlink" href="#cantera.CounterflowPremixedFlame.reactants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactants</code><a class="headerlink" href="#cantera.CounterflowPremixedFlame.reactants" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.CounterflowPremixedFlame.set_initial_guess">
-<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><em>equilibrate=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowPremixedFlame.set_initial_guess" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><em>equilibrate=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.CounterflowPremixedFlame.set_initial_guess" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the initial guess for the solution.</p>
 <p>If <code class="xref py py-obj docutils literal notranslate"><span class="pre">equilibrate</span></code> is True, then the products composition and temperature
 will be set to the equilibrium state of the reactants mixture.</p>
@@ -543,25 +539,25 @@ will be set to the equilibrium state of the reactants mixture.</p>
 
 </div>
 <div class="section" id="impingingjet">
-<h3><a class="toc-backref" href="#id26">ImpingingJet</a><a class="headerlink" href="#impingingjet" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id26">ImpingingJet</a><a class="headerlink" href="#impingingjet" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ImpingingJet">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ImpingingJet</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ImpingingJet" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ImpingingJet</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ImpingingJet" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.onedim.FlameBase</span></code></p>
 <p>An axisymmetric flow impinging on a surface at normal incidence.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>gas</strong> – <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> (using the IdealGas thermodynamic model) used to
+<li><strong>gas</strong> &#8211; <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> (using the IdealGas thermodynamic model) used to
 evaluate all gas properties and reaction rates.</li>
-<li><strong>grid</strong> – A list of points to be used as the initial grid. Not recommended
+<li><strong>grid</strong> &#8211; A list of points to be used as the initial grid. Not recommended
 unless solving only on the initial grid; Use the <code class="xref py py-obj docutils literal notranslate"><span class="pre">width</span></code> parameter
 instead.</li>
-<li><strong>width</strong> – Defines a grid on the interval [0, width] with internal points
+<li><strong>width</strong> &#8211; Defines a grid on the interval [0, width] with internal points
 determined automatically by the solver.</li>
-<li><strong>surface</strong> – A Kinetics object used to compute any surface reactions.</li>
+<li><strong>surface</strong> &#8211; A Kinetics object used to compute any surface reactions.</li>
 </ul>
 </td>
 </tr>
@@ -573,18 +569,18 @@ domains comprising the stack are stored as <code class="docutils literal notrans
 <code class="docutils literal notranslate"><span class="pre">self.flame</span></code>, and <code class="docutils literal notranslate"><span class="pre">self.surface</span></code>.</p>
 <dl class="attribute">
 <dt id="cantera.ImpingingJet.flame">
-<code class="descname">flame</code><a class="headerlink" href="#cantera.ImpingingJet.flame" title="Permalink to this definition">¶</a></dt>
+<code class="descname">flame</code><a class="headerlink" href="#cantera.ImpingingJet.flame" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ImpingingJet.inlet">
-<code class="descname">inlet</code><a class="headerlink" href="#cantera.ImpingingJet.inlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">inlet</code><a class="headerlink" href="#cantera.ImpingingJet.inlet" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.ImpingingJet.set_initial_guess">
-<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><em>products='inlet'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ImpingingJet.set_initial_guess" title="Permalink to this definition">¶</a></dt>
-<dd><p>Set the initial guess for the solution. If products = ‘equil’, then
+<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><em>products='inlet'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ImpingingJet.set_initial_guess" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Set the initial guess for the solution. If products = &#8216;equil&#8217;, then
 the equilibrium composition at the adiabatic flame temperature will be
 used to form the initial guess. Otherwise the inlet composition will
 be used.</p>
@@ -592,44 +588,44 @@ be used.</p>
 
 <dl class="attribute">
 <dt id="cantera.ImpingingJet.surface">
-<code class="descname">surface</code><a class="headerlink" href="#cantera.ImpingingJet.surface" title="Permalink to this definition">¶</a></dt>
+<code class="descname">surface</code><a class="headerlink" href="#cantera.ImpingingJet.surface" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="ionfreeflame">
-<h3><a class="toc-backref" href="#id27">IonFreeFlame</a><a class="headerlink" href="#ionfreeflame" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id27">IonFreeFlame</a><a class="headerlink" href="#ionfreeflame" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.IonFreeFlame">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IonFreeFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonFreeFlame" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IonFreeFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonFreeFlame" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.onedim.IonFlameBase</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.onedim.FreeFlame</span></code></p>
 <p>A freely-propagating flame with ionized gas.</p>
 <dl class="attribute">
 <dt id="cantera.IonFreeFlame.E">
-<code class="descname">E</code><a class="headerlink" href="#cantera.IonFreeFlame.E" title="Permalink to this definition">¶</a></dt>
+<code class="descname">E</code><a class="headerlink" href="#cantera.IonFreeFlame.E" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array containing the electric field strength at each point.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IonFreeFlame.electric_field_enabled">
-<code class="descname">electric_field_enabled</code><a class="headerlink" href="#cantera.IonFreeFlame.electric_field_enabled" title="Permalink to this definition">¶</a></dt>
-<dd><p>Get/Set whether or not to solve the Poisson’s equation.</p>
+<code class="descname">electric_field_enabled</code><a class="headerlink" href="#cantera.IonFreeFlame.electric_field_enabled" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Get/Set whether or not to solve the Poisson&#8217;s equation.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IonFreeFlame.solve">
-<code class="descname">solve</code><span class="sig-paren">(</span><em>self</em>, <em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonFreeFlame.solve" title="Permalink to this definition">¶</a></dt>
+<code class="descname">solve</code><span class="sig-paren">(</span><em>self</em>, <em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonFreeFlame.solve" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Solve the problem.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>loglevel</strong> – integer flag controlling the amount of diagnostic output. Zero
+<li><strong>loglevel</strong> &#8211; integer flag controlling the amount of diagnostic output. Zero
 suppresses all output, and 5 produces very verbose output.</li>
-<li><strong>refine_grid</strong> – if True, enable grid refinement.</li>
-<li><strong>auto</strong> – if True, sequentially execute the different solution stages
+<li><strong>refine_grid</strong> &#8211; if True, enable grid refinement.</li>
+<li><strong>auto</strong> &#8211; if True, sequentially execute the different solution stages
 and attempt to automatically recover from errors. Attempts to first
 solve on the initial grid with energy enabled. If that does not
 succeed, a fixed-temperature solution will be tried followed by
@@ -646,54 +642,54 @@ will be calculated.</li>
 
 <dl class="attribute">
 <dt id="cantera.IonFreeFlame.flame">
-<code class="descname">flame</code><a class="headerlink" href="#cantera.IonFreeFlame.flame" title="Permalink to this definition">¶</a></dt>
+<code class="descname">flame</code><a class="headerlink" href="#cantera.IonFreeFlame.flame" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IonFreeFlame.inlet">
-<code class="descname">inlet</code><a class="headerlink" href="#cantera.IonFreeFlame.inlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">inlet</code><a class="headerlink" href="#cantera.IonFreeFlame.inlet" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IonFreeFlame.outlet">
-<code class="descname">outlet</code><a class="headerlink" href="#cantera.IonFreeFlame.outlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">outlet</code><a class="headerlink" href="#cantera.IonFreeFlame.outlet" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="ionburnerflame">
-<h3><a class="toc-backref" href="#id28">IonBurnerFlame</a><a class="headerlink" href="#ionburnerflame" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id28">IonBurnerFlame</a><a class="headerlink" href="#ionburnerflame" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.IonBurnerFlame">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IonBurnerFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonBurnerFlame" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IonBurnerFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>grid=None</em>, <em>width=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonBurnerFlame" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.onedim.IonFlameBase</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera.onedim.BurnerFlame</span></code></p>
 <p>A burner-stabilized flat flame with ionized gas.</p>
 <dl class="attribute">
 <dt id="cantera.IonBurnerFlame.E">
-<code class="descname">E</code><a class="headerlink" href="#cantera.IonBurnerFlame.E" title="Permalink to this definition">¶</a></dt>
+<code class="descname">E</code><a class="headerlink" href="#cantera.IonBurnerFlame.E" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array containing the electric field strength at each point.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IonBurnerFlame.electric_field_enabled">
-<code class="descname">electric_field_enabled</code><a class="headerlink" href="#cantera.IonBurnerFlame.electric_field_enabled" title="Permalink to this definition">¶</a></dt>
-<dd><p>Get/Set whether or not to solve the Poisson’s equation.</p>
+<code class="descname">electric_field_enabled</code><a class="headerlink" href="#cantera.IonBurnerFlame.electric_field_enabled" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Get/Set whether or not to solve the Poisson&#8217;s equation.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IonBurnerFlame.solve">
-<code class="descname">solve</code><span class="sig-paren">(</span><em>self</em>, <em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonBurnerFlame.solve" title="Permalink to this definition">¶</a></dt>
+<code class="descname">solve</code><span class="sig-paren">(</span><em>self</em>, <em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonBurnerFlame.solve" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Solve the problem.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>loglevel</strong> – integer flag controlling the amount of diagnostic output. Zero
+<li><strong>loglevel</strong> &#8211; integer flag controlling the amount of diagnostic output. Zero
 suppresses all output, and 5 produces very verbose output.</li>
-<li><strong>refine_grid</strong> – if True, enable grid refinement.</li>
-<li><strong>auto</strong> – if True, sequentially execute the different solution stages
+<li><strong>refine_grid</strong> &#8211; if True, enable grid refinement.</li>
+<li><strong>auto</strong> &#8211; if True, sequentially execute the different solution stages
 and attempt to automatically recover from errors. Attempts to first
 solve on the initial grid with energy enabled. If that does not
 succeed, a fixed-temperature solution will be tried followed by
@@ -710,17 +706,17 @@ will be calculated.</li>
 
 <dl class="attribute">
 <dt id="cantera.IonBurnerFlame.burner">
-<code class="descname">burner</code><a class="headerlink" href="#cantera.IonBurnerFlame.burner" title="Permalink to this definition">¶</a></dt>
+<code class="descname">burner</code><a class="headerlink" href="#cantera.IonBurnerFlame.burner" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IonBurnerFlame.flame">
-<code class="descname">flame</code><a class="headerlink" href="#cantera.IonBurnerFlame.flame" title="Permalink to this definition">¶</a></dt>
+<code class="descname">flame</code><a class="headerlink" href="#cantera.IonBurnerFlame.flame" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IonBurnerFlame.outlet">
-<code class="descname">outlet</code><a class="headerlink" href="#cantera.IonBurnerFlame.outlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">outlet</code><a class="headerlink" href="#cantera.IonBurnerFlame.outlet" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 </dd></dl>
@@ -728,12 +724,12 @@ will be calculated.</li>
 </div>
 </div>
 <div class="section" id="flow-domains">
-<h2><a class="toc-backref" href="#id29">Flow Domains</a><a class="headerlink" href="#flow-domains" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id29">Flow Domains</a><a class="headerlink" href="#flow-domains" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="idealgasflow">
-<h3><a class="toc-backref" href="#id30">IdealGasFlow</a><a class="headerlink" href="#idealgasflow" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id30">IdealGasFlow</a><a class="headerlink" href="#idealgasflow" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.IdealGasFlow">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IdealGasFlow</code><span class="sig-paren">(</span><em>thermo</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IdealGasFlow</code><span class="sig-paren">(</span><em>thermo</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera._FlowBase</span></code></p>
 <p>An ideal gas flow domain. Functions <a class="reference internal" href="#cantera.IdealGasFlow.set_free_flow" title="cantera.IdealGasFlow.set_free_flow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_free_flow</span></code></a> and
 <a class="reference internal" href="#cantera.IdealGasFlow.set_axisymmetric_flow" title="cantera.IdealGasFlow.set_axisymmetric_flow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_axisymmetric_flow</span></code></a> can be used to set different type of flow.</p>
@@ -763,15 +759,15 @@ equations assume an ideal gas mixture.  Arbitrary chemistry is allowed, as
 well as arbitrary variation of the transport properties.</p>
 <dl class="attribute">
 <dt id="cantera.IdealGasFlow.P">
-<code class="descname">P</code><a class="headerlink" href="#cantera.IdealGasFlow.P" title="Permalink to this definition">¶</a></dt>
+<code class="descname">P</code><a class="headerlink" href="#cantera.IdealGasFlow.P" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Pressure [Pa]</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.bounds">
-<code class="descname">bounds</code><span class="sig-paren">(</span><em>self</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.bounds" title="Permalink to this definition">¶</a></dt>
+<code class="descname">bounds</code><span class="sig-paren">(</span><em>self</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.bounds" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the (lower, upper) bounds for a solution component.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">d</span><span class="o">.</span><span class="n">bounds</span><span class="p">(</span><span class="s1">&#39;T&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">d</span><span class="o">.</span><span class="n">bounds</span><span class="p">(</span><span class="s1">'T'</span><span class="p">)</span>
 <span class="go">(200.0, 5000.0)</span>
 </pre></div>
 </div>
@@ -779,86 +775,86 @@ well as arbitrary variation of the transport properties.</p>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.component_index">
-<code class="descname">component_index</code><span class="sig-paren">(</span><em>self</em>, <em>str name</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.component_index" title="Permalink to this definition">¶</a></dt>
-<dd><p>Index of the component with name ‘name’</p>
+<code class="descname">component_index</code><span class="sig-paren">(</span><em>self</em>, <em>str name</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.component_index" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Index of the component with name &#8216;name&#8217;</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.component_name">
-<code class="descname">component_name</code><span class="sig-paren">(</span><em>self</em>, <em>int n</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.component_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">component_name</code><span class="sig-paren">(</span><em>self</em>, <em>int n</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.component_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Name of the nth component.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IdealGasFlow.component_names">
-<code class="descname">component_names</code><a class="headerlink" href="#cantera.IdealGasFlow.component_names" title="Permalink to this definition">¶</a></dt>
+<code class="descname">component_names</code><a class="headerlink" href="#cantera.IdealGasFlow.component_names" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>List of the names of all components of this domain.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IdealGasFlow.energy_enabled">
-<code class="descname">energy_enabled</code><a class="headerlink" href="#cantera.IdealGasFlow.energy_enabled" title="Permalink to this definition">¶</a></dt>
+<code class="descname">energy_enabled</code><a class="headerlink" href="#cantera.IdealGasFlow.energy_enabled" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Determines whether or not to solve the energy equation.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IdealGasFlow.grid">
-<code class="descname">grid</code><a class="headerlink" href="#cantera.IdealGasFlow.grid" title="Permalink to this definition">¶</a></dt>
+<code class="descname">grid</code><a class="headerlink" href="#cantera.IdealGasFlow.grid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The grid for this domain</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IdealGasFlow.have_user_tolerances">
-<code class="descname">have_user_tolerances</code><a class="headerlink" href="#cantera.IdealGasFlow.have_user_tolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">have_user_tolerances</code><a class="headerlink" href="#cantera.IdealGasFlow.have_user_tolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>have_user_tolerances: __builtin__.bool</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IdealGasFlow.index">
-<code class="descname">index</code><a class="headerlink" href="#cantera.IdealGasFlow.index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">index</code><a class="headerlink" href="#cantera.IdealGasFlow.index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Index of this domain in a stack. Returns -1 if this domain is not part
 of a stack.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IdealGasFlow.n_components">
-<code class="descname">n_components</code><a class="headerlink" href="#cantera.IdealGasFlow.n_components" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_components</code><a class="headerlink" href="#cantera.IdealGasFlow.n_components" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of solution components at each grid point.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IdealGasFlow.n_points">
-<code class="descname">n_points</code><a class="headerlink" href="#cantera.IdealGasFlow.n_points" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_points</code><a class="headerlink" href="#cantera.IdealGasFlow.n_points" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of grid points belonging to this domain.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IdealGasFlow.name">
-<code class="descname">name</code><a class="headerlink" href="#cantera.IdealGasFlow.name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">name</code><a class="headerlink" href="#cantera.IdealGasFlow.name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The name / id of this domain</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IdealGasFlow.radiation_enabled">
-<code class="descname">radiation_enabled</code><a class="headerlink" href="#cantera.IdealGasFlow.radiation_enabled" title="Permalink to this definition">¶</a></dt>
+<code class="descname">radiation_enabled</code><a class="headerlink" href="#cantera.IdealGasFlow.radiation_enabled" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Determines whether or not to include radiative heat transfer</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.set_axisymmetric_flow">
-<code class="descname">set_axisymmetric_flow</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_axisymmetric_flow" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_axisymmetric_flow</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_axisymmetric_flow" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set flow configuration for axisymmetric counterflow or burner-stabilized
 flames, using specified inlet mass fluxes.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.set_boundary_emissivities">
-<code class="descname">set_boundary_emissivities</code><span class="sig-paren">(</span><em>self</em>, <em>e_left</em>, <em>e_right</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_boundary_emissivities" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_boundary_emissivities</code><span class="sig-paren">(</span><em>self</em>, <em>e_left</em>, <em>e_right</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_boundary_emissivities" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.set_bounds">
-<code class="descname">set_bounds</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_bounds" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_bounds</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_bounds" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the lower and upper bounds on the solution.</p>
 <p>The argument list should consist of keyword/value pairs, with
 component names as keywords and (lower_bound, upper_bound) tuples as
@@ -872,22 +868,22 @@ stand for all species mass fractions in flow domains.</p>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.set_default_tolerances">
-<code class="descname">set_default_tolerances</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_default_tolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_default_tolerances</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_default_tolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set all tolerances to their default values</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.set_fixed_temp_profile">
-<code class="descname">set_fixed_temp_profile</code><span class="sig-paren">(</span><em>self</em>, <em>pos</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_fixed_temp_profile" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_fixed_temp_profile</code><span class="sig-paren">(</span><em>self</em>, <em>pos</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_fixed_temp_profile" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the fixed temperature profile. This profile is used
 whenever the energy equation is disabled.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>pos</strong> – arrray of relative positions from 0 to 1</li>
-<li><strong>temp</strong> – array of temperature values</li>
+<li><strong>pos</strong> &#8211; arrray of relative positions from 0 to 1</li>
+<li><strong>temp</strong> &#8211; array of temperature values</li>
 </ul>
 </td>
 </tr>
@@ -901,7 +897,7 @@ whenever the energy equation is disabled.</p>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.set_free_flow">
-<code class="descname">set_free_flow</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_free_flow" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_free_flow</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_free_flow" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set flow configuration for freely-propagating flames, using an internal
 point with a fixed temperature as the condition to determine the inlet
 mass flux.</p>
@@ -909,7 +905,7 @@ mass flux.</p>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.set_steady_tolerances">
-<code class="descname">set_steady_tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>abs=None</em>, <em>rel=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_steady_tolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_steady_tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>abs=None</em>, <em>rel=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_steady_tolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the error tolerances for the steady-state problem.</p>
 <p>The argument list should consist of keyword/value pairs, with
 component names as keywords and (rtol, atol) tuples as the values.
@@ -922,7 +918,7 @@ relative tolerances for each solution component.</p>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.set_transient_tolerances">
-<code class="descname">set_transient_tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>abs=None</em>, <em>rel=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_transient_tolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_transient_tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>abs=None</em>, <em>rel=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_transient_tolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the error tolerances for the steady-state problem.</p>
 <p>The argument list should consist of keyword/value pairs, with
 component names as keywords and (rtol, atol) tuples as the values.
@@ -935,13 +931,13 @@ relative tolerances for each solution component.</p>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.set_transport">
-<code class="descname">set_transport</code><span class="sig-paren">(</span><em>self</em>, <em>_SolutionBase phase</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_transport" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_transport</code><span class="sig-paren">(</span><em>self</em>, <em>_SolutionBase phase</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.set_transport" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object used for calculating transport properties.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.IdealGasFlow.soret_enabled">
-<code class="descname">soret_enabled</code><a class="headerlink" href="#cantera.IdealGasFlow.soret_enabled" title="Permalink to this definition">¶</a></dt>
+<code class="descname">soret_enabled</code><a class="headerlink" href="#cantera.IdealGasFlow.soret_enabled" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Determines whether or not to include diffusive mass fluxes due to the
 Soret effect. Enabling this option works only when using the
 multicomponent transport model.</p>
@@ -949,38 +945,38 @@ multicomponent transport model.</p>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.steady_abstol">
-<code class="descname">steady_abstol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.steady_abstol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">steady_abstol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.steady_abstol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the absolute error tolerance for the steady state problem for a
 specified solution component, or all components if none is specified.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.steady_reltol">
-<code class="descname">steady_reltol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.steady_reltol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">steady_reltol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.steady_reltol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the relative error tolerance for the steady state problem for a
 specified solution component, or all components if none is specified.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.tolerances">
-<code class="descname">tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.tolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.tolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the (relative, absolute) error tolerances for a solution
 component.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">rtol</span><span class="p">,</span> <span class="n">atol</span> <span class="o">=</span> <span class="n">d</span><span class="o">.</span><span class="n">tolerances</span><span class="p">(</span><span class="s1">&#39;u&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">rtol</span><span class="p">,</span> <span class="n">atol</span> <span class="o">=</span> <span class="n">d</span><span class="o">.</span><span class="n">tolerances</span><span class="p">(</span><span class="s1">'u'</span><span class="p">)</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.transient_abstol">
-<code class="descname">transient_abstol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.transient_abstol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">transient_abstol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.transient_abstol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the absolute error tolerance for the transient problem for a
 specified solution component, or all components if none is specified.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IdealGasFlow.transient_reltol">
-<code class="descname">transient_reltol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.transient_reltol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">transient_reltol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasFlow.transient_reltol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the relative error tolerance for the transient problem for a
 specified solution component, or all components if none is specified.</p>
 </dd></dl>
@@ -989,37 +985,37 @@ specified solution component, or all components if none is specified.</p>
 
 </div>
 <div class="section" id="ionflow">
-<h3><a class="toc-backref" href="#id31">IonFlow</a><a class="headerlink" href="#ionflow" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id31">IonFlow</a><a class="headerlink" href="#ionflow" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.IonFlow">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IonFlow</code><span class="sig-paren">(</span><em>thermo</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonFlow" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IonFlow</code><span class="sig-paren">(</span><em>thermo</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonFlow" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera._FlowBase</span></code></p>
 <p>An ion flow domain.</p>
 <p>In an ion flow dommain, the electric drift is added to the diffusion flux</p>
 <dl class="attribute">
 <dt id="cantera.IonFlow.electric_field_enabled">
-<code class="descname">electric_field_enabled</code><a class="headerlink" href="#cantera.IonFlow.electric_field_enabled" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electric_field_enabled</code><a class="headerlink" href="#cantera.IonFlow.electric_field_enabled" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Determines whether or not to solve the energy equation.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.IonFlow.set_default_tolerances">
-<code class="descname">set_default_tolerances</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonFlow.set_default_tolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_default_tolerances</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonFlow.set_default_tolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.IonFlow.set_solving_stage">
-<code class="descname">set_solving_stage</code><span class="sig-paren">(</span><em>self</em>, <em>stage</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonFlow.set_solving_stage" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_solving_stage</code><span class="sig-paren">(</span><em>self</em>, <em>stage</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IonFlow.set_solving_stage" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="freeflow">
-<h3><a class="toc-backref" href="#id32">FreeFlow</a><a class="headerlink" href="#freeflow" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id32">FreeFlow</a><a class="headerlink" href="#freeflow" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.FreeFlow">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FreeFlow</code><span class="sig-paren">(</span><em>thermo</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FreeFlow" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FreeFlow</code><span class="sig-paren">(</span><em>thermo</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FreeFlow" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.IdealGasFlow</span></code></p>
 <p>FreeFlow(<a href="#id1"><span class="problematic" id="id2">*</span></a>args, <a href="#id3"><span class="problematic" id="id4">**</span></a>kwargs)</p>
 <div class="deprecated">
@@ -1030,10 +1026,10 @@ call the <code class="docutils literal notranslate"><span class="pre">set_free_f
 
 </div>
 <div class="section" id="axisymmetricstagnationflow">
-<h3><a class="toc-backref" href="#id33">AxisymmetricStagnationFlow</a><a class="headerlink" href="#axisymmetricstagnationflow" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id33">AxisymmetricStagnationFlow</a><a class="headerlink" href="#axisymmetricstagnationflow" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.AxisymmetricStagnationFlow">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">AxisymmetricStagnationFlow</code><span class="sig-paren">(</span><em>thermo</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.AxisymmetricStagnationFlow" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">AxisymmetricStagnationFlow</code><span class="sig-paren">(</span><em>thermo</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.AxisymmetricStagnationFlow" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.IdealGasFlow</span></code></p>
 <p>AxisymmetricStagnationFlow(<a href="#id5"><span class="problematic" id="id6">*</span></a>args, <a href="#id7"><span class="problematic" id="id8">**</span></a>kwargs)</p>
 <div class="deprecated">
@@ -1045,19 +1041,19 @@ call the <code class="docutils literal notranslate"><span class="pre">set_axisym
 </div>
 </div>
 <div class="section" id="boundaries">
-<h2><a class="toc-backref" href="#id34">Boundaries</a><a class="headerlink" href="#boundaries" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id34">Boundaries</a><a class="headerlink" href="#boundaries" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="inlet1d">
-<h3><a class="toc-backref" href="#id35">Inlet1D</a><a class="headerlink" href="#inlet1d" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id35">Inlet1D</a><a class="headerlink" href="#inlet1d" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Inlet1D">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Inlet1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Inlet1D" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Inlet1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Inlet1D" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Boundary1D</span></code></p>
 <p>A one-dimensional inlet. Note that an inlet can only be a terminal
 domain - it must be either the leftmost or rightmost domain in a
 stack.</p>
 <dl class="attribute">
 <dt id="cantera.Inlet1D.spread_rate">
-<code class="descname">spread_rate</code><a class="headerlink" href="#cantera.Inlet1D.spread_rate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">spread_rate</code><a class="headerlink" href="#cantera.Inlet1D.spread_rate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/set the tangential velocity gradient [1/s] at this boundary.</p>
 </dd></dl>
 
@@ -1065,10 +1061,10 @@ stack.</p>
 
 </div>
 <div class="section" id="outlet1d">
-<h3><a class="toc-backref" href="#id36">Outlet1D</a><a class="headerlink" href="#outlet1d" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id36">Outlet1D</a><a class="headerlink" href="#outlet1d" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Outlet1D">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Outlet1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Outlet1D" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Outlet1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Outlet1D" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Boundary1D</span></code></p>
 <p>A one-dimensional outlet. An outlet imposes a zero-gradient boundary
 condition on the flow.</p>
@@ -1076,51 +1072,51 @@ condition on the flow.</p>
 
 </div>
 <div class="section" id="outletreservoir1d">
-<h3><a class="toc-backref" href="#id37">OutletReservoir1D</a><a class="headerlink" href="#outletreservoir1d" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id37">OutletReservoir1D</a><a class="headerlink" href="#outletreservoir1d" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.OutletReservoir1D">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">OutletReservoir1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.OutletReservoir1D" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">OutletReservoir1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.OutletReservoir1D" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Boundary1D</span></code></p>
 <p>A one-dimensional outlet into a reservoir.</p>
 </dd></dl>
 
 </div>
 <div class="section" id="symmetryplane1d">
-<h3><a class="toc-backref" href="#id38">SymmetryPlane1D</a><a class="headerlink" href="#symmetryplane1d" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id38">SymmetryPlane1D</a><a class="headerlink" href="#symmetryplane1d" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.SymmetryPlane1D">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">SymmetryPlane1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SymmetryPlane1D" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">SymmetryPlane1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SymmetryPlane1D" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Boundary1D</span></code></p>
 <p>A symmetry plane.</p>
 </dd></dl>
 
 </div>
 <div class="section" id="surface1d">
-<h3><a class="toc-backref" href="#id39">Surface1D</a><a class="headerlink" href="#surface1d" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id39">Surface1D</a><a class="headerlink" href="#surface1d" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Surface1D">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Surface1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Surface1D" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Surface1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Surface1D" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Boundary1D</span></code></p>
 <p>A solid surface.</p>
 </dd></dl>
 
 </div>
 <div class="section" id="reactingsurface1d">
-<h3><a class="toc-backref" href="#id40">ReactingSurface1D</a><a class="headerlink" href="#reactingsurface1d" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id40">ReactingSurface1D</a><a class="headerlink" href="#reactingsurface1d" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ReactingSurface1D">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ReactingSurface1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactingSurface1D" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ReactingSurface1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactingSurface1D" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Boundary1D</span></code></p>
 <p>A reacting solid surface.</p>
 <dl class="attribute">
 <dt id="cantera.ReactingSurface1D.coverage_enabled">
-<code class="descname">coverage_enabled</code><a class="headerlink" href="#cantera.ReactingSurface1D.coverage_enabled" title="Permalink to this definition">¶</a></dt>
+<code class="descname">coverage_enabled</code><a class="headerlink" href="#cantera.ReactingSurface1D.coverage_enabled" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Controls whether or not to solve the surface coverage equations.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactingSurface1D.set_kinetics">
-<code class="descname">set_kinetics</code><span class="sig-paren">(</span><em>self</em>, <em>Kinetics kin</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactingSurface1D.set_kinetics" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_kinetics</code><span class="sig-paren">(</span><em>self</em>, <em>Kinetics kin</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactingSurface1D.set_kinetics" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the kinetics manager (surface reaction mechanism object).</p>
 </dd></dl>
 
@@ -1129,19 +1125,19 @@ condition on the flow.</p>
 </div>
 </div>
 <div class="section" id="base-classes">
-<h2><a class="toc-backref" href="#id41">Base Classes</a><a class="headerlink" href="#base-classes" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id41">Base Classes</a><a class="headerlink" href="#base-classes" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="domain1d">
-<h3><a class="toc-backref" href="#id42">Domain1D</a><a class="headerlink" href="#domain1d" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id42">Domain1D</a><a class="headerlink" href="#domain1d" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Domain1D">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Domain1D</code><span class="sig-paren">(</span><em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Domain1D</code><span class="sig-paren">(</span><em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>Domain1D(_SolutionBase phase, name=None, <a href="#id9"><span class="problematic" id="id10">*</span></a>args, <a href="#id11"><span class="problematic" id="id12">**</span></a>kwargs)</p>
 <dl class="method">
 <dt id="cantera.Domain1D.bounds">
-<code class="descname">bounds</code><span class="sig-paren">(</span><em>self</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.bounds" title="Permalink to this definition">¶</a></dt>
+<code class="descname">bounds</code><span class="sig-paren">(</span><em>self</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.bounds" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the (lower, upper) bounds for a solution component.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">d</span><span class="o">.</span><span class="n">bounds</span><span class="p">(</span><span class="s1">&#39;T&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">d</span><span class="o">.</span><span class="n">bounds</span><span class="p">(</span><span class="s1">'T'</span><span class="p">)</span>
 <span class="go">(200.0, 5000.0)</span>
 </pre></div>
 </div>
@@ -1149,62 +1145,62 @@ condition on the flow.</p>
 
 <dl class="method">
 <dt id="cantera.Domain1D.component_index">
-<code class="descname">component_index</code><span class="sig-paren">(</span><em>self</em>, <em>str name</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.component_index" title="Permalink to this definition">¶</a></dt>
-<dd><p>Index of the component with name ‘name’</p>
+<code class="descname">component_index</code><span class="sig-paren">(</span><em>self</em>, <em>str name</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.component_index" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Index of the component with name &#8216;name&#8217;</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Domain1D.component_name">
-<code class="descname">component_name</code><span class="sig-paren">(</span><em>self</em>, <em>int n</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.component_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">component_name</code><span class="sig-paren">(</span><em>self</em>, <em>int n</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.component_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Name of the nth component.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Domain1D.component_names">
-<code class="descname">component_names</code><a class="headerlink" href="#cantera.Domain1D.component_names" title="Permalink to this definition">¶</a></dt>
+<code class="descname">component_names</code><a class="headerlink" href="#cantera.Domain1D.component_names" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>List of the names of all components of this domain.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Domain1D.grid">
-<code class="descname">grid</code><a class="headerlink" href="#cantera.Domain1D.grid" title="Permalink to this definition">¶</a></dt>
+<code class="descname">grid</code><a class="headerlink" href="#cantera.Domain1D.grid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The grid for this domain</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Domain1D.have_user_tolerances">
-<code class="descname">have_user_tolerances</code><a class="headerlink" href="#cantera.Domain1D.have_user_tolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">have_user_tolerances</code><a class="headerlink" href="#cantera.Domain1D.have_user_tolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>have_user_tolerances: __builtin__.bool</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Domain1D.index">
-<code class="descname">index</code><a class="headerlink" href="#cantera.Domain1D.index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">index</code><a class="headerlink" href="#cantera.Domain1D.index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Index of this domain in a stack. Returns -1 if this domain is not part
 of a stack.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Domain1D.n_components">
-<code class="descname">n_components</code><a class="headerlink" href="#cantera.Domain1D.n_components" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_components</code><a class="headerlink" href="#cantera.Domain1D.n_components" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of solution components at each grid point.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Domain1D.n_points">
-<code class="descname">n_points</code><a class="headerlink" href="#cantera.Domain1D.n_points" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_points</code><a class="headerlink" href="#cantera.Domain1D.n_points" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of grid points belonging to this domain.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Domain1D.name">
-<code class="descname">name</code><a class="headerlink" href="#cantera.Domain1D.name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">name</code><a class="headerlink" href="#cantera.Domain1D.name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The name / id of this domain</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Domain1D.set_bounds">
-<code class="descname">set_bounds</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.set_bounds" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_bounds</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.set_bounds" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the lower and upper bounds on the solution.</p>
 <p>The argument list should consist of keyword/value pairs, with
 component names as keywords and (lower_bound, upper_bound) tuples as
@@ -1218,13 +1214,13 @@ stand for all species mass fractions in flow domains.</p>
 
 <dl class="method">
 <dt id="cantera.Domain1D.set_default_tolerances">
-<code class="descname">set_default_tolerances</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.set_default_tolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_default_tolerances</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.set_default_tolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set all tolerances to their default values</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Domain1D.set_steady_tolerances">
-<code class="descname">set_steady_tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>abs=None</em>, <em>rel=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.set_steady_tolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_steady_tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>abs=None</em>, <em>rel=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.set_steady_tolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the error tolerances for the steady-state problem.</p>
 <p>The argument list should consist of keyword/value pairs, with
 component names as keywords and (rtol, atol) tuples as the values.
@@ -1237,7 +1233,7 @@ relative tolerances for each solution component.</p>
 
 <dl class="method">
 <dt id="cantera.Domain1D.set_transient_tolerances">
-<code class="descname">set_transient_tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>abs=None</em>, <em>rel=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.set_transient_tolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_transient_tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>*</em>, <em>default=None</em>, <em>Y=None</em>, <em>abs=None</em>, <em>rel=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.set_transient_tolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the error tolerances for the steady-state problem.</p>
 <p>The argument list should consist of keyword/value pairs, with
 component names as keywords and (rtol, atol) tuples as the values.
@@ -1250,38 +1246,38 @@ relative tolerances for each solution component.</p>
 
 <dl class="method">
 <dt id="cantera.Domain1D.steady_abstol">
-<code class="descname">steady_abstol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.steady_abstol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">steady_abstol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.steady_abstol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the absolute error tolerance for the steady state problem for a
 specified solution component, or all components if none is specified.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Domain1D.steady_reltol">
-<code class="descname">steady_reltol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.steady_reltol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">steady_reltol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.steady_reltol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the relative error tolerance for the steady state problem for a
 specified solution component, or all components if none is specified.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Domain1D.tolerances">
-<code class="descname">tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.tolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">tolerances</code><span class="sig-paren">(</span><em>self</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.tolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the (relative, absolute) error tolerances for a solution
 component.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">rtol</span><span class="p">,</span> <span class="n">atol</span> <span class="o">=</span> <span class="n">d</span><span class="o">.</span><span class="n">tolerances</span><span class="p">(</span><span class="s1">&#39;u&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">rtol</span><span class="p">,</span> <span class="n">atol</span> <span class="o">=</span> <span class="n">d</span><span class="o">.</span><span class="n">tolerances</span><span class="p">(</span><span class="s1">'u'</span><span class="p">)</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Domain1D.transient_abstol">
-<code class="descname">transient_abstol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.transient_abstol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">transient_abstol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.transient_abstol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the absolute error tolerance for the transient problem for a
 specified solution component, or all components if none is specified.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Domain1D.transient_reltol">
-<code class="descname">transient_reltol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.transient_reltol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">transient_reltol</code><span class="sig-paren">(</span><em>self</em>, <em>component=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Domain1D.transient_reltol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the relative error tolerance for the transient problem for a
 specified solution component, or all components if none is specified.</p>
 </dd></dl>
@@ -1290,44 +1286,44 @@ specified solution component, or all components if none is specified.</p>
 
 </div>
 <div class="section" id="boundary1d">
-<h3><a class="toc-backref" href="#id43">Boundary1D</a><a class="headerlink" href="#boundary1d" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id43">Boundary1D</a><a class="headerlink" href="#boundary1d" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Boundary1D">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Boundary1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Boundary1D" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Boundary1D</code><span class="sig-paren">(</span><em>phase</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Boundary1D" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Domain1D</span></code></p>
 <p>Boundary1D(<a href="#id13"><span class="problematic" id="id14">*</span></a>args, <a href="#id15"><span class="problematic" id="id16">**</span></a>kwargs)</p>
 <p>Base class for boundary domains.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>phase</strong> – The (gas) phase corresponding to the adjacent flow domain</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>phase</strong> &#8211; The (gas) phase corresponding to the adjacent flow domain</td>
 </tr>
 </tbody>
 </table>
 <dl class="attribute">
 <dt id="cantera.Boundary1D.T">
-<code class="descname">T</code><a class="headerlink" href="#cantera.Boundary1D.T" title="Permalink to this definition">¶</a></dt>
+<code class="descname">T</code><a class="headerlink" href="#cantera.Boundary1D.T" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The temperature [K] at this boundary.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Boundary1D.X">
-<code class="descname">X</code><a class="headerlink" href="#cantera.Boundary1D.X" title="Permalink to this definition">¶</a></dt>
+<code class="descname">X</code><a class="headerlink" href="#cantera.Boundary1D.X" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Species mole fractions at this boundary. May be set as either a string
 or as an array.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Boundary1D.Y">
-<code class="descname">Y</code><a class="headerlink" href="#cantera.Boundary1D.Y" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Y</code><a class="headerlink" href="#cantera.Boundary1D.Y" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Species mass fractions at this boundary. May be set as either a string
 or as an array.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Boundary1D.mdot">
-<code class="descname">mdot</code><a class="headerlink" href="#cantera.Boundary1D.mdot" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mdot</code><a class="headerlink" href="#cantera.Boundary1D.mdot" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The mass flow rate per unit area [kg/m^2]</p>
 </dd></dl>
 
@@ -1335,10 +1331,10 @@ or as an array.</p>
 
 </div>
 <div class="section" id="sim1d">
-<h3><a class="toc-backref" href="#id44">Sim1D</a><a class="headerlink" href="#sim1d" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id44">Sim1D</a><a class="headerlink" href="#sim1d" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Sim1D">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Sim1D</code><span class="sig-paren">(</span><em>domains</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Sim1D</code><span class="sig-paren">(</span><em>domains</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>Sim1D(domains, <a href="#id17"><span class="problematic" id="id18">*</span></a>args, <a href="#id19"><span class="problematic" id="id20">**</span></a>kwargs)</p>
 <p>Class Sim1D is a container for one-dimensional domains. It also holds the
@@ -1347,33 +1343,33 @@ solution.</p>
 <p>Domains are ordered left-to-right, with domain number 0 at the left.</p>
 <dl class="method">
 <dt id="cantera.Sim1D.clear_stats">
-<code class="descname">clear_stats</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.clear_stats" title="Permalink to this definition">¶</a></dt>
+<code class="descname">clear_stats</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.clear_stats" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Clear solver statistics.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.domain_index">
-<code class="descname">domain_index</code><span class="sig-paren">(</span><em>self</em>, <em>dom</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.domain_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">domain_index</code><span class="sig-paren">(</span><em>self</em>, <em>dom</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.domain_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the index of a domain, specified either by name or as a Domain1D
 object.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Sim1D.domains">
-<code class="descname">domains</code><a class="headerlink" href="#cantera.Sim1D.domains" title="Permalink to this definition">¶</a></dt>
+<code class="descname">domains</code><a class="headerlink" href="#cantera.Sim1D.domains" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.eval">
-<code class="descname">eval</code><span class="sig-paren">(</span><em>self</em>, <em>rdt=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.eval" title="Permalink to this definition">¶</a></dt>
+<code class="descname">eval</code><span class="sig-paren">(</span><em>self</em>, <em>rdt=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.eval" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Evaluate the governing equations using the current solution estimate,
 storing the residual in the array which is accessible with the
 <a class="reference internal" href="#cantera.Sim1D.work_value" title="cantera.Sim1D.work_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">work_value</span></code></a> function.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>rdt</strong> – Reciprocal of the time-step</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>rdt</strong> &#8211; Reciprocal of the time-step</td>
 </tr>
 </tbody>
 </table>
@@ -1381,131 +1377,131 @@ storing the residual in the array which is accessible with the
 
 <dl class="attribute">
 <dt id="cantera.Sim1D.eval_count_stats">
-<code class="descname">eval_count_stats</code><a class="headerlink" href="#cantera.Sim1D.eval_count_stats" title="Permalink to this definition">¶</a></dt>
+<code class="descname">eval_count_stats</code><a class="headerlink" href="#cantera.Sim1D.eval_count_stats" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return number of non-Jacobian function evaluations made in each call to
 solve()</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Sim1D.eval_time_stats">
-<code class="descname">eval_time_stats</code><a class="headerlink" href="#cantera.Sim1D.eval_time_stats" title="Permalink to this definition">¶</a></dt>
+<code class="descname">eval_time_stats</code><a class="headerlink" href="#cantera.Sim1D.eval_time_stats" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return CPU time spent on non-Jacobian function evaluations in each call
 to solve()</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.extinct">
-<code class="descname">extinct</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.extinct" title="Permalink to this definition">¶</a></dt>
+<code class="descname">extinct</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.extinct" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Method overloaded for some flame types to indicate if the flame has been
-extinguished. Base class method always returns ‘False’</p>
+extinguished. Base class method always returns &#8216;False&#8217;</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.get_max_grid_points">
-<code class="descname">get_max_grid_points</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.get_max_grid_points" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_max_grid_points</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.get_max_grid_points" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the maximum number of grid points in the specified domain.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.get_refine_criteria">
-<code class="descname">get_refine_criteria</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.get_refine_criteria" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_refine_criteria</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.get_refine_criteria" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get a dictionary of the criteria used to refine one domain. The items in
 the dictionary are the <code class="docutils literal notranslate"><span class="pre">ratio</span></code>, <code class="docutils literal notranslate"><span class="pre">slope</span></code>, <code class="docutils literal notranslate"><span class="pre">curve</span></code>, and <code class="docutils literal notranslate"><span class="pre">prune</span></code>,
 as defined in <a class="reference internal" href="#cantera.Sim1D.set_refine_criteria" title="cantera.Sim1D.set_refine_criteria"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_refine_criteria</span></code></a>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>domain</strong> – domain object, index, or name</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>domain</strong> &#8211; domain object, index, or name</td>
 </tr>
 </tbody>
 </table>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">set_refine_criteria</span><span class="p">(</span><span class="n">d</span><span class="p">,</span> <span class="n">ratio</span><span class="o">=</span><span class="mf">5.0</span><span class="p">,</span> <span class="n">slope</span><span class="o">=</span><span class="mf">0.2</span><span class="p">,</span> <span class="n">curve</span><span class="o">=</span><span class="mf">0.3</span><span class="p">,</span> <span class="n">prune</span><span class="o">=</span><span class="mf">0.03</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">get_refine_criteria</span><span class="p">(</span><span class="n">d</span><span class="p">)</span>
-<span class="go">{&#39;ratio&#39;: 5.0, &#39;slope&#39;: 0.2, &#39;curve&#39;: 0.3, &#39;prune&#39;: 0.03}</span>
+<span class="go">{'ratio': 5.0, 'slope': 0.2, 'curve': 0.3, 'prune': 0.03}</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Sim1D.grid_size_stats">
-<code class="descname">grid_size_stats</code><a class="headerlink" href="#cantera.Sim1D.grid_size_stats" title="Permalink to this definition">¶</a></dt>
+<code class="descname">grid_size_stats</code><a class="headerlink" href="#cantera.Sim1D.grid_size_stats" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return total grid size in each call to solve()</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Sim1D.jacobian_count_stats">
-<code class="descname">jacobian_count_stats</code><a class="headerlink" href="#cantera.Sim1D.jacobian_count_stats" title="Permalink to this definition">¶</a></dt>
+<code class="descname">jacobian_count_stats</code><a class="headerlink" href="#cantera.Sim1D.jacobian_count_stats" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return number of Jacobian evaluations made in each call to solve()</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Sim1D.jacobian_time_stats">
-<code class="descname">jacobian_time_stats</code><a class="headerlink" href="#cantera.Sim1D.jacobian_time_stats" title="Permalink to this definition">¶</a></dt>
+<code class="descname">jacobian_time_stats</code><a class="headerlink" href="#cantera.Sim1D.jacobian_time_stats" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return CPU time spent evaluating Jacobians in each call to solve()</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Sim1D.max_time_step_count">
-<code class="descname">max_time_step_count</code><a class="headerlink" href="#cantera.Sim1D.max_time_step_count" title="Permalink to this definition">¶</a></dt>
+<code class="descname">max_time_step_count</code><a class="headerlink" href="#cantera.Sim1D.max_time_step_count" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the maximum number of time steps allowed before reaching the
 steady-state solution</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.profile">
-<code class="descname">profile</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.profile" title="Permalink to this definition">¶</a></dt>
+<code class="descname">profile</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.profile" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Spatial profile of one component in one domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>domain</strong> – Domain1D object, name, or index</li>
-<li><strong>component</strong> – component name or index</li>
+<li><strong>domain</strong> &#8211; Domain1D object, name, or index</li>
+<li><strong>component</strong> &#8211; component name or index</li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">T</span> <span class="o">=</span> <span class="n">s</span><span class="o">.</span><span class="n">profile</span><span class="p">(</span><span class="n">flow</span><span class="p">,</span> <span class="s1">&#39;T&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">T</span> <span class="o">=</span> <span class="n">s</span><span class="o">.</span><span class="n">profile</span><span class="p">(</span><span class="n">flow</span><span class="p">,</span> <span class="s1">'T'</span><span class="p">)</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.refine">
-<code class="descname">refine</code><span class="sig-paren">(</span><em>self</em>, <em>loglevel=1</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.refine" title="Permalink to this definition">¶</a></dt>
+<code class="descname">refine</code><span class="sig-paren">(</span><em>self</em>, <em>loglevel=1</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.refine" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Refine the grid, adding points where solution is not adequately
 resolved.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.restore">
-<code class="descname">restore</code><span class="sig-paren">(</span><em>self</em>, <em>filename='soln.xml'</em>, <em>name='solution'</em>, <em>loglevel=2</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.restore" title="Permalink to this definition">¶</a></dt>
+<code class="descname">restore</code><span class="sig-paren">(</span><em>self</em>, <em>filename='soln.xml'</em>, <em>name='solution'</em>, <em>loglevel=2</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.restore" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the solution vector to a previously-saved solution.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>filename</strong> – solution file</li>
-<li><strong>name</strong> – solution name within the file</li>
-<li><strong>loglevel</strong> – Amount of logging information to display while restoring,
+<li><strong>filename</strong> &#8211; solution file</li>
+<li><strong>name</strong> &#8211; solution name within the file</li>
+<li><strong>loglevel</strong> &#8211; Amount of logging information to display while restoring,
 from 0 (disabled) to 2 (most verbose).</li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">restore</span><span class="p">(</span><span class="n">filename</span><span class="o">=</span><span class="s1">&#39;save.xml&#39;</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">&#39;energy_off&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">restore</span><span class="p">(</span><span class="n">filename</span><span class="o">=</span><span class="s1">'save.xml'</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">'energy_off'</span><span class="p">)</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.restore_steady_solution">
-<code class="descname">restore_steady_solution</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.restore_steady_solution" title="Permalink to this definition">¶</a></dt>
+<code class="descname">restore_steady_solution</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.restore_steady_solution" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the current solution vector to the last successful steady-state
 solution. This can be used to examine the solver progress after a
 failure during grid refinement.</p>
@@ -1513,7 +1509,7 @@ failure during grid refinement.</p>
 
 <dl class="method">
 <dt id="cantera.Sim1D.restore_time_stepping_solution">
-<code class="descname">restore_time_stepping_solution</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.restore_time_stepping_solution" title="Permalink to this definition">¶</a></dt>
+<code class="descname">restore_time_stepping_solution</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.restore_time_stepping_solution" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the current solution vector to the last successful time-stepping
 solution. This can be used to examine the solver progress after a failed
 integration.</p>
@@ -1521,66 +1517,66 @@ integration.</p>
 
 <dl class="method">
 <dt id="cantera.Sim1D.save">
-<code class="descname">save</code><span class="sig-paren">(</span><em>self</em>, <em>filename='soln.xml'</em>, <em>name='solution'</em>, <em>description='none'</em>, <em>loglevel=1</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.save" title="Permalink to this definition">¶</a></dt>
+<code class="descname">save</code><span class="sig-paren">(</span><em>self</em>, <em>filename='soln.xml'</em>, <em>name='solution'</em>, <em>description='none'</em>, <em>loglevel=1</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.save" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Save the solution in XML format.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>filename</strong> – solution file</li>
-<li><strong>name</strong> – solution name within the file</li>
-<li><strong>description</strong> – custom description text</li>
+<li><strong>filename</strong> &#8211; solution file</li>
+<li><strong>name</strong> &#8211; solution name within the file</li>
+<li><strong>description</strong> &#8211; custom description text</li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">save</span><span class="p">(</span><span class="n">filename</span><span class="o">=</span><span class="s1">&#39;save.xml&#39;</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">&#39;energy_off&#39;</span><span class="p">,</span>
-<span class="gp">... </span>       <span class="n">description</span><span class="o">=</span><span class="s1">&#39;solution with energy eqn. disabled&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">save</span><span class="p">(</span><span class="n">filename</span><span class="o">=</span><span class="s1">'save.xml'</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">'energy_off'</span><span class="p">,</span>
+<span class="gp">... </span>       <span class="n">description</span><span class="o">=</span><span class="s1">'solution with energy eqn. disabled'</span><span class="p">)</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_fixed_temperature">
-<code class="descname">set_fixed_temperature</code><span class="sig-paren">(</span><em>self</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_fixed_temperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_fixed_temperature</code><span class="sig-paren">(</span><em>self</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_fixed_temperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the temperature used to fix the spatial location of a freely
 propagating flame.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_flat_profile">
-<code class="descname">set_flat_profile</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em>, <em>value</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_flat_profile" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_flat_profile</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em>, <em>value</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_flat_profile" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set a flat profile for one component in one domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>domain</strong> – Domain1D object, name, or index</li>
-<li><strong>component</strong> – component name or index</li>
-<li><strong>v</strong> – value</li>
+<li><strong>domain</strong> &#8211; Domain1D object, name, or index</li>
+<li><strong>component</strong> &#8211; component name or index</li>
+<li><strong>v</strong> &#8211; value</li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">set_flat_profile</span><span class="p">(</span><span class="n">d</span><span class="p">,</span> <span class="s1">&#39;u&#39;</span><span class="p">,</span> <span class="o">-</span><span class="mf">3.0</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">set_flat_profile</span><span class="p">(</span><span class="n">d</span><span class="p">,</span> <span class="s1">'u'</span><span class="p">,</span> <span class="o">-</span><span class="mf">3.0</span><span class="p">)</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_grid_min">
-<code class="descname">set_grid_min</code><span class="sig-paren">(</span><em>self</em>, <em>dz</em>, <em>domain=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_grid_min" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_grid_min</code><span class="sig-paren">(</span><em>self</em>, <em>dz</em>, <em>domain=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_grid_min" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the minimum grid spacing on <em>domain</em>. If <em>domain</em> is None, then
 set the grid spacing for all domains.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_initial_guess">
-<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><em>self</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_initial_guess" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_initial_guess</code><span class="sig-paren">(</span><em>self</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_initial_guess" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the initial guess for the solution. Derived classes extend this
 function to set approximations for the temperature and composition
 profiles.</p>
@@ -1588,7 +1584,7 @@ profiles.</p>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_interrupt">
-<code class="descname">set_interrupt</code><span class="sig-paren">(</span><em>self</em>, <em>f</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_interrupt" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_interrupt</code><span class="sig-paren">(</span><em>self</em>, <em>f</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_interrupt" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set an interrupt function to be called each time that OneDim::eval is
 called. The signature of <em>f</em> is <code class="xref py py-obj docutils literal notranslate"><span class="pre">float</span> <span class="pre">f(float)</span></code>. The default
 interrupt function is used to trap KeyboardInterrupt exceptions so
@@ -1597,22 +1593,22 @@ that <code class="xref py py-obj docutils literal notranslate"><span class="pre"
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_max_grid_points">
-<code class="descname">set_max_grid_points</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>npmax</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_max_grid_points" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_max_grid_points</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>npmax</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_max_grid_points" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the maximum number of grid points in the specified domain.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_max_jac_age">
-<code class="descname">set_max_jac_age</code><span class="sig-paren">(</span><em>self</em>, <em>ss_age</em>, <em>ts_age</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_max_jac_age" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_max_jac_age</code><span class="sig-paren">(</span><em>self</em>, <em>ss_age</em>, <em>ts_age</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_max_jac_age" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the maximum number of times the Jacobian will be used before it
 must be re-evaluated.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>ss_age</strong> – age criterion during steady-state mode</li>
-<li><strong>ts_age</strong> – age criterion during time-stepping mode</li>
+<li><strong>ss_age</strong> &#8211; age criterion during steady-state mode</li>
+<li><strong>ts_age</strong> &#8211; age criterion during time-stepping mode</li>
 </ul>
 </td>
 </tr>
@@ -1622,60 +1618,60 @@ must be re-evaluated.</p>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_max_time_step">
-<code class="descname">set_max_time_step</code><span class="sig-paren">(</span><em>self</em>, <em>tsmax</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_max_time_step" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_max_time_step</code><span class="sig-paren">(</span><em>self</em>, <em>tsmax</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_max_time_step" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the maximum time step.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_min_time_step">
-<code class="descname">set_min_time_step</code><span class="sig-paren">(</span><em>self</em>, <em>tsmin</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_min_time_step" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_min_time_step</code><span class="sig-paren">(</span><em>self</em>, <em>tsmin</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_min_time_step" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the minimum time step.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_profile">
-<code class="descname">set_profile</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em>, <em>positions</em>, <em>values</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_profile" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_profile</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em>, <em>positions</em>, <em>values</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_profile" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set an initial estimate for a profile of one component in one domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>domain</strong> – Domain1D object, name, or index</li>
-<li><strong>component</strong> – component name or index</li>
-<li><strong>positions</strong> – sequence of relative positions, from 0 on the left to 1 on the right</li>
-<li><strong>values</strong> – sequence of values at the relative positions specified in <em>positions</em></li>
+<li><strong>domain</strong> &#8211; Domain1D object, name, or index</li>
+<li><strong>component</strong> &#8211; component name or index</li>
+<li><strong>positions</strong> &#8211; sequence of relative positions, from 0 on the left to 1 on the right</li>
+<li><strong>values</strong> &#8211; sequence of values at the relative positions specified in <em>positions</em></li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">set_profile</span><span class="p">(</span><span class="n">d</span><span class="p">,</span> <span class="s1">&#39;T&#39;</span><span class="p">,</span> <span class="p">[</span><span class="mf">0.0</span><span class="p">,</span> <span class="mf">0.2</span><span class="p">,</span> <span class="mf">1.0</span><span class="p">],</span> <span class="p">[</span><span class="mf">400.0</span><span class="p">,</span> <span class="mf">800.0</span><span class="p">,</span> <span class="mf">1500.0</span><span class="p">])</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">set_profile</span><span class="p">(</span><span class="n">d</span><span class="p">,</span> <span class="s1">'T'</span><span class="p">,</span> <span class="p">[</span><span class="mf">0.0</span><span class="p">,</span> <span class="mf">0.2</span><span class="p">,</span> <span class="mf">1.0</span><span class="p">],</span> <span class="p">[</span><span class="mf">400.0</span><span class="p">,</span> <span class="mf">800.0</span><span class="p">,</span> <span class="mf">1500.0</span><span class="p">])</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_refine_criteria">
-<code class="descname">set_refine_criteria</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>ratio=10.0</em>, <em>slope=0.8</em>, <em>curve=0.8</em>, <em>prune=0.05</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_refine_criteria" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_refine_criteria</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>ratio=10.0</em>, <em>slope=0.8</em>, <em>curve=0.8</em>, <em>prune=0.05</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_refine_criteria" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the criteria used to refine one domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>domain</strong> – domain object, index, or name</li>
-<li><strong>ratio</strong> – additional points will be added if the ratio of the spacing on
+<li><strong>domain</strong> &#8211; domain object, index, or name</li>
+<li><strong>ratio</strong> &#8211; additional points will be added if the ratio of the spacing on
 either side of a grid point exceeds this value</li>
-<li><strong>slope</strong> – maximum difference in value between two adjacent points, scaled by
+<li><strong>slope</strong> &#8211; maximum difference in value between two adjacent points, scaled by
 the maximum difference in the profile (0.0 &lt; slope &lt; 1.0). Adds
 points in regions of high slope.</li>
-<li><strong>curve</strong> – maximum difference in slope between two adjacent intervals, scaled
+<li><strong>curve</strong> &#8211; maximum difference in slope between two adjacent intervals, scaled
 by the maximum difference in the profile (0.0 &lt; curve &lt; 1.0). Adds
 points in regions of high curvature.</li>
-<li><strong>prune</strong> – if the slope or curve criteria are satisfied to the level of
-‘prune’, the grid point is assumed not to be needed and is removed.
-Set prune significantly smaller than ‘slope’ and ‘curve’. Set to
+<li><strong>prune</strong> &#8211; if the slope or curve criteria are satisfied to the level of
+&#8216;prune&#8217;, the grid point is assumed not to be needed and is removed.
+Set prune significantly smaller than &#8216;slope&#8217; and &#8216;curve&#8217;. Set to
 zero to disable pruning the grid.</li>
 </ul>
 </td>
@@ -1689,23 +1685,23 @@ zero to disable pruning the grid.</li>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_steady_callback">
-<code class="descname">set_steady_callback</code><span class="sig-paren">(</span><em>self</em>, <em>f</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_steady_callback" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_steady_callback</code><span class="sig-paren">(</span><em>self</em>, <em>f</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_steady_callback" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set a callback function to be called after each successful steady-state
 solve, before regridding. The signature of <em>f</em> is <code class="xref py py-obj docutils literal notranslate"><span class="pre">float</span> <span class="pre">f(float)</span></code>. The
-argument passed to <em>f</em> is “0” and the output is ignored.</p>
+argument passed to <em>f</em> is &#8220;0&#8221; and the output is ignored.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_time_step">
-<code class="descname">set_time_step</code><span class="sig-paren">(</span><em>self</em>, <em>stepsize</em>, <em>n_steps</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_time_step" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_time_step</code><span class="sig-paren">(</span><em>self</em>, <em>stepsize</em>, <em>n_steps</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_time_step" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the sequence of time steps to try when Newton fails.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>stepsize</strong> – initial time step size [s]</li>
-<li><strong>n_steps</strong> – sequence of integer step numbers</li>
+<li><strong>stepsize</strong> &#8211; initial time step size [s]</li>
+<li><strong>n_steps</strong> &#8211; sequence of integer step numbers</li>
 </ul>
 </td>
 </tr>
@@ -1718,7 +1714,7 @@ argument passed to <em>f</em> is “0” and the output is ignored.</p>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_time_step_callback">
-<code class="descname">set_time_step_callback</code><span class="sig-paren">(</span><em>self</em>, <em>f</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_time_step_callback" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_time_step_callback</code><span class="sig-paren">(</span><em>self</em>, <em>f</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_time_step_callback" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set a callback function to be called after each successful timestep.
 The signature of <em>f</em> is <code class="xref py py-obj docutils literal notranslate"><span class="pre">float</span> <span class="pre">f(float)</span></code>. The argument passed to <em>f</em> is
 the size of the timestep. The output is ignored.</p>
@@ -1726,24 +1722,24 @@ the size of the timestep. The output is ignored.</p>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_time_step_factor">
-<code class="descname">set_time_step_factor</code><span class="sig-paren">(</span><em>self</em>, <em>tfactor</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_time_step_factor" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_time_step_factor</code><span class="sig-paren">(</span><em>self</em>, <em>tfactor</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_time_step_factor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the factor by which the time step will be increased after a
 successful step, or decreased after an unsuccessful one.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.set_value">
-<code class="descname">set_value</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em>, <em>point</em>, <em>value</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_value" title="Permalink to this definition">¶</a></dt>
-<dd><p>Set the value of one component in one domain at one point to ‘value’.</p>
+<code class="descname">set_value</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em>, <em>point</em>, <em>value</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.set_value" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Set the value of one component in one domain at one point to &#8216;value&#8217;.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>domain</strong> – Domain1D object, name, or index</li>
-<li><strong>component</strong> – component name or index</li>
-<li><strong>point</strong> – grid point number within <em>domain</em> starting with 0 on the left</li>
-<li><strong>value</strong> – numerical value</li>
+<li><strong>domain</strong> &#8211; Domain1D object, name, or index</li>
+<li><strong>component</strong> &#8211; component name or index</li>
+<li><strong>point</strong> &#8211; grid point number within <em>domain</em> starting with 0 on the left</li>
+<li><strong>value</strong> &#8211; numerical value</li>
 </ul>
 </td>
 </tr>
@@ -1751,20 +1747,20 @@ successful step, or decreased after an unsuccessful one.</p>
 </table>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">set</span><span class="p">(</span><span class="n">d</span><span class="p">,</span> <span class="mi">3</span><span class="p">,</span> <span class="mi">5</span><span class="p">,</span> <span class="mf">6.7</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">set</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">5</span><span class="p">,</span> <span class="mf">6.7</span><span class="p">)</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">set</span><span class="p">(</span><span class="s1">&#39;flow&#39;</span><span class="p">,</span> <span class="s1">&#39;T&#39;</span><span class="p">,</span> <span class="mi">5</span><span class="p">,</span> <span class="mi">500</span><span class="p">)</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">s</span><span class="o">.</span><span class="n">set</span><span class="p">(</span><span class="s1">'flow'</span><span class="p">,</span> <span class="s1">'T'</span><span class="p">,</span> <span class="mi">5</span><span class="p">,</span> <span class="mi">500</span><span class="p">)</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.show_solution">
-<code class="descname">show_solution</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.show_solution" title="Permalink to this definition">¶</a></dt>
+<code class="descname">show_solution</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.show_solution" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>print the current solution.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.show_stats">
-<code class="descname">show_stats</code><span class="sig-paren">(</span><em>self</em>, <em>print_time=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.show_stats" title="Permalink to this definition">¶</a></dt>
+<code class="descname">show_stats</code><span class="sig-paren">(</span><em>self</em>, <em>print_time=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.show_stats" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Show the statistics for the last solution.</p>
 <p>If invoked with no arguments or with a non-zero argument, the timing
 statistics will be printed. Otherwise, the timing will not be printed.</p>
@@ -1772,17 +1768,17 @@ statistics will be printed. Otherwise, the timing will not be printed.</p>
 
 <dl class="method">
 <dt id="cantera.Sim1D.solve">
-<code class="descname">solve</code><span class="sig-paren">(</span><em>self</em>, <em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.solve" title="Permalink to this definition">¶</a></dt>
+<code class="descname">solve</code><span class="sig-paren">(</span><em>self</em>, <em>loglevel=1</em>, <em>refine_grid=True</em>, <em>auto=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.solve" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Solve the problem.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>loglevel</strong> – integer flag controlling the amount of diagnostic output. Zero
+<li><strong>loglevel</strong> &#8211; integer flag controlling the amount of diagnostic output. Zero
 suppresses all output, and 5 produces very verbose output.</li>
-<li><strong>refine_grid</strong> – if True, enable grid refinement.</li>
-<li><strong>auto</strong> – if True, sequentially execute the different solution stages
+<li><strong>refine_grid</strong> &#8211; if True, enable grid refinement.</li>
+<li><strong>auto</strong> &#8211; if True, sequentially execute the different solution stages
 and attempt to automatically recover from errors. Attempts to first
 solve on the initial grid with energy enabled. If that does not
 succeed, a fixed-temperature solution will be tried followed by
@@ -1799,18 +1795,18 @@ will be calculated.</li>
 
 <dl class="method">
 <dt id="cantera.Sim1D.solve_adjoint">
-<code class="descname">solve_adjoint</code><span class="sig-paren">(</span><em>self</em>, <em>perturb</em>, <em>n_params</em>, <em>dgdx</em>, <em>g=None</em>, <em>dp=1e-5</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.solve_adjoint" title="Permalink to this definition">¶</a></dt>
+<code class="descname">solve_adjoint</code><span class="sig-paren">(</span><em>self</em>, <em>perturb</em>, <em>n_params</em>, <em>dgdx</em>, <em>g=None</em>, <em>dp=1e-5</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.solve_adjoint" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Find the sensitivities of an objective function using an adjoint method.</p>
 <p>For an objective function <span class="math">\(g(x, p)\)</span> where <span class="math">\(x\)</span> is the state
 vector of the system and <span class="math">\(p\)</span> is a vector of parameters, this
 computes the vector of sensitivities <span class="math">\(dg/dp\)</span>. This assumes that
 the system of equations has already been solved to find <span class="math">\(x\)</span>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>perturb</strong> – <p>A function with the signature <code class="docutils literal notranslate"><span class="pre">perturb(sim,</span> <span class="pre">i,</span> <span class="pre">dp)</span></code> which
+<li><strong>perturb</strong> &#8211; <p>A function with the signature <code class="docutils literal notranslate"><span class="pre">perturb(sim,</span> <span class="pre">i,</span> <span class="pre">dp)</span></code> which
 perturbs parameter <code class="docutils literal notranslate"><span class="pre">i</span></code> by a relative factor of <code class="docutils literal notranslate"><span class="pre">dp</span></code>. To
 perturb a reaction rate constant, this function could be defined
 as:</p>
@@ -1821,15 +1817,15 @@ as:</p>
 <p>Calling <code class="docutils literal notranslate"><span class="pre">perturb(sim,</span> <span class="pre">i,</span> <span class="pre">0)</span></code> should restore that parameter to its
 default value.</p>
 </li>
-<li><strong>n_params</strong> – The length of the vector of sensitivity parameters</li>
-<li><strong>dgdx</strong> – The vector of partial derivatives of the function <span class="math">\(g(x, p)\)</span>
+<li><strong>n_params</strong> &#8211; The length of the vector of sensitivity parameters</li>
+<li><strong>dgdx</strong> &#8211; The vector of partial derivatives of the function <span class="math">\(g(x, p)\)</span>
 with respect to the system state <span class="math">\(x\)</span>.</li>
-<li><strong>g</strong> – A function with the signature <code class="docutils literal notranslate"><span class="pre">value</span> <span class="pre">=</span> <span class="pre">g(sim)</span></code> which computes the
+<li><strong>g</strong> &#8211; A function with the signature <code class="docutils literal notranslate"><span class="pre">value</span> <span class="pre">=</span> <span class="pre">g(sim)</span></code> which computes the
 value of <span class="math">\(g(x,p)\)</span> at the current system state. This is used to
 compute <span class="math">\(\partial g/\partial p\)</span>. If this is identically zero
 (i.e. <span class="math">\(g\)</span> is independent of <span class="math">\(p\)</span>) then this argument may
 be omitted.</li>
-<li><strong>dp</strong> – A relative value by which to perturb each parameter</li>
+<li><strong>dp</strong> &#8211; A relative value by which to perturb each parameter</li>
 </ul>
 </td>
 </tr>
@@ -1839,51 +1835,51 @@ be omitted.</li>
 
 <dl class="attribute">
 <dt id="cantera.Sim1D.time_step_stats">
-<code class="descname">time_step_stats</code><a class="headerlink" href="#cantera.Sim1D.time_step_stats" title="Permalink to this definition">¶</a></dt>
+<code class="descname">time_step_stats</code><a class="headerlink" href="#cantera.Sim1D.time_step_stats" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return number of time steps taken in each call to solve()</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.value">
-<code class="descname">value</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em>, <em>point</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.value" title="Permalink to this definition">¶</a></dt>
+<code class="descname">value</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em>, <em>point</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.value" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Solution value at one point</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>domain</strong> – Domain1D object, name, or index</li>
-<li><strong>component</strong> – component name or index</li>
-<li><strong>point</strong> – grid point number within <em>domain</em> starting with 0 on the left</li>
+<li><strong>domain</strong> &#8211; Domain1D object, name, or index</li>
+<li><strong>component</strong> &#8211; component name or index</li>
+<li><strong>point</strong> &#8211; grid point number within <em>domain</em> starting with 0 on the left</li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">t</span> <span class="o">=</span> <span class="n">s</span><span class="o">.</span><span class="n">value</span><span class="p">(</span><span class="s1">&#39;flow&#39;</span><span class="p">,</span> <span class="s1">&#39;T&#39;</span><span class="p">,</span> <span class="mi">6</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">t</span> <span class="o">=</span> <span class="n">s</span><span class="o">.</span><span class="n">value</span><span class="p">(</span><span class="s1">'flow'</span><span class="p">,</span> <span class="s1">'T'</span><span class="p">,</span> <span class="mi">6</span><span class="p">)</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Sim1D.work_value">
-<code class="descname">work_value</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em>, <em>point</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.work_value" title="Permalink to this definition">¶</a></dt>
+<code class="descname">work_value</code><span class="sig-paren">(</span><em>self</em>, <em>domain</em>, <em>component</em>, <em>point</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Sim1D.work_value" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Internal work array value at one point. After calling <a class="reference internal" href="#cantera.Sim1D.eval" title="cantera.Sim1D.eval"><code class="xref py py-obj docutils literal notranslate"><span class="pre">eval</span></code></a>, this array
 contains the values of the residual function.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>domain</strong> – Domain1D object, name, or index</li>
-<li><strong>component</strong> – component name or index</li>
-<li><strong>point</strong> – grid point number in the domain, starting with zero at the left</li>
+<li><strong>domain</strong> &#8211; Domain1D object, name, or index</li>
+<li><strong>component</strong> &#8211; component name or index</li>
+<li><strong>point</strong> &#8211; grid point number in the domain, starting with zero at the left</li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">t</span> <span class="o">=</span> <span class="n">s</span><span class="o">.</span><span class="n">value</span><span class="p">(</span><span class="n">flow</span><span class="p">,</span> <span class="s1">&#39;T&#39;</span><span class="p">,</span> <span class="mi">6</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">t</span> <span class="o">=</span> <span class="n">s</span><span class="o">.</span><span class="n">value</span><span class="p">(</span><span class="n">flow</span><span class="p">,</span> <span class="s1">'T'</span><span class="p">,</span> <span class="mi">6</span><span class="p">)</span>
 </pre></div>
 </div>
 </dd></dl>
@@ -1892,19 +1888,19 @@ contains the values of the residual function.</p>
 
 </div>
 <div class="section" id="flamebase">
-<h3><a class="toc-backref" href="#id45">FlameBase</a><a class="headerlink" href="#flamebase" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id45">FlameBase</a><a class="headerlink" href="#flamebase" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.FlameBase">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FlameBase</code><span class="sig-paren">(</span><em>domains</em>, <em>gas</em>, <em>grid=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FlameBase</code><span class="sig-paren">(</span><em>domains</em>, <em>gas</em>, <em>grid=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Sim1D</span></code></p>
 <p>Base class for flames with a single flow domain</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>gas</strong> – object to use to evaluate all gas properties and reaction rates</li>
-<li><strong>grid</strong> – array of initial grid points</li>
+<li><strong>gas</strong> &#8211; object to use to evaluate all gas properties and reaction rates</li>
+<li><strong>grid</strong> &#8211; array of initial grid points</li>
 </ul>
 </td>
 </tr>
@@ -1912,37 +1908,37 @@ contains the values of the residual function.</p>
 </table>
 <dl class="attribute">
 <dt id="cantera.FlameBase.L">
-<code class="descname">L</code><a class="headerlink" href="#cantera.FlameBase.L" title="Permalink to this definition">¶</a></dt>
+<code class="descname">L</code><a class="headerlink" href="#cantera.FlameBase.L" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array containing the radial pressure gradient (1/r)(dP/dr) [N/m^4] at
-each point. Note: This value is named ‘lambda’ in the C++ code.</p>
+each point. Note: This value is named &#8216;lambda&#8217; in the C++ code.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.P">
-<code class="descname">P</code><a class="headerlink" href="#cantera.FlameBase.P" title="Permalink to this definition">¶</a></dt>
+<code class="descname">P</code><a class="headerlink" href="#cantera.FlameBase.P" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the pressure of the flame [Pa]</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.T">
-<code class="descname">T</code><a class="headerlink" href="#cantera.FlameBase.T" title="Permalink to this definition">¶</a></dt>
+<code class="descname">T</code><a class="headerlink" href="#cantera.FlameBase.T" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array containing the temperature [K] at each grid point.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.V">
-<code class="descname">V</code><a class="headerlink" href="#cantera.FlameBase.V" title="Permalink to this definition">¶</a></dt>
+<code class="descname">V</code><a class="headerlink" href="#cantera.FlameBase.V" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array containing the tangential velocity gradient [1/s] at each point.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.X">
-<code class="descname">X</code><a class="headerlink" href="#cantera.FlameBase.X" title="Permalink to this definition">¶</a></dt>
+<code class="descname">X</code><a class="headerlink" href="#cantera.FlameBase.X" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species mole fractions. Can be set as an array, as a dictionary,
 or as a string. Always returns an array:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">[</span><span class="mf">0.1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.4</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">]</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;H2&#39;</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">&#39;O2&#39;</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">&#39;AR&#39;</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">&#39;H2:0.1, O2:0.4, AR:0.5&#39;</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">{</span><span class="s1">'H2'</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">'O2'</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">'AR'</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">'H2:0.1, O2:0.4, AR:0.5'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span>
 <span class="go">array([0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5])</span>
 </pre></div>
@@ -1952,12 +1948,12 @@ or as a string. Always returns an array:</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.Y">
-<code class="descname">Y</code><a class="headerlink" href="#cantera.FlameBase.Y" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Y</code><a class="headerlink" href="#cantera.FlameBase.Y" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species mass fractions. Can be set as an array, as a dictionary,
 or as a string. Always returns an array:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">[</span><span class="mf">0.1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.4</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">]</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;H2&#39;</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">&#39;O2&#39;</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">&#39;AR&#39;</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="s1">&#39;H2:0.1, O2:0.4, AR:0.5&#39;</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">{</span><span class="s1">'H2'</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">'O2'</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">'AR'</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="s1">'H2:0.1, O2:0.4, AR:0.5'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span>
 <span class="go">array([0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5])</span>
 </pre></div>
@@ -1967,21 +1963,21 @@ or as a string. Always returns an array:</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.chemical_potentials">
-<code class="descname">chemical_potentials</code><a class="headerlink" href="#cantera.FlameBase.chemical_potentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">chemical_potentials</code><a class="headerlink" href="#cantera.FlameBase.chemical_potentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species chemical potentials [J/kmol].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.concentrations">
-<code class="descname">concentrations</code><a class="headerlink" href="#cantera.FlameBase.concentrations" title="Permalink to this definition">¶</a></dt>
+<code class="descname">concentrations</code><a class="headerlink" href="#cantera.FlameBase.concentrations" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species concentrations [kmol/m^3].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.cp">
-<code class="descname">cp</code><a class="headerlink" href="#cantera.FlameBase.cp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp</code><a class="headerlink" href="#cantera.FlameBase.cp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Heat capacity at constant pressure [J/kg/K or J/kmol/K] depending
 on <code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code>.</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -1989,21 +1985,21 @@ on <code class="xref py py-obj docutils literal notranslate"><span class="pre">b
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.cp_mass">
-<code class="descname">cp_mass</code><a class="headerlink" href="#cantera.FlameBase.cp_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp_mass</code><a class="headerlink" href="#cantera.FlameBase.cp_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific heat capacity at constant pressure [J/kg/K].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.cp_mole">
-<code class="descname">cp_mole</code><a class="headerlink" href="#cantera.FlameBase.cp_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp_mole</code><a class="headerlink" href="#cantera.FlameBase.cp_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar heat capacity at constant pressure [J/kmol/K].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.creation_rates">
-<code class="descname">creation_rates</code><a class="headerlink" href="#cantera.FlameBase.creation_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">creation_rates</code><a class="headerlink" href="#cantera.FlameBase.creation_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Creation rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2011,7 +2007,7 @@ on <code class="xref py py-obj docutils literal notranslate"><span class="pre">b
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.cv">
-<code class="descname">cv</code><a class="headerlink" href="#cantera.FlameBase.cv" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv</code><a class="headerlink" href="#cantera.FlameBase.cv" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Heat capacity at constant volume [J/kg/K or J/kmol/K] depending on
 <code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code>.</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2019,42 +2015,42 @@ on <code class="xref py py-obj docutils literal notranslate"><span class="pre">b
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.cv_mass">
-<code class="descname">cv_mass</code><a class="headerlink" href="#cantera.FlameBase.cv_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv_mass</code><a class="headerlink" href="#cantera.FlameBase.cv_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific heat capacity at constant volume [J/kg/K].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.cv_mole">
-<code class="descname">cv_mole</code><a class="headerlink" href="#cantera.FlameBase.cv_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv_mole</code><a class="headerlink" href="#cantera.FlameBase.cv_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar heat capacity at constant volume [J/kmol/K].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.delta_enthalpy">
-<code class="descname">delta_enthalpy</code><a class="headerlink" href="#cantera.FlameBase.delta_enthalpy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_enthalpy</code><a class="headerlink" href="#cantera.FlameBase.delta_enthalpy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in enthalpy for each reaction [J/kmol].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_reactions</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.delta_entropy">
-<code class="descname">delta_entropy</code><a class="headerlink" href="#cantera.FlameBase.delta_entropy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_entropy</code><a class="headerlink" href="#cantera.FlameBase.delta_entropy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in entropy for each reaction [J/kmol/K].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_reactions</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.delta_gibbs">
-<code class="descname">delta_gibbs</code><a class="headerlink" href="#cantera.FlameBase.delta_gibbs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_gibbs</code><a class="headerlink" href="#cantera.FlameBase.delta_gibbs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in Gibbs free energy for each reaction [J/kmol].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_reactions</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.delta_standard_enthalpy">
-<code class="descname">delta_standard_enthalpy</code><a class="headerlink" href="#cantera.FlameBase.delta_standard_enthalpy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_enthalpy</code><a class="headerlink" href="#cantera.FlameBase.delta_standard_enthalpy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state enthalpy (independent of composition) for
 each reaction [J/kmol].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_reactions</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2062,7 +2058,7 @@ each reaction [J/kmol].</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.delta_standard_entropy">
-<code class="descname">delta_standard_entropy</code><a class="headerlink" href="#cantera.FlameBase.delta_standard_entropy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_entropy</code><a class="headerlink" href="#cantera.FlameBase.delta_standard_entropy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state entropy (independent of composition) for
 each reaction [J/kmol/K].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_reactions</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2070,7 +2066,7 @@ each reaction [J/kmol/K].</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.delta_standard_gibbs">
-<code class="descname">delta_standard_gibbs</code><a class="headerlink" href="#cantera.FlameBase.delta_standard_gibbs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">delta_standard_gibbs</code><a class="headerlink" href="#cantera.FlameBase.delta_standard_gibbs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Change in standard-state Gibbs free energy (independent of composition)
 for each reaction [J/kmol].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_reactions</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2078,28 +2074,28 @@ for each reaction [J/kmol].</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.density">
-<code class="descname">density</code><a class="headerlink" href="#cantera.FlameBase.density" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density</code><a class="headerlink" href="#cantera.FlameBase.density" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Density [kg/m^3 or kmol/m^3] depending on <code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code>.</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.density_mass">
-<code class="descname">density_mass</code><a class="headerlink" href="#cantera.FlameBase.density_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density_mass</code><a class="headerlink" href="#cantera.FlameBase.density_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>(Mass) density [kg/m^3].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.density_mole">
-<code class="descname">density_mole</code><a class="headerlink" href="#cantera.FlameBase.density_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density_mole</code><a class="headerlink" href="#cantera.FlameBase.density_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar density [kmol/m^3].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.destruction_rates">
-<code class="descname">destruction_rates</code><a class="headerlink" href="#cantera.FlameBase.destruction_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">destruction_rates</code><a class="headerlink" href="#cantera.FlameBase.destruction_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Destruction rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2107,14 +2103,14 @@ for each reaction [J/kmol].</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.electrochemical_potentials">
-<code class="descname">electrochemical_potentials</code><a class="headerlink" href="#cantera.FlameBase.electrochemical_potentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electrochemical_potentials</code><a class="headerlink" href="#cantera.FlameBase.electrochemical_potentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species electrochemical potentials [J/kmol].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.FlameBase.elemental_mass_fraction">
-<code class="descname">elemental_mass_fraction</code><span class="sig-paren">(</span><em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.elemental_mass_fraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elemental_mass_fraction</code><span class="sig-paren">(</span><em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.elemental_mass_fraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the elemental mass fraction <span class="math">\(Z_{\mathrm{mass},m}\)</span> of element
 <span class="math">\(m\)</span> at each grid point, which is defined as:</p>
 <div class="math">
@@ -2126,14 +2122,14 @@ species <span class="math">\(k\)</span>, <span class="math">\(M_m\)</span> the a
 <span class="math">\(M_k\)</span> the molecular weight of species <span class="math">\(k\)</span>, and <span class="math">\(Y_k\)</span>
 the mass fraction of species <span class="math">\(k\)</span>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> – Base element, may be specified by name or by index.</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> &#8211; Base element, may be specified by name or by index.</td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mass_fraction</span><span class="p">(</span><span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mass_fraction</span><span class="p">(</span><span class="s1">'H'</span><span class="p">)</span>
 <span class="go">[1.0, ..., 0.0]</span>
 </pre></div>
 </div>
@@ -2141,7 +2137,7 @@ the mass fraction of species <span class="math">\(k\)</span>.</p>
 
 <dl class="method">
 <dt id="cantera.FlameBase.elemental_mole_fraction">
-<code class="descname">elemental_mole_fraction</code><span class="sig-paren">(</span><em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.elemental_mole_fraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elemental_mole_fraction</code><span class="sig-paren">(</span><em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.elemental_mole_fraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the elemental mole fraction <span class="math">\(Z_{\mathrm{mole},m}\)</span> of element
 <span class="math">\(m\)</span> at each grid point, which is defined as:</p>
 <div class="math">
@@ -2152,14 +2148,14 @@ the mass fraction of species <span class="math">\(k\)</span>.</p>
 species <span class="math">\(k\)</span> and <span class="math">\(X_k\)</span> the mole fraction of species
 <span class="math">\(k\)</span>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> – Base element, may be specified by name or by index.</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> &#8211; Base element, may be specified by name or by index.</td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mole_fraction</span><span class="p">(</span><span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mole_fraction</span><span class="p">(</span><span class="s1">'H'</span><span class="p">)</span>
 <span class="go">[1.0, ..., 0.0]</span>
 </pre></div>
 </div>
@@ -2167,48 +2163,48 @@ species <span class="math">\(k\)</span> and <span class="math">\(X_k\)</span> th
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.energy_enabled">
-<code class="descname">energy_enabled</code><a class="headerlink" href="#cantera.FlameBase.energy_enabled" title="Permalink to this definition">¶</a></dt>
+<code class="descname">energy_enabled</code><a class="headerlink" href="#cantera.FlameBase.energy_enabled" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set whether or not to solve the energy equation.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.enthalpy_mass">
-<code class="descname">enthalpy_mass</code><a class="headerlink" href="#cantera.FlameBase.enthalpy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy_mass</code><a class="headerlink" href="#cantera.FlameBase.enthalpy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific enthalpy [J/kg].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.enthalpy_mole">
-<code class="descname">enthalpy_mole</code><a class="headerlink" href="#cantera.FlameBase.enthalpy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy_mole</code><a class="headerlink" href="#cantera.FlameBase.enthalpy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar enthalpy [J/kmol].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.entropy_mass">
-<code class="descname">entropy_mass</code><a class="headerlink" href="#cantera.FlameBase.entropy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropy_mass</code><a class="headerlink" href="#cantera.FlameBase.entropy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific entropy [J/kg].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.entropy_mole">
-<code class="descname">entropy_mole</code><a class="headerlink" href="#cantera.FlameBase.entropy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropy_mole</code><a class="headerlink" href="#cantera.FlameBase.entropy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar entropy [J/kmol/K].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.equilibrium_constants">
-<code class="descname">equilibrium_constants</code><a class="headerlink" href="#cantera.FlameBase.equilibrium_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equilibrium_constants</code><a class="headerlink" href="#cantera.FlameBase.equilibrium_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Equilibrium constants in concentration units for all reactions.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_reactions</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.forward_rate_constants">
-<code class="descname">forward_rate_constants</code><a class="headerlink" href="#cantera.FlameBase.forward_rate_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">forward_rate_constants</code><a class="headerlink" href="#cantera.FlameBase.forward_rate_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Forward rate constants for all reactions. The computed values include
 all temperature-dependent, pressure-dependent, and third body
 contributions. Units are a combination of kmol, m^3 and s, that depend
@@ -2218,7 +2214,7 @@ on the rate expression for the reaction.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.forward_rates_of_progress">
-<code class="descname">forward_rates_of_progress</code><a class="headerlink" href="#cantera.FlameBase.forward_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">forward_rates_of_progress</code><a class="headerlink" href="#cantera.FlameBase.forward_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Forward rates of progress for the reactions. [kmol/m^3/s] for bulk
 phases or [kmol/m^2/s] for surface phases.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_reactions</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2226,59 +2222,59 @@ phases or [kmol/m^2/s] for surface phases.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.g">
-<code class="descname">g</code><a class="headerlink" href="#cantera.FlameBase.g" title="Permalink to this definition">¶</a></dt>
+<code class="descname">g</code><a class="headerlink" href="#cantera.FlameBase.g" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Gibbs free energy [J/kg or J/kmol] depending on <code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code>.</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.gas">
-<code class="descname">gas</code><a class="headerlink" href="#cantera.FlameBase.gas" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gas</code><a class="headerlink" href="#cantera.FlameBase.gas" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.FlameBase.get_refine_criteria">
-<code class="descname">get_refine_criteria</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.get_refine_criteria" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_refine_criteria</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.get_refine_criteria" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get a dictionary of the criteria used for grid refinement. The items in
 the dictionary are the <code class="docutils literal notranslate"><span class="pre">ratio</span></code>, <code class="docutils literal notranslate"><span class="pre">slope</span></code>, <code class="docutils literal notranslate"><span class="pre">curve</span></code>, and <code class="docutils literal notranslate"><span class="pre">prune</span></code>,
 as defined in <a class="reference internal" href="#cantera.FlameBase.set_refine_criteria" title="cantera.FlameBase.set_refine_criteria"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_refine_criteria</span></code></a>.</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">f</span><span class="o">.</span><span class="n">set_refine_criteria</span><span class="p">(</span><span class="n">ratio</span><span class="o">=</span><span class="mf">3.0</span><span class="p">,</span> <span class="n">slope</span><span class="o">=</span><span class="mf">0.1</span><span class="p">,</span> <span class="n">curve</span><span class="o">=</span><span class="mf">0.2</span><span class="p">,</span> <span class="n">prune</span><span class="o">=</span><span class="mi">0</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">f</span><span class="o">.</span><span class="n">get_refine_criteria</span><span class="p">()</span>
-<span class="go">{&#39;ratio&#39;: 3.0, &#39;slope&#39;: 0.1, &#39;curve&#39;: 0.2, &#39;prune&#39;: 0.0}</span>
+<span class="go">{'ratio': 3.0, 'slope': 0.1, 'curve': 0.2, 'prune': 0.0}</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.gibbs_mass">
-<code class="descname">gibbs_mass</code><a class="headerlink" href="#cantera.FlameBase.gibbs_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs_mass</code><a class="headerlink" href="#cantera.FlameBase.gibbs_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific Gibbs free energy [J/kg].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.gibbs_mole">
-<code class="descname">gibbs_mole</code><a class="headerlink" href="#cantera.FlameBase.gibbs_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs_mole</code><a class="headerlink" href="#cantera.FlameBase.gibbs_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar Gibbs free energy [J/kmol].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.grid">
-<code class="descname">grid</code><a class="headerlink" href="#cantera.FlameBase.grid" title="Permalink to this definition">¶</a></dt>
+<code class="descname">grid</code><a class="headerlink" href="#cantera.FlameBase.grid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of grid point positions along the flame.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.h">
-<code class="descname">h</code><a class="headerlink" href="#cantera.FlameBase.h" title="Permalink to this definition">¶</a></dt>
+<code class="descname">h</code><a class="headerlink" href="#cantera.FlameBase.h" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Enthalpy [J/kg or J/kmol] depending on <code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code>.</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.heat_production_rates">
-<code class="descname">heat_production_rates</code><a class="headerlink" href="#cantera.FlameBase.heat_production_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">heat_production_rates</code><a class="headerlink" href="#cantera.FlameBase.heat_production_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the volumetric heat production rates [W/m^3] on a per-reaction
 basis. The sum over all reactions results in the total volumetric heat
 release rate.
@@ -2290,48 +2286,48 @@ Example: C. K. Law: Combustion Physics (2006), Fig. 7.8.6</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.heat_release_rate">
-<code class="descname">heat_release_rate</code><a class="headerlink" href="#cantera.FlameBase.heat_release_rate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">heat_release_rate</code><a class="headerlink" href="#cantera.FlameBase.heat_release_rate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total volumetric heat release rate [W/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.int_energy">
-<code class="descname">int_energy</code><a class="headerlink" href="#cantera.FlameBase.int_energy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">int_energy</code><a class="headerlink" href="#cantera.FlameBase.int_energy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Internal energy in [J/kg or J/kmol].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.int_energy_mass">
-<code class="descname">int_energy_mass</code><a class="headerlink" href="#cantera.FlameBase.int_energy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">int_energy_mass</code><a class="headerlink" href="#cantera.FlameBase.int_energy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific internal energy [J/kg].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.int_energy_mole">
-<code class="descname">int_energy_mole</code><a class="headerlink" href="#cantera.FlameBase.int_energy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">int_energy_mole</code><a class="headerlink" href="#cantera.FlameBase.int_energy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar internal energy [J/kmol].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.isothermal_compressibility">
-<code class="descname">isothermal_compressibility</code><a class="headerlink" href="#cantera.FlameBase.isothermal_compressibility" title="Permalink to this definition">¶</a></dt>
+<code class="descname">isothermal_compressibility</code><a class="headerlink" href="#cantera.FlameBase.isothermal_compressibility" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Isothermal compressibility [1/Pa].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.max_grid_points">
-<code class="descname">max_grid_points</code><a class="headerlink" href="#cantera.FlameBase.max_grid_points" title="Permalink to this definition">¶</a></dt>
+<code class="descname">max_grid_points</code><a class="headerlink" href="#cantera.FlameBase.max_grid_points" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the maximum number of grid points used in the solution of
 this flame.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.mix_diff_coeffs">
-<code class="descname">mix_diff_coeffs</code><a class="headerlink" href="#cantera.FlameBase.mix_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs</code><a class="headerlink" href="#cantera.FlameBase.mix_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 mass-averaged diffusive fluxes (with respect to the mass averaged
 velocity) to gradients in the species mole fractions.</p>
@@ -2340,7 +2336,7 @@ velocity) to gradients in the species mole fractions.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.mix_diff_coeffs_mass">
-<code class="descname">mix_diff_coeffs_mass</code><a class="headerlink" href="#cantera.FlameBase.mix_diff_coeffs_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs_mass</code><a class="headerlink" href="#cantera.FlameBase.mix_diff_coeffs_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 diffusive mass fluxes to gradients in the species mass fractions.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2348,7 +2344,7 @@ diffusive mass fluxes to gradients in the species mass fractions.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.mix_diff_coeffs_mole">
-<code class="descname">mix_diff_coeffs_mole</code><a class="headerlink" href="#cantera.FlameBase.mix_diff_coeffs_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs_mole</code><a class="headerlink" href="#cantera.FlameBase.mix_diff_coeffs_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 molar diffusive fluxes to gradients in the species mole fractions.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2356,7 +2352,7 @@ molar diffusive fluxes to gradients in the species mole fractions.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.net_production_rates">
-<code class="descname">net_production_rates</code><a class="headerlink" href="#cantera.FlameBase.net_production_rates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">net_production_rates</code><a class="headerlink" href="#cantera.FlameBase.net_production_rates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Net production rates for each species. [kmol/m^3/s] for bulk phases or
 [kmol/m^2/s] for surface phases.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2364,7 +2360,7 @@ molar diffusive fluxes to gradients in the species mole fractions.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.net_rates_of_progress">
-<code class="descname">net_rates_of_progress</code><a class="headerlink" href="#cantera.FlameBase.net_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">net_rates_of_progress</code><a class="headerlink" href="#cantera.FlameBase.net_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Net rates of progress for the reactions. [kmol/m^3/s] for bulk phases
 or [kmol/m^2/s] for surface phases.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_reactions</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2372,7 +2368,7 @@ or [kmol/m^2/s] for surface phases.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.partial_molar_cp">
-<code class="descname">partial_molar_cp</code><a class="headerlink" href="#cantera.FlameBase.partial_molar_cp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_cp</code><a class="headerlink" href="#cantera.FlameBase.partial_molar_cp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar specific heat capacities at constant
 pressure [J/kmol/K].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2380,41 +2376,41 @@ pressure [J/kmol/K].</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.partial_molar_enthalpies">
-<code class="descname">partial_molar_enthalpies</code><a class="headerlink" href="#cantera.FlameBase.partial_molar_enthalpies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_enthalpies</code><a class="headerlink" href="#cantera.FlameBase.partial_molar_enthalpies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar enthalpies [J/kmol].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.partial_molar_entropies">
-<code class="descname">partial_molar_entropies</code><a class="headerlink" href="#cantera.FlameBase.partial_molar_entropies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_entropies</code><a class="headerlink" href="#cantera.FlameBase.partial_molar_entropies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar entropies [J/kmol/K].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.partial_molar_int_energies">
-<code class="descname">partial_molar_int_energies</code><a class="headerlink" href="#cantera.FlameBase.partial_molar_int_energies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_int_energies</code><a class="headerlink" href="#cantera.FlameBase.partial_molar_int_energies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar internal energies [J/kmol].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.partial_molar_volumes">
-<code class="descname">partial_molar_volumes</code><a class="headerlink" href="#cantera.FlameBase.partial_molar_volumes" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_volumes</code><a class="headerlink" href="#cantera.FlameBase.partial_molar_volumes" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar volumes [m^3/kmol].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.radiation_enabled">
-<code class="descname">radiation_enabled</code><a class="headerlink" href="#cantera.FlameBase.radiation_enabled" title="Permalink to this definition">¶</a></dt>
+<code class="descname">radiation_enabled</code><a class="headerlink" href="#cantera.FlameBase.radiation_enabled" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set whether or not to include radiative heat transfer</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.reverse_rate_constants">
-<code class="descname">reverse_rate_constants</code><a class="headerlink" href="#cantera.FlameBase.reverse_rate_constants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reverse_rate_constants</code><a class="headerlink" href="#cantera.FlameBase.reverse_rate_constants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reverse rate constants for all reactions. The computed values include
 all temperature-dependent, pressure-dependent, and third body
 contributions. Units are a combination of kmol, m^3 and s, that depend
@@ -2424,7 +2420,7 @@ on the rate expression for the reaction.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.reverse_rates_of_progress">
-<code class="descname">reverse_rates_of_progress</code><a class="headerlink" href="#cantera.FlameBase.reverse_rates_of_progress" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reverse_rates_of_progress</code><a class="headerlink" href="#cantera.FlameBase.reverse_rates_of_progress" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reverse rates of progress for the reactions. [kmol/m^3/s] for bulk
 phases or [kmol/m^2/s] for surface phases.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_reactions</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2432,19 +2428,19 @@ phases or [kmol/m^2/s] for surface phases.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.s">
-<code class="descname">s</code><a class="headerlink" href="#cantera.FlameBase.s" title="Permalink to this definition">¶</a></dt>
+<code class="descname">s</code><a class="headerlink" href="#cantera.FlameBase.s" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Entropy [J/kg/K or J/kmol/K] depending on <code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code>.</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.FlameBase.set_boundary_emissivities">
-<code class="descname">set_boundary_emissivities</code><span class="sig-paren">(</span><em>e_left</em>, <em>e_right</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.set_boundary_emissivities" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_boundary_emissivities</code><span class="sig-paren">(</span><em>e_left</em>, <em>e_right</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.set_boundary_emissivities" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.FlameBase.set_gas_state">
-<code class="descname">set_gas_state</code><span class="sig-paren">(</span><em>point</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.set_gas_state" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_gas_state</code><span class="sig-paren">(</span><em>point</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.set_gas_state" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the state of the the Solution object used for calculations,
 <code class="xref py py-obj docutils literal notranslate"><span class="pre">self.gas</span></code>, to the temperature and composition at the point with index
 <em>point</em>.</p>
@@ -2452,46 +2448,46 @@ phases or [kmol/m^2/s] for surface phases.</p>
 
 <dl class="method">
 <dt id="cantera.FlameBase.set_profile">
-<code class="descname">set_profile</code><span class="sig-paren">(</span><em>component</em>, <em>locations</em>, <em>values</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.set_profile" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_profile</code><span class="sig-paren">(</span><em>component</em>, <em>locations</em>, <em>values</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.set_profile" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set an initial estimate for a profile of one component.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>component</strong> – component name or index</li>
-<li><strong>positions</strong> – sequence of relative positions, from 0 on the left to 1 on the right</li>
-<li><strong>values</strong> – sequence of values at the relative positions specified in <em>positions</em></li>
+<li><strong>component</strong> &#8211; component name or index</li>
+<li><strong>positions</strong> &#8211; sequence of relative positions, from 0 on the left to 1 on the right</li>
+<li><strong>values</strong> &#8211; sequence of values at the relative positions specified in <em>positions</em></li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">f</span><span class="o">.</span><span class="n">set_profile</span><span class="p">(</span><span class="s1">&#39;T&#39;</span><span class="p">,</span> <span class="p">[</span><span class="mf">0.0</span><span class="p">,</span> <span class="mf">0.2</span><span class="p">,</span> <span class="mf">1.0</span><span class="p">],</span> <span class="p">[</span><span class="mf">400.0</span><span class="p">,</span> <span class="mf">800.0</span><span class="p">,</span> <span class="mf">1500.0</span><span class="p">])</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">f</span><span class="o">.</span><span class="n">set_profile</span><span class="p">(</span><span class="s1">'T'</span><span class="p">,</span> <span class="p">[</span><span class="mf">0.0</span><span class="p">,</span> <span class="mf">0.2</span><span class="p">,</span> <span class="mf">1.0</span><span class="p">],</span> <span class="p">[</span><span class="mf">400.0</span><span class="p">,</span> <span class="mf">800.0</span><span class="p">,</span> <span class="mf">1500.0</span><span class="p">])</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.FlameBase.set_refine_criteria">
-<code class="descname">set_refine_criteria</code><span class="sig-paren">(</span><em>ratio=10.0</em>, <em>slope=0.8</em>, <em>curve=0.8</em>, <em>prune=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.set_refine_criteria" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_refine_criteria</code><span class="sig-paren">(</span><em>ratio=10.0</em>, <em>slope=0.8</em>, <em>curve=0.8</em>, <em>prune=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.set_refine_criteria" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the criteria used for grid refinement.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>ratio</strong> – additional points will be added if the ratio of the spacing on
+<li><strong>ratio</strong> &#8211; additional points will be added if the ratio of the spacing on
 either side of a grid point exceeds this value</li>
-<li><strong>slope</strong> – maximum difference in value between two adjacent points, scaled by
+<li><strong>slope</strong> &#8211; maximum difference in value between two adjacent points, scaled by
 the maximum difference in the profile (0.0 &lt; slope &lt; 1.0). Adds
 points in regions of high slope.</li>
-<li><strong>curve</strong> – maximum difference in slope between two adjacent intervals, scaled
+<li><strong>curve</strong> &#8211; maximum difference in slope between two adjacent intervals, scaled
 by the maximum difference in the profile (0.0 &lt; curve &lt; 1.0). Adds
 points in regions of high curvature.</li>
-<li><strong>prune</strong> – if the slope or curve criteria are satisfied to the level of
-‘prune’, the grid point is assumed not to be needed and is removed.
-Set prune significantly smaller than ‘slope’ and ‘curve’. Set to
+<li><strong>prune</strong> &#8211; if the slope or curve criteria are satisfied to the level of
+&#8216;prune&#8217;, the grid point is assumed not to be needed and is removed.
+Set prune significantly smaller than &#8216;slope&#8217; and &#8216;curve&#8217;. Set to
 zero to disable pruning the grid.</li>
 </ul>
 </td>
@@ -2505,7 +2501,7 @@ zero to disable pruning the grid.</li>
 
 <dl class="method">
 <dt id="cantera.FlameBase.solution">
-<code class="descname">solution</code><span class="sig-paren">(</span><em>component</em>, <em>point=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.solution" title="Permalink to this definition">¶</a></dt>
+<code class="descname">solution</code><span class="sig-paren">(</span><em>component</em>, <em>point=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.solution" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the solution at one point or for the full flame domain (if
 <code class="xref py py-obj docutils literal notranslate"><span class="pre">point=None</span></code>) for the specified <em>component</em>. The <em>component</em> can be
 specified by name or index.</p>
@@ -2513,7 +2509,7 @@ specified by name or index.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.soret_enabled">
-<code class="descname">soret_enabled</code><a class="headerlink" href="#cantera.FlameBase.soret_enabled" title="Permalink to this definition">¶</a></dt>
+<code class="descname">soret_enabled</code><a class="headerlink" href="#cantera.FlameBase.soret_enabled" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set whether or not to include diffusive mass fluxes due to the
 Soret effect. Enabling this option works only when using the
 multicomponent transport model.</p>
@@ -2521,7 +2517,7 @@ multicomponent transport model.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.standard_cp_R">
-<code class="descname">standard_cp_R</code><a class="headerlink" href="#cantera.FlameBase.standard_cp_R" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_cp_R</code><a class="headerlink" href="#cantera.FlameBase.standard_cp_R" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state specific heat capacities
 at constant pressure at the current temperature and pressure.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2529,7 +2525,7 @@ at constant pressure at the current temperature and pressure.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.standard_enthalpies_RT">
-<code class="descname">standard_enthalpies_RT</code><a class="headerlink" href="#cantera.FlameBase.standard_enthalpies_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_enthalpies_RT</code><a class="headerlink" href="#cantera.FlameBase.standard_enthalpies_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state enthalpies at the
 current temperature and pressure.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2537,7 +2533,7 @@ current temperature and pressure.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.standard_entropies_R">
-<code class="descname">standard_entropies_R</code><a class="headerlink" href="#cantera.FlameBase.standard_entropies_R" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_entropies_R</code><a class="headerlink" href="#cantera.FlameBase.standard_entropies_R" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state entropies at the
 current temperature and pressure.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2545,7 +2541,7 @@ current temperature and pressure.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.standard_gibbs_RT">
-<code class="descname">standard_gibbs_RT</code><a class="headerlink" href="#cantera.FlameBase.standard_gibbs_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_gibbs_RT</code><a class="headerlink" href="#cantera.FlameBase.standard_gibbs_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state Gibbs free energies at
 the current temperature and pressure.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2553,7 +2549,7 @@ the current temperature and pressure.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.standard_int_energies_RT">
-<code class="descname">standard_int_energies_RT</code><a class="headerlink" href="#cantera.FlameBase.standard_int_energies_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_int_energies_RT</code><a class="headerlink" href="#cantera.FlameBase.standard_int_energies_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state internal energies at the
 current temperature and pressure.</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2561,14 +2557,14 @@ current temperature and pressure.</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.thermal_conductivity">
-<code class="descname">thermal_conductivity</code><a class="headerlink" href="#cantera.FlameBase.thermal_conductivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_conductivity</code><a class="headerlink" href="#cantera.FlameBase.thermal_conductivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Thermal conductivity. [W/m/K].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.thermal_diff_coeffs">
-<code class="descname">thermal_diff_coeffs</code><a class="headerlink" href="#cantera.FlameBase.thermal_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_diff_coeffs</code><a class="headerlink" href="#cantera.FlameBase.thermal_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return a one-dimensional array of the species thermal diffusion
 coefficients [kg/m/s].</p>
 <p>Returns an array of size <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> x <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
@@ -2576,64 +2572,64 @@ coefficients [kg/m/s].</p>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.thermal_expansion_coeff">
-<code class="descname">thermal_expansion_coeff</code><a class="headerlink" href="#cantera.FlameBase.thermal_expansion_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_expansion_coeff</code><a class="headerlink" href="#cantera.FlameBase.thermal_expansion_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Thermal expansion coefficient [1/K].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.transport_model">
-<code class="descname">transport_model</code><a class="headerlink" href="#cantera.FlameBase.transport_model" title="Permalink to this definition">¶</a></dt>
+<code class="descname">transport_model</code><a class="headerlink" href="#cantera.FlameBase.transport_model" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the transport model used by the <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> object used for this
 simulation.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.u">
-<code class="descname">u</code><a class="headerlink" href="#cantera.FlameBase.u" title="Permalink to this definition">¶</a></dt>
+<code class="descname">u</code><a class="headerlink" href="#cantera.FlameBase.u" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array containing the velocity [m/s] normal to the flame at each point.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.viscosity">
-<code class="descname">viscosity</code><a class="headerlink" href="#cantera.FlameBase.viscosity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">viscosity</code><a class="headerlink" href="#cantera.FlameBase.viscosity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Viscosity [Pa-s].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.volume">
-<code class="descname">volume</code><a class="headerlink" href="#cantera.FlameBase.volume" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume</code><a class="headerlink" href="#cantera.FlameBase.volume" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific volume [m^3/kg or m^3/kmol] depending on <code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code>.</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.volume_mass">
-<code class="descname">volume_mass</code><a class="headerlink" href="#cantera.FlameBase.volume_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume_mass</code><a class="headerlink" href="#cantera.FlameBase.volume_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific volume [m^3/kg].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlameBase.volume_mole">
-<code class="descname">volume_mole</code><a class="headerlink" href="#cantera.FlameBase.volume_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume_mole</code><a class="headerlink" href="#cantera.FlameBase.volume_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar volume [m^3/kmol].</p>
 <p>Returns an array of length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_points</span></code>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.FlameBase.write_csv">
-<code class="descname">write_csv</code><span class="sig-paren">(</span><em>filename</em>, <em>species='X'</em>, <em>quiet=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.write_csv" title="Permalink to this definition">¶</a></dt>
+<code class="descname">write_csv</code><span class="sig-paren">(</span><em>filename</em>, <em>species='X'</em>, <em>quiet=True</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlameBase.write_csv" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Write the velocity, temperature, density, and species profiles
 to a CSV file.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>filename</strong> – Output file name</li>
-<li><strong>species</strong> – Attribute to use obtaining species profiles, e.g. <code class="docutils literal notranslate"><span class="pre">X</span></code> for
+<li><strong>filename</strong> &#8211; Output file name</li>
+<li><strong>species</strong> &#8211; Attribute to use obtaining species profiles, e.g. <code class="docutils literal notranslate"><span class="pre">X</span></code> for
 mole fractions or <code class="docutils literal notranslate"><span class="pre">Y</span></code> for mass fractions.</li>
 </ul>
 </td>
@@ -2708,25 +2704,24 @@ mole fractions or <code class="docutils literal notranslate"><span class="pre">Y
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/cython/onedim.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/cython/onedim.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -2735,15 +2730,14 @@ mole fractions or <code class="docutils literal notranslate"><span class="pre">Y
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/cython/onedim.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/cython/onedim.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/cython/onedim.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/onedim.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/cython/thermo.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/thermo.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Thermodynamic Properties | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,7 +77,7 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="thermodynamic-properties">
-<h1>Thermodynamic Properties<a class="headerlink" href="#thermodynamic-properties" title="Permalink to this headline">¶</a></h1>
+<h1>Thermodynamic Properties<a class="headerlink" href="#thermodynamic-properties" title="Permalink to this headline">&#182;</a></h1>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#phases" id="id5">Phases</a><ul>
@@ -103,13 +99,13 @@ lang="en">
 </ul>
 </div>
 <div class="section" id="phases">
-<h2><a class="toc-backref" href="#id5">Phases</a><a class="headerlink" href="#phases" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id5">Phases</a><a class="headerlink" href="#phases" title="Permalink to this headline">&#182;</a></h2>
 <p>These classes are used to describe the thermodynamic state of a system.</p>
 <div class="section" id="thermophase">
-<h3><a class="toc-backref" href="#id6">ThermoPhase</a><a class="headerlink" href="#thermophase" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id6">ThermoPhase</a><a class="headerlink" href="#thermophase" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ThermoPhase">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ThermoPhase</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ThermoPhase</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera._SolutionBase</span></code></p>
 <p>ThermoPhase(<a href="#id1"><span class="problematic" id="id2">*</span></a>args, <a href="#id3"><span class="problematic" id="id4">**</span></a>kwargs)</p>
 <p>A phase with an equation of state.</p>
@@ -119,176 +115,176 @@ state of a phase of matter, which might be a gas, liquid, or solid.</p>
 as a base class for classes <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> and <a class="reference internal" href="importing.html#cantera.Interface" title="cantera.Interface"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Interface</span></code></a>.</p>
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.DP">
-<code class="descname">DP</code><a class="headerlink" href="#cantera.ThermoPhase.DP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">DP</code><a class="headerlink" href="#cantera.ThermoPhase.DP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set density [kg/m^3] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.DPX">
-<code class="descname">DPX</code><a class="headerlink" href="#cantera.ThermoPhase.DPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">DPX</code><a class="headerlink" href="#cantera.ThermoPhase.DPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set density [kg/m^3], pressure [Pa], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.DPY">
-<code class="descname">DPY</code><a class="headerlink" href="#cantera.ThermoPhase.DPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">DPY</code><a class="headerlink" href="#cantera.ThermoPhase.DPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set density [kg/m^3], pressure [Pa], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.HP">
-<code class="descname">HP</code><a class="headerlink" href="#cantera.ThermoPhase.HP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">HP</code><a class="headerlink" href="#cantera.ThermoPhase.HP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set enthalpy [J/kg or J/kmol] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.HPX">
-<code class="descname">HPX</code><a class="headerlink" href="#cantera.ThermoPhase.HPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">HPX</code><a class="headerlink" href="#cantera.ThermoPhase.HPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set enthalpy [J/kg or J/kmol], pressure [Pa] and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.HPY">
-<code class="descname">HPY</code><a class="headerlink" href="#cantera.ThermoPhase.HPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">HPY</code><a class="headerlink" href="#cantera.ThermoPhase.HPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set enthalpy [J/kg or J/kmol], pressure [Pa] and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.ID">
-<code class="descname">ID</code><a class="headerlink" href="#cantera.ThermoPhase.ID" title="Permalink to this definition">¶</a></dt>
+<code class="descname">ID</code><a class="headerlink" href="#cantera.ThermoPhase.ID" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The ID of the phase. The default is taken from the CTI/XML input file.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.P">
-<code class="descname">P</code><a class="headerlink" href="#cantera.ThermoPhase.P" title="Permalink to this definition">¶</a></dt>
+<code class="descname">P</code><a class="headerlink" href="#cantera.ThermoPhase.P" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.P_sat">
-<code class="descname">P_sat</code><a class="headerlink" href="#cantera.ThermoPhase.P_sat" title="Permalink to this definition">¶</a></dt>
+<code class="descname">P_sat</code><a class="headerlink" href="#cantera.ThermoPhase.P_sat" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Saturation pressure [Pa] at the current temperature.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.SP">
-<code class="descname">SP</code><a class="headerlink" href="#cantera.ThermoPhase.SP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SP</code><a class="headerlink" href="#cantera.ThermoPhase.SP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.SPX">
-<code class="descname">SPX</code><a class="headerlink" href="#cantera.ThermoPhase.SPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SPX</code><a class="headerlink" href="#cantera.ThermoPhase.SPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], pressure [Pa], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.SPY">
-<code class="descname">SPY</code><a class="headerlink" href="#cantera.ThermoPhase.SPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SPY</code><a class="headerlink" href="#cantera.ThermoPhase.SPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], pressure [Pa], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.SV">
-<code class="descname">SV</code><a class="headerlink" href="#cantera.ThermoPhase.SV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SV</code><a class="headerlink" href="#cantera.ThermoPhase.SV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K] and specific volume [m^3/kg or
 m^3/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.SVX">
-<code class="descname">SVX</code><a class="headerlink" href="#cantera.ThermoPhase.SVX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SVX</code><a class="headerlink" href="#cantera.ThermoPhase.SVX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
 m^3/kmol], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.SVY">
-<code class="descname">SVY</code><a class="headerlink" href="#cantera.ThermoPhase.SVY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SVY</code><a class="headerlink" href="#cantera.ThermoPhase.SVY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
 m^3/kmol], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.T">
-<code class="descname">T</code><a class="headerlink" href="#cantera.ThermoPhase.T" title="Permalink to this definition">¶</a></dt>
+<code class="descname">T</code><a class="headerlink" href="#cantera.ThermoPhase.T" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Temperature [K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.TD">
-<code class="descname">TD</code><a class="headerlink" href="#cantera.ThermoPhase.TD" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TD</code><a class="headerlink" href="#cantera.ThermoPhase.TD" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K] and density [kg/m^3 or kmol/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.TDX">
-<code class="descname">TDX</code><a class="headerlink" href="#cantera.ThermoPhase.TDX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TDX</code><a class="headerlink" href="#cantera.ThermoPhase.TDX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K], density [kg/m^3 or kmol/m^3], and mole
 fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.TDY">
-<code class="descname">TDY</code><a class="headerlink" href="#cantera.ThermoPhase.TDY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TDY</code><a class="headerlink" href="#cantera.ThermoPhase.TDY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K] and density [kg/m^3 or kmol/m^3], and mass
 fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.TP">
-<code class="descname">TP</code><a class="headerlink" href="#cantera.ThermoPhase.TP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TP</code><a class="headerlink" href="#cantera.ThermoPhase.TP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K] and pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.TPX">
-<code class="descname">TPX</code><a class="headerlink" href="#cantera.ThermoPhase.TPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TPX</code><a class="headerlink" href="#cantera.ThermoPhase.TPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K], pressure [Pa], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.TPY">
-<code class="descname">TPY</code><a class="headerlink" href="#cantera.ThermoPhase.TPY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TPY</code><a class="headerlink" href="#cantera.ThermoPhase.TPY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set temperature [K], pressure [Pa], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.T_sat">
-<code class="descname">T_sat</code><a class="headerlink" href="#cantera.ThermoPhase.T_sat" title="Permalink to this definition">¶</a></dt>
+<code class="descname">T_sat</code><a class="headerlink" href="#cantera.ThermoPhase.T_sat" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Saturation temperature [K] at the current pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.UV">
-<code class="descname">UV</code><a class="headerlink" href="#cantera.ThermoPhase.UV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UV</code><a class="headerlink" href="#cantera.ThermoPhase.UV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set internal energy [J/kg or J/kmol] and specific volume
 [m^3/kg or m^3/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.UVX">
-<code class="descname">UVX</code><a class="headerlink" href="#cantera.ThermoPhase.UVX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UVX</code><a class="headerlink" href="#cantera.ThermoPhase.UVX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set internal energy [J/kg or J/kmol], specific volume
 [m^3/kg or m^3/kmol], and mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.UVY">
-<code class="descname">UVY</code><a class="headerlink" href="#cantera.ThermoPhase.UVY" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UVY</code><a class="headerlink" href="#cantera.ThermoPhase.UVY" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set internal energy [J/kg or J/kmol], specific volume
 [m^3/kg or m^3/kmol], and mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.X">
-<code class="descname">X</code><a class="headerlink" href="#cantera.ThermoPhase.X" title="Permalink to this definition">¶</a></dt>
+<code class="descname">X</code><a class="headerlink" href="#cantera.ThermoPhase.X" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species mole fractions. Can be set as an array, as a dictionary,
 or as a string. Always returns an array:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">[</span><span class="mf">0.1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.4</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">]</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;H2&#39;</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">&#39;O2&#39;</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">&#39;AR&#39;</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">&#39;H2:0.1, O2:0.4, AR:0.5&#39;</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="p">{</span><span class="s1">'H2'</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">'O2'</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">'AR'</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">'H2:0.1, O2:0.4, AR:0.5'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">X</span>
 <span class="go">array([0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5])</span>
 </pre></div>
@@ -297,12 +293,12 @@ or as a string. Always returns an array:</p>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.Y">
-<code class="descname">Y</code><a class="headerlink" href="#cantera.ThermoPhase.Y" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Y</code><a class="headerlink" href="#cantera.ThermoPhase.Y" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species mass fractions. Can be set as an array, as a dictionary,
 or as a string. Always returns an array:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">[</span><span class="mf">0.1</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.4</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mf">0.5</span><span class="p">]</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">{</span><span class="s1">&#39;H2&#39;</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">&#39;O2&#39;</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">&#39;AR&#39;</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="s1">&#39;H2:0.1, O2:0.4, AR:0.5&#39;</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="p">{</span><span class="s1">'H2'</span><span class="p">:</span><span class="mf">0.1</span><span class="p">,</span> <span class="s1">'O2'</span><span class="p">:</span><span class="mf">0.4</span><span class="p">,</span> <span class="s1">'AR'</span><span class="p">:</span><span class="mf">0.5</span><span class="p">}</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span> <span class="o">=</span> <span class="s1">'H2:0.1, O2:0.4, AR:0.5'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">Y</span>
 <span class="go">array([0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5])</span>
 </pre></div>
@@ -311,39 +307,39 @@ or as a string. Always returns an array:</p>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.activities">
-<code class="descname">activities</code><a class="headerlink" href="#cantera.ThermoPhase.activities" title="Permalink to this definition">¶</a></dt>
+<code class="descname">activities</code><a class="headerlink" href="#cantera.ThermoPhase.activities" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional activities. Returns either molar or molal
 activities depending on the convention of the thermodynamic model.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.activity_coefficients">
-<code class="descname">activity_coefficients</code><a class="headerlink" href="#cantera.ThermoPhase.activity_coefficients" title="Permalink to this definition">¶</a></dt>
+<code class="descname">activity_coefficients</code><a class="headerlink" href="#cantera.ThermoPhase.activity_coefficients" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional, molar activity coefficients.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.add_species">
-<code class="descname">add_species</code><span class="sig-paren">(</span><em>self</em>, <em>Species species</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.add_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">add_species</code><span class="sig-paren">(</span><em>self</em>, <em>Species species</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.add_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Add a new species to this phase. Missing elements will be added
 automatically.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.atomic_weight">
-<code class="descname">atomic_weight</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.atomic_weight" title="Permalink to this definition">¶</a></dt>
+<code class="descname">atomic_weight</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.atomic_weight" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Atomic weight [kg/kmol] of element <em>m</em></p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.atomic_weights">
-<code class="descname">atomic_weights</code><a class="headerlink" href="#cantera.ThermoPhase.atomic_weights" title="Permalink to this definition">¶</a></dt>
+<code class="descname">atomic_weights</code><a class="headerlink" href="#cantera.ThermoPhase.atomic_weights" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of atomic weight [kg/kmol] for each element in the mixture.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.basis">
-<code class="descname">basis</code><a class="headerlink" href="#cantera.ThermoPhase.basis" title="Permalink to this definition">¶</a></dt>
+<code class="descname">basis</code><a class="headerlink" href="#cantera.ThermoPhase.basis" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Determines whether intensive thermodynamic properties are treated on a
 <code class="xref py py-obj docutils literal notranslate"><span class="pre">mass</span></code> (per kg) or <code class="xref py py-obj docutils literal notranslate"><span class="pre">molar</span></code> (per kmol) basis. This affects the values
 returned by the properties <a class="reference internal" href="#cantera.ThermoPhase.h" title="cantera.ThermoPhase.h"><code class="xref py py-obj docutils literal notranslate"><span class="pre">h</span></code></a>, <a class="reference internal" href="#cantera.ThermoPhase.u" title="cantera.ThermoPhase.u"><code class="xref py py-obj docutils literal notranslate"><span class="pre">u</span></code></a>, <a class="reference internal" href="#cantera.ThermoPhase.s" title="cantera.ThermoPhase.s"><code class="xref py py-obj docutils literal notranslate"><span class="pre">s</span></code></a>, <a class="reference internal" href="#cantera.ThermoPhase.g" title="cantera.ThermoPhase.g"><code class="xref py py-obj docutils literal notranslate"><span class="pre">g</span></code></a>, <a class="reference internal" href="#cantera.ThermoPhase.v" title="cantera.ThermoPhase.v"><code class="xref py py-obj docutils literal notranslate"><span class="pre">v</span></code></a>, <a class="reference internal" href="#cantera.ThermoPhase.density" title="cantera.ThermoPhase.density"><code class="xref py py-obj docutils literal notranslate"><span class="pre">density</span></code></a>, <a class="reference internal" href="#cantera.ThermoPhase.cv" title="cantera.ThermoPhase.cv"><code class="xref py py-obj docutils literal notranslate"><span class="pre">cv</span></code></a>,
@@ -353,105 +349,105 @@ such as <a class="reference internal" href="#cantera.ThermoPhase.HPX" title="can
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.chemical_potentials">
-<code class="descname">chemical_potentials</code><a class="headerlink" href="#cantera.ThermoPhase.chemical_potentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">chemical_potentials</code><a class="headerlink" href="#cantera.ThermoPhase.chemical_potentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species chemical potentials [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.concentrations">
-<code class="descname">concentrations</code><a class="headerlink" href="#cantera.ThermoPhase.concentrations" title="Permalink to this definition">¶</a></dt>
+<code class="descname">concentrations</code><a class="headerlink" href="#cantera.ThermoPhase.concentrations" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species concentrations [kmol/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.cp">
-<code class="descname">cp</code><a class="headerlink" href="#cantera.ThermoPhase.cp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp</code><a class="headerlink" href="#cantera.ThermoPhase.cp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Heat capacity at constant pressure [J/kg/K or J/kmol/K] depending
 on <a class="reference internal" href="#cantera.ThermoPhase.basis" title="cantera.ThermoPhase.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.cp_mass">
-<code class="descname">cp_mass</code><a class="headerlink" href="#cantera.ThermoPhase.cp_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp_mass</code><a class="headerlink" href="#cantera.ThermoPhase.cp_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific heat capacity at constant pressure [J/kg/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.cp_mole">
-<code class="descname">cp_mole</code><a class="headerlink" href="#cantera.ThermoPhase.cp_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp_mole</code><a class="headerlink" href="#cantera.ThermoPhase.cp_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar heat capacity at constant pressure [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.critical_density">
-<code class="descname">critical_density</code><a class="headerlink" href="#cantera.ThermoPhase.critical_density" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critical_density</code><a class="headerlink" href="#cantera.ThermoPhase.critical_density" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Critical density [kg/m^3 or kmol/m^3] depending on <a class="reference internal" href="#cantera.ThermoPhase.basis" title="cantera.ThermoPhase.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.critical_pressure">
-<code class="descname">critical_pressure</code><a class="headerlink" href="#cantera.ThermoPhase.critical_pressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critical_pressure</code><a class="headerlink" href="#cantera.ThermoPhase.critical_pressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Critical pressure [Pa].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.critical_temperature">
-<code class="descname">critical_temperature</code><a class="headerlink" href="#cantera.ThermoPhase.critical_temperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critical_temperature</code><a class="headerlink" href="#cantera.ThermoPhase.critical_temperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Critical temperature [K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.cv">
-<code class="descname">cv</code><a class="headerlink" href="#cantera.ThermoPhase.cv" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv</code><a class="headerlink" href="#cantera.ThermoPhase.cv" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Heat capacity at constant volume [J/kg/K or J/kmol/K] depending on
 <a class="reference internal" href="#cantera.ThermoPhase.basis" title="cantera.ThermoPhase.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.cv_mass">
-<code class="descname">cv_mass</code><a class="headerlink" href="#cantera.ThermoPhase.cv_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv_mass</code><a class="headerlink" href="#cantera.ThermoPhase.cv_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific heat capacity at constant volume [J/kg/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.cv_mole">
-<code class="descname">cv_mole</code><a class="headerlink" href="#cantera.ThermoPhase.cv_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv_mole</code><a class="headerlink" href="#cantera.ThermoPhase.cv_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar heat capacity at constant volume [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.density">
-<code class="descname">density</code><a class="headerlink" href="#cantera.ThermoPhase.density" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density</code><a class="headerlink" href="#cantera.ThermoPhase.density" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Density [kg/m^3 or kmol/m^3] depending on <a class="reference internal" href="#cantera.ThermoPhase.basis" title="cantera.ThermoPhase.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.density_mass">
-<code class="descname">density_mass</code><a class="headerlink" href="#cantera.ThermoPhase.density_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density_mass</code><a class="headerlink" href="#cantera.ThermoPhase.density_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>(Mass) density [kg/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.density_mole">
-<code class="descname">density_mole</code><a class="headerlink" href="#cantera.ThermoPhase.density_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density_mole</code><a class="headerlink" href="#cantera.ThermoPhase.density_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar density [kmol/m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.electric_potential">
-<code class="descname">electric_potential</code><a class="headerlink" href="#cantera.ThermoPhase.electric_potential" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electric_potential</code><a class="headerlink" href="#cantera.ThermoPhase.electric_potential" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the electric potential [V] for this phase.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.electrochemical_potentials">
-<code class="descname">electrochemical_potentials</code><a class="headerlink" href="#cantera.ThermoPhase.electrochemical_potentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electrochemical_potentials</code><a class="headerlink" href="#cantera.ThermoPhase.electrochemical_potentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species electrochemical potentials [J/kmol].</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.element_index">
-<code class="descname">element_index</code><span class="sig-paren">(</span><em>self</em>, <em>element</em><span class="sig-paren">)</span> &#x2192; int<a class="headerlink" href="#cantera.ThermoPhase.element_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_index</code><span class="sig-paren">(</span><em>self</em>, <em>element</em><span class="sig-paren">)</span> &#8594; int<a class="headerlink" href="#cantera.ThermoPhase.element_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of element <em>element</em>, which may be specified as a string or
 an integer. In the latter case, the index is checked for validity and
 returned. If no such element is present, an exception is thrown.</p>
@@ -459,19 +455,19 @@ returned. If no such element is present, an exception is thrown.</p>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.element_name">
-<code class="descname">element_name</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.element_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_name</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.element_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Name of the element with index <em>m</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.element_names">
-<code class="descname">element_names</code><a class="headerlink" href="#cantera.ThermoPhase.element_names" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_names</code><a class="headerlink" href="#cantera.ThermoPhase.element_names" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A list of all the element names.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.element_potentials">
-<code class="descname">element_potentials</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.element_potentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_potentials</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.element_potentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the array of element potentials. The element potentials are only
 defined for equilibrium states. This method first sets the composition
 to a state of equilibrium at constant T and P, then computes the
@@ -483,7 +479,7 @@ element potentials for this equilibrium state.</p>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.elemental_mass_fraction">
-<code class="descname">elemental_mass_fraction</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.elemental_mass_fraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elemental_mass_fraction</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.elemental_mass_fraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the elemental mass fraction <span class="math">\(Z_{\mathrm{mass},m}\)</span> of element
 <span class="math">\(m\)</span> as defined by:</p>
 <div class="math">
@@ -495,14 +491,14 @@ species <span class="math">\(k\)</span>, <span class="math">\(M_m\)</span> the a
 <span class="math">\(M_k\)</span> the molecular weight of species <span class="math">\(k\)</span>, and <span class="math">\(Y_k\)</span>
 the mass fraction of species <span class="math">\(k\)</span>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> – Base element, may be specified by name or by index.</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> &#8211; Base element, may be specified by name or by index.</td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mass_fraction</span><span class="p">(</span><span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mass_fraction</span><span class="p">(</span><span class="s1">'H'</span><span class="p">)</span>
 <span class="go">1.0</span>
 </pre></div>
 </div>
@@ -510,7 +506,7 @@ the mass fraction of species <span class="math">\(k\)</span>.</p>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.elemental_mole_fraction">
-<code class="descname">elemental_mole_fraction</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.elemental_mole_fraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elemental_mole_fraction</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.elemental_mole_fraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the elemental mole fraction <span class="math">\(Z_{\mathrm{mole},m}\)</span> of element
 <span class="math">\(m\)</span> (the number of atoms of element m divided by the total number
 of atoms) as defined by:</p>
@@ -523,14 +519,14 @@ of atoms) as defined by:</p>
 species <span class="math">\(k\)</span>, <span class="math">\(\sum_j\)</span> being a sum over all elements, and
 <span class="math">\(X_k\)</span> being the mole fraction of species <span class="math">\(k\)</span>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> – Base element, may be specified by name or by index.</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>m</strong> &#8211; Base element, may be specified by name or by index.</td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mole_fraction</span><span class="p">(</span><span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">elemental_mole_fraction</span><span class="p">(</span><span class="s1">'H'</span><span class="p">)</span>
 <span class="go">1.0</span>
 </pre></div>
 </div>
@@ -538,66 +534,66 @@ species <span class="math">\(k\)</span>, <span class="math">\(\sum_j\)</span> be
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.enthalpy_mass">
-<code class="descname">enthalpy_mass</code><a class="headerlink" href="#cantera.ThermoPhase.enthalpy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy_mass</code><a class="headerlink" href="#cantera.ThermoPhase.enthalpy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific enthalpy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.enthalpy_mole">
-<code class="descname">enthalpy_mole</code><a class="headerlink" href="#cantera.ThermoPhase.enthalpy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy_mole</code><a class="headerlink" href="#cantera.ThermoPhase.enthalpy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar enthalpy [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.entropy_mass">
-<code class="descname">entropy_mass</code><a class="headerlink" href="#cantera.ThermoPhase.entropy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropy_mass</code><a class="headerlink" href="#cantera.ThermoPhase.entropy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific entropy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.entropy_mole">
-<code class="descname">entropy_mole</code><a class="headerlink" href="#cantera.ThermoPhase.entropy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropy_mole</code><a class="headerlink" href="#cantera.ThermoPhase.entropy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar entropy [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.equilibrate">
-<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>self</em>, <em>XY</em>, <em>solver='auto'</em>, <em>double rtol=1e-9</em>, <em>int maxsteps=1000</em>, <em>int maxiter=100</em>, <em>int estimate_equil=0</em>, <em>int loglevel=0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.equilibrate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>self</em>, <em>XY</em>, <em>solver='auto'</em>, <em>double rtol=1e-9</em>, <em>int maxsteps=1000</em>, <em>int maxiter=100</em>, <em>int estimate_equil=0</em>, <em>int loglevel=0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.equilibrate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set to a state of chemical equilibrium holding property pair
 <em>XY</em> constant.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>XY</strong> – <p>A two-letter string, which must be one of the set:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="p">[</span><span class="s1">&#39;TP&#39;</span><span class="p">,</span><span class="s1">&#39;TV&#39;</span><span class="p">,</span><span class="s1">&#39;HP&#39;</span><span class="p">,</span><span class="s1">&#39;SP&#39;</span><span class="p">,</span><span class="s1">&#39;SV&#39;</span><span class="p">,</span><span class="s1">&#39;UV&#39;</span><span class="p">]</span>
+<li><strong>XY</strong> &#8211; <p>A two-letter string, which must be one of the set:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="p">[</span><span class="s1">'TP'</span><span class="p">,</span><span class="s1">'TV'</span><span class="p">,</span><span class="s1">'HP'</span><span class="p">,</span><span class="s1">'SP'</span><span class="p">,</span><span class="s1">'SV'</span><span class="p">,</span><span class="s1">'UV'</span><span class="p">]</span>
 </pre></div>
 </div>
 </li>
-<li><strong>solver</strong> – <p>Specifies the equilibrium solver to use. May be one of the following:</p>
+<li><strong>solver</strong> &#8211; <p>Specifies the equilibrium solver to use. May be one of the following:</p>
 <ul>
-<li>’‘element_potential’’ - a fast solver using the element potential
+<li>&#8217;&#8216;element_potential&#8217;&#8217; - a fast solver using the element potential
 method</li>
-<li>’gibbs’ - a slower but more robust Gibbs minimization solver</li>
-<li>’vcs’ - the VCS non-ideal equilibrium solver</li>
-<li>”auto” - The element potential solver will be tried first, then
+<li>&#8217;gibbs&#8217; - a slower but more robust Gibbs minimization solver</li>
+<li>&#8217;vcs&#8217; - the VCS non-ideal equilibrium solver</li>
+<li>&#8221;auto&#8221; - The element potential solver will be tried first, then
 if it fails the Gibbs solver will be tried.</li>
 </ul>
 </li>
-<li><strong>rtol</strong> – the relative error tolerance.</li>
-<li><strong>maxsteps</strong> – maximum number of steps in composition to take to find a converged
+<li><strong>rtol</strong> &#8211; the relative error tolerance.</li>
+<li><strong>maxsteps</strong> &#8211; maximum number of steps in composition to take to find a converged
 solution.</li>
-<li><strong>maxiter</strong> – For the Gibbs minimization solver, this specifies the number of
-‘outer’ iterations on T or P when some property pair other
+<li><strong>maxiter</strong> &#8211; For the Gibbs minimization solver, this specifies the number of
+&#8216;outer&#8217; iterations on T or P when some property pair other
 than TP is specified.</li>
-<li><strong>estimate_equil</strong> – Integer indicating whether the solver should estimate its own
+<li><strong>estimate_equil</strong> &#8211; Integer indicating whether the solver should estimate its own
 initial condition. If 0, the initial mole fraction vector in the
 ThermoPhase object is used as the initial condition. If 1, the
 initial mole fraction vector is used if the element abundances are
 satisfied. If -1, the initial mole fraction vector is thrown out,
 and an estimate is formulated.</li>
-<li><strong>loglevel</strong> – Set to a value &gt; 0 to write diagnostic output.</li>
+<li><strong>loglevel</strong> &#8211; Set to a value &gt; 0 to write diagnostic output.</li>
 </ul>
 </td>
 </tr>
@@ -607,39 +603,39 @@ and an estimate is formulated.</li>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.g">
-<code class="descname">g</code><a class="headerlink" href="#cantera.ThermoPhase.g" title="Permalink to this definition">¶</a></dt>
+<code class="descname">g</code><a class="headerlink" href="#cantera.ThermoPhase.g" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Gibbs free energy [J/kg or J/kmol] depending on <a class="reference internal" href="#cantera.ThermoPhase.basis" title="cantera.ThermoPhase.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.get_equivalence_ratio">
-<code class="descname">get_equivalence_ratio</code><span class="sig-paren">(</span><em>self</em>, <em>oxidizers=[]</em>, <em>ignore=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.get_equivalence_ratio" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_equivalence_ratio</code><span class="sig-paren">(</span><em>self</em>, <em>oxidizers=[]</em>, <em>ignore=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.get_equivalence_ratio" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the composition of a fuel/oxidizer mixture. This gives the
 equivalence ratio of an unburned mixture. This is not a quantity that is
 conserved after oxidation. Considers the oxidation of C to CO2, H to H2O
 and S to SO2. Other elements are assumed not to participate in oxidation
 (i.e. N ends up as N2).</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>oxidizers</strong> – List of oxidizer species names as strings. Default: with
+<li><strong>oxidizers</strong> &#8211; List of oxidizer species names as strings. Default: with
 <code class="docutils literal notranslate"><span class="pre">oxidizers=[]</span></code>, every species that contains O but does not contain
 H, C, or S is considered to be an oxidizer.</li>
-<li><strong>ignore</strong> – List of species names as strings to ignore.</li>
+<li><strong>ignore</strong> &#8211; List of species names as strings to ignore.</li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">0.5</span><span class="p">,</span> <span class="s1">&#39;CH3:0.5, CH3OH:.5, N2:0.125&#39;</span><span class="p">,</span> <span class="s1">&#39;O2:0.21, N2:0.79, NO:0.01&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">0.5</span><span class="p">,</span> <span class="s1">'CH3:0.5, CH3OH:.5, N2:0.125'</span><span class="p">,</span> <span class="s1">'O2:0.21, N2:0.79, NO:0.01'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">get_equivalence_ratio</span><span class="p">()</span>
 <span class="go">0.50000000000000011</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">get_equivalence_ratio</span><span class="p">([</span><span class="s1">&#39;O2&#39;</span><span class="p">])</span>  <span class="c1"># Only consider O2 as the oxidizer instead of O2 and NO</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">get_equivalence_ratio</span><span class="p">([</span><span class="s1">'O2'</span><span class="p">])</span>  <span class="c1"># Only consider O2 as the oxidizer instead of O2 and NO</span>
 <span class="go">0.48809523809523814</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">&#39;CH4:1, O2:2, NO:0.1&#39;</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">get_equivalence_ratio</span><span class="p">(</span><span class="n">ignore</span><span class="o">=</span><span class="p">[</span><span class="s1">&#39;NO&#39;</span><span class="p">])</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">X</span> <span class="o">=</span> <span class="s1">'CH4:1, O2:2, NO:0.1'</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">get_equivalence_ratio</span><span class="p">(</span><span class="n">ignore</span><span class="o">=</span><span class="p">[</span><span class="s1">'NO'</span><span class="p">])</span>
 <span class="go">1.0</span>
 </pre></div>
 </div>
@@ -647,87 +643,87 @@ H, C, or S is considered to be an oxidizer.</li>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.gibbs_mass">
-<code class="descname">gibbs_mass</code><a class="headerlink" href="#cantera.ThermoPhase.gibbs_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs_mass</code><a class="headerlink" href="#cantera.ThermoPhase.gibbs_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific Gibbs free energy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.gibbs_mole">
-<code class="descname">gibbs_mole</code><a class="headerlink" href="#cantera.ThermoPhase.gibbs_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs_mole</code><a class="headerlink" href="#cantera.ThermoPhase.gibbs_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar Gibbs free energy [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.h">
-<code class="descname">h</code><a class="headerlink" href="#cantera.ThermoPhase.h" title="Permalink to this definition">¶</a></dt>
+<code class="descname">h</code><a class="headerlink" href="#cantera.ThermoPhase.h" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Enthalpy [J/kg or J/kmol] depending on <a class="reference internal" href="#cantera.ThermoPhase.basis" title="cantera.ThermoPhase.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.int_energy_mass">
-<code class="descname">int_energy_mass</code><a class="headerlink" href="#cantera.ThermoPhase.int_energy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">int_energy_mass</code><a class="headerlink" href="#cantera.ThermoPhase.int_energy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific internal energy [J/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.int_energy_mole">
-<code class="descname">int_energy_mole</code><a class="headerlink" href="#cantera.ThermoPhase.int_energy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">int_energy_mole</code><a class="headerlink" href="#cantera.ThermoPhase.int_energy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar internal energy [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.isothermal_compressibility">
-<code class="descname">isothermal_compressibility</code><a class="headerlink" href="#cantera.ThermoPhase.isothermal_compressibility" title="Permalink to this definition">¶</a></dt>
+<code class="descname">isothermal_compressibility</code><a class="headerlink" href="#cantera.ThermoPhase.isothermal_compressibility" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Isothermal compressibility [1/Pa].</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.mass_fraction_dict">
-<code class="descname">mass_fraction_dict</code><span class="sig-paren">(</span><em>self</em>, <em>double threshold=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.mass_fraction_dict" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mass_fraction_dict</code><span class="sig-paren">(</span><em>self</em>, <em>double threshold=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.mass_fraction_dict" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.max_temp">
-<code class="descname">max_temp</code><a class="headerlink" href="#cantera.ThermoPhase.max_temp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">max_temp</code><a class="headerlink" href="#cantera.ThermoPhase.max_temp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Maximum temperature for which the thermodynamic data for the phase are
 valid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.mean_molecular_weight">
-<code class="descname">mean_molecular_weight</code><a class="headerlink" href="#cantera.ThermoPhase.mean_molecular_weight" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mean_molecular_weight</code><a class="headerlink" href="#cantera.ThermoPhase.mean_molecular_weight" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The mean molecular weight (molar mass) [kg/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.min_temp">
-<code class="descname">min_temp</code><a class="headerlink" href="#cantera.ThermoPhase.min_temp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">min_temp</code><a class="headerlink" href="#cantera.ThermoPhase.min_temp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Minimum temperature for which the thermodynamic data for the phase are
 valid.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.modify_species">
-<code class="descname">modify_species</code><span class="sig-paren">(</span><em>self</em>, <em>k</em>, <em>Species species</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.modify_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">modify_species</code><span class="sig-paren">(</span><em>self</em>, <em>k</em>, <em>Species species</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.modify_species" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.mole_fraction_dict">
-<code class="descname">mole_fraction_dict</code><span class="sig-paren">(</span><em>self</em>, <em>double threshold=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.mole_fraction_dict" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mole_fraction_dict</code><span class="sig-paren">(</span><em>self</em>, <em>double threshold=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.mole_fraction_dict" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.molecular_weights">
-<code class="descname">molecular_weights</code><a class="headerlink" href="#cantera.ThermoPhase.molecular_weights" title="Permalink to this definition">¶</a></dt>
+<code class="descname">molecular_weights</code><a class="headerlink" href="#cantera.ThermoPhase.molecular_weights" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species molecular weights (molar masses) [kg/kmol].</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.n_atoms">
-<code class="descname">n_atoms</code><span class="sig-paren">(</span><em>self</em>, <em>species</em>, <em>element</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.n_atoms" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_atoms</code><span class="sig-paren">(</span><em>self</em>, <em>species</em>, <em>element</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.n_atoms" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of atoms of element <em>element</em> in species <em>species</em>. The element
 and species may be specified by name or by index.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">n_atoms</span><span class="p">(</span><span class="s1">&#39;CH4&#39;</span><span class="p">,</span><span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">phase</span><span class="o">.</span><span class="n">n_atoms</span><span class="p">(</span><span class="s1">'CH4'</span><span class="p">,</span><span class="s1">'H'</span><span class="p">)</span>
 <span class="go">4</span>
 </pre></div>
 </div>
@@ -735,69 +731,69 @@ and species may be specified by name or by index.</p>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.n_elements">
-<code class="descname">n_elements</code><a class="headerlink" href="#cantera.ThermoPhase.n_elements" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_elements</code><a class="headerlink" href="#cantera.ThermoPhase.n_elements" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of elements.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.n_selected_species">
-<code class="descname">n_selected_species</code><a class="headerlink" href="#cantera.ThermoPhase.n_selected_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_selected_species</code><a class="headerlink" href="#cantera.ThermoPhase.n_selected_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of species selected for output (by slicing of Solution object)</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.n_species">
-<code class="descname">n_species</code><a class="headerlink" href="#cantera.ThermoPhase.n_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_species</code><a class="headerlink" href="#cantera.ThermoPhase.n_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of species.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.name">
-<code class="descname">name</code><a class="headerlink" href="#cantera.ThermoPhase.name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">name</code><a class="headerlink" href="#cantera.ThermoPhase.name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The name assigned to this phase. The default is taken from the CTI/XML
 input file.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.partial_molar_cp">
-<code class="descname">partial_molar_cp</code><a class="headerlink" href="#cantera.ThermoPhase.partial_molar_cp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_cp</code><a class="headerlink" href="#cantera.ThermoPhase.partial_molar_cp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar specific heat capacities at constant
 pressure [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.partial_molar_enthalpies">
-<code class="descname">partial_molar_enthalpies</code><a class="headerlink" href="#cantera.ThermoPhase.partial_molar_enthalpies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_enthalpies</code><a class="headerlink" href="#cantera.ThermoPhase.partial_molar_enthalpies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar enthalpies [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.partial_molar_entropies">
-<code class="descname">partial_molar_entropies</code><a class="headerlink" href="#cantera.ThermoPhase.partial_molar_entropies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_entropies</code><a class="headerlink" href="#cantera.ThermoPhase.partial_molar_entropies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar entropies [J/kmol/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.partial_molar_int_energies">
-<code class="descname">partial_molar_int_energies</code><a class="headerlink" href="#cantera.ThermoPhase.partial_molar_int_energies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_int_energies</code><a class="headerlink" href="#cantera.ThermoPhase.partial_molar_int_energies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar internal energies [J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.partial_molar_volumes">
-<code class="descname">partial_molar_volumes</code><a class="headerlink" href="#cantera.ThermoPhase.partial_molar_volumes" title="Permalink to this definition">¶</a></dt>
+<code class="descname">partial_molar_volumes</code><a class="headerlink" href="#cantera.ThermoPhase.partial_molar_volumes" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of species partial molar volumes [m^3/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.reference_pressure">
-<code class="descname">reference_pressure</code><a class="headerlink" href="#cantera.ThermoPhase.reference_pressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reference_pressure</code><a class="headerlink" href="#cantera.ThermoPhase.reference_pressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reference state pressure [Pa].</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.report">
-<code class="descname">report</code><span class="sig-paren">(</span><em>self</em>, <em>show_thermo=True</em>, <em>float threshold=1e-14</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.report" title="Permalink to this definition">¶</a></dt>
+<code class="descname">report</code><span class="sig-paren">(</span><em>self</em>, <em>show_thermo=True</em>, <em>float threshold=1e-14</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.report" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Generate a report describing the thermodynamic state of this phase. To
 print the report to the terminal, simply call the phase object. The
 following two statements are equivalent:</p>
@@ -809,35 +805,35 @@ following two statements are equivalent:</p>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.s">
-<code class="descname">s</code><a class="headerlink" href="#cantera.ThermoPhase.s" title="Permalink to this definition">¶</a></dt>
+<code class="descname">s</code><a class="headerlink" href="#cantera.ThermoPhase.s" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Entropy [J/kg/K or J/kmol/K] depending on <a class="reference internal" href="#cantera.ThermoPhase.basis" title="cantera.ThermoPhase.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.set_equivalence_ratio">
-<code class="descname">set_equivalence_ratio</code><span class="sig-paren">(</span><em>self</em>, <em>phi</em>, <em>fuel</em>, <em>oxidizer</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.set_equivalence_ratio" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_equivalence_ratio</code><span class="sig-paren">(</span><em>self</em>, <em>phi</em>, <em>fuel</em>, <em>oxidizer</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.set_equivalence_ratio" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the composition to a mixture of <em>fuel</em> and <em>oxidizer</em> at the
 specified equivalence ratio <em>phi</em>, holding temperature and pressure
 constant. Considers the oxidation of C to CO2, H to H2O and S to SO2.
 Other elements are assumed not to participate in oxidation (i.e. N ends up as
 N2):</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">0.5</span><span class="p">,</span> <span class="s1">&#39;CH4&#39;</span><span class="p">,</span> <span class="s1">&#39;O2:1.0, N2:3.76&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">0.5</span><span class="p">,</span> <span class="s1">'CH4'</span><span class="p">,</span> <span class="s1">'O2:1.0, N2:3.76'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">mole_fraction_dict</span><span class="p">()</span>
-<span class="go">{&#39;CH4&#39;: 0.049900199, &#39;N2&#39;: 0.750499001, &#39;O2&#39;: 0.199600798}</span>
+<span class="go">{'CH4': 0.049900199, 'N2': 0.750499001, 'O2': 0.199600798}</span>
 
-<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">1.2</span><span class="p">,</span> <span class="p">{</span><span class="s1">&#39;NH3;:0.8, &#39;</span><span class="n">CO</span><span class="s1">&#39;:0.2}, &#39;</span><span class="n">O2</span><span class="p">:</span><span class="mf">1.0</span><span class="s1">&#39;)</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">set_equivalence_ratio</span><span class="p">(</span><span class="mf">1.2</span><span class="p">,</span> <span class="p">{</span><span class="s1">'NH3;:0.8, '</span><span class="n">CO</span><span class="s1">':0.2}, '</span><span class="n">O2</span><span class="p">:</span><span class="mf">1.0</span><span class="s1">')</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">mole_fraction_dict</span><span class="p">()</span>
-<span class="go">{&#39;CO&#39;: 0.1263157894, &#39;NH3&#39;: 0.505263157, &#39;O2&#39;: 0.36842105}</span>
+<span class="go">{'CO': 0.1263157894, 'NH3': 0.505263157, 'O2': 0.36842105}</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>phi</strong> – Equivalence ratio</li>
-<li><strong>fuel</strong> – Fuel species name or molar composition as string, array, or dict.</li>
-<li><strong>oxidizer</strong> – Oxidizer species name or molar composition as a string, array, or
+<li><strong>phi</strong> &#8211; Equivalence ratio</li>
+<li><strong>fuel</strong> &#8211; Fuel species name or molar composition as string, array, or dict.</li>
+<li><strong>oxidizer</strong> &#8211; Oxidizer species name or molar composition as a string, array, or
 dict.</li>
 </ul>
 </td>
@@ -848,7 +844,7 @@ dict.</li>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.set_unnormalized_mass_fractions">
-<code class="descname">set_unnormalized_mass_fractions</code><span class="sig-paren">(</span><em>self</em>, <em>Y</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.set_unnormalized_mass_fractions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_unnormalized_mass_fractions</code><span class="sig-paren">(</span><em>self</em>, <em>Y</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.set_unnormalized_mass_fractions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mass fractions without normalizing to force sum(Y) == 1.0.
 Useful primarily when calculating derivatives with respect to Y[k] by
 finite difference.</p>
@@ -856,7 +852,7 @@ finite difference.</p>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.set_unnormalized_mole_fractions">
-<code class="descname">set_unnormalized_mole_fractions</code><span class="sig-paren">(</span><em>self</em>, <em>X</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.set_unnormalized_mole_fractions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_unnormalized_mole_fractions</code><span class="sig-paren">(</span><em>self</em>, <em>X</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.set_unnormalized_mole_fractions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mole fractions without normalizing to force sum(X) == 1.0.
 Useful primarily when calculating derivatives with respect to X[k]
 by finite difference.</p>
@@ -864,7 +860,7 @@ by finite difference.</p>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.species">
-<code class="descname">species</code><span class="sig-paren">(</span><em>self</em>, <em>k=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species</code><span class="sig-paren">(</span><em>self</em>, <em>k=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the <a class="reference internal" href="#cantera.Species" title="cantera.Species"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Species</span></code></a> object for species <em>k</em>, where <em>k</em> is either the
 species index or the species name. If <em>k</em> is not specified, a list of
 all species objects is returned. Changes to this object do not affect
@@ -874,7 +870,7 @@ function is called.</p>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.species_index">
-<code class="descname">species_index</code><span class="sig-paren">(</span><em>self</em>, <em>species</em><span class="sig-paren">)</span> &#x2192; int<a class="headerlink" href="#cantera.ThermoPhase.species_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_index</code><span class="sig-paren">(</span><em>self</em>, <em>species</em><span class="sig-paren">)</span> &#8594; int<a class="headerlink" href="#cantera.ThermoPhase.species_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The index of species <em>species</em>, which may be specified as a string or
 an integer. In the latter case, the index is checked for validity and
 returned. If no such species is present, an exception is thrown.</p>
@@ -882,54 +878,54 @@ returned. If no such species is present, an exception is thrown.</p>
 
 <dl class="method">
 <dt id="cantera.ThermoPhase.species_name">
-<code class="descname">species_name</code><span class="sig-paren">(</span><em>self</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.species_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_name</code><span class="sig-paren">(</span><em>self</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ThermoPhase.species_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Name of the species with index <em>k</em>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.species_names">
-<code class="descname">species_names</code><a class="headerlink" href="#cantera.ThermoPhase.species_names" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_names</code><a class="headerlink" href="#cantera.ThermoPhase.species_names" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A list of all the species names.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.standard_cp_R">
-<code class="descname">standard_cp_R</code><a class="headerlink" href="#cantera.ThermoPhase.standard_cp_R" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_cp_R</code><a class="headerlink" href="#cantera.ThermoPhase.standard_cp_R" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state specific heat capacities
 at constant pressure at the current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.standard_enthalpies_RT">
-<code class="descname">standard_enthalpies_RT</code><a class="headerlink" href="#cantera.ThermoPhase.standard_enthalpies_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_enthalpies_RT</code><a class="headerlink" href="#cantera.ThermoPhase.standard_enthalpies_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state enthalpies at the
 current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.standard_entropies_R">
-<code class="descname">standard_entropies_R</code><a class="headerlink" href="#cantera.ThermoPhase.standard_entropies_R" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_entropies_R</code><a class="headerlink" href="#cantera.ThermoPhase.standard_entropies_R" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state entropies at the
 current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.standard_gibbs_RT">
-<code class="descname">standard_gibbs_RT</code><a class="headerlink" href="#cantera.ThermoPhase.standard_gibbs_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_gibbs_RT</code><a class="headerlink" href="#cantera.ThermoPhase.standard_gibbs_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state Gibbs free energies at
 the current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.standard_int_energies_RT">
-<code class="descname">standard_int_energies_RT</code><a class="headerlink" href="#cantera.ThermoPhase.standard_int_energies_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">standard_int_energies_RT</code><a class="headerlink" href="#cantera.ThermoPhase.standard_int_energies_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of nondimensional species standard-state internal energies at the
 current temperature and pressure.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.state">
-<code class="descname">state</code><a class="headerlink" href="#cantera.ThermoPhase.state" title="Permalink to this definition">¶</a></dt>
+<code class="descname">state</code><a class="headerlink" href="#cantera.ThermoPhase.state" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the full thermodynamic state as a single array, arranged as
 [temperature, density, mass fractions] for most phases. Useful mainly
 in cases where it is desired to store many states in a multidimensional
@@ -938,31 +934,31 @@ array.</p>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.thermal_expansion_coeff">
-<code class="descname">thermal_expansion_coeff</code><a class="headerlink" href="#cantera.ThermoPhase.thermal_expansion_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_expansion_coeff</code><a class="headerlink" href="#cantera.ThermoPhase.thermal_expansion_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Thermal expansion coefficient [1/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.u">
-<code class="descname">u</code><a class="headerlink" href="#cantera.ThermoPhase.u" title="Permalink to this definition">¶</a></dt>
+<code class="descname">u</code><a class="headerlink" href="#cantera.ThermoPhase.u" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Internal energy in [J/kg or J/kmol].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.v">
-<code class="descname">v</code><a class="headerlink" href="#cantera.ThermoPhase.v" title="Permalink to this definition">¶</a></dt>
+<code class="descname">v</code><a class="headerlink" href="#cantera.ThermoPhase.v" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific volume [m^3/kg or m^3/kmol] depending on <a class="reference internal" href="#cantera.ThermoPhase.basis" title="cantera.ThermoPhase.basis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">basis</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.volume_mass">
-<code class="descname">volume_mass</code><a class="headerlink" href="#cantera.ThermoPhase.volume_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume_mass</code><a class="headerlink" href="#cantera.ThermoPhase.volume_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specific volume [m^3/kg].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ThermoPhase.volume_mole">
-<code class="descname">volume_mole</code><a class="headerlink" href="#cantera.ThermoPhase.volume_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume_mole</code><a class="headerlink" href="#cantera.ThermoPhase.volume_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar volume [m^3/kmol].</p>
 </dd></dl>
 
@@ -970,21 +966,21 @@ array.</p>
 
 </div>
 <div class="section" id="interfacephase">
-<h3><a class="toc-backref" href="#id7">InterfacePhase</a><a class="headerlink" href="#interfacephase" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id7">InterfacePhase</a><a class="headerlink" href="#interfacephase" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.InterfacePhase">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">InterfacePhase</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfacePhase" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">InterfacePhase</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfacePhase" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.ThermoPhase</span></code></p>
 <p>A class representing a surface or edge phase</p>
 <dl class="attribute">
 <dt id="cantera.InterfacePhase.coverages">
-<code class="descname">coverages</code><a class="headerlink" href="#cantera.InterfacePhase.coverages" title="Permalink to this definition">¶</a></dt>
+<code class="descname">coverages</code><a class="headerlink" href="#cantera.InterfacePhase.coverages" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the fraction of sites covered by each species.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.InterfacePhase.set_unnormalized_coverages">
-<code class="descname">set_unnormalized_coverages</code><span class="sig-paren">(</span><em>self</em>, <em>cov</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfacePhase.set_unnormalized_coverages" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_unnormalized_coverages</code><span class="sig-paren">(</span><em>self</em>, <em>cov</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.InterfacePhase.set_unnormalized_coverages" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the surface coverages without normalizing to force sum(cov) == 1.0.
 Useful primarily when calculating derivatives with respect to cov[k] by
 finite difference.</p>
@@ -992,7 +988,7 @@ finite difference.</p>
 
 <dl class="attribute">
 <dt id="cantera.InterfacePhase.site_density">
-<code class="descname">site_density</code><a class="headerlink" href="#cantera.InterfacePhase.site_density" title="Permalink to this definition">¶</a></dt>
+<code class="descname">site_density</code><a class="headerlink" href="#cantera.InterfacePhase.site_density" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the site density. [kmol/m^2] for surface phases; [kmol/m] for
 edge phases.</p>
 </dd></dl>
@@ -1001,121 +997,121 @@ edge phases.</p>
 
 </div>
 <div class="section" id="purefluid">
-<h3><a class="toc-backref" href="#id8">PureFluid</a><a class="headerlink" href="#purefluid" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id8">PureFluid</a><a class="headerlink" href="#purefluid" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.PureFluid">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">PureFluid</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.PureFluid" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">PureFluid</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.PureFluid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.ThermoPhase</span></code></p>
 <p>A pure substance that can  be a gas, a liquid, a mixed gas-liquid fluid,
 or a fluid beyond its critical point.</p>
 <dl class="attribute">
 <dt id="cantera.PureFluid.DPX">
-<code class="descname">DPX</code><a class="headerlink" href="#cantera.PureFluid.DPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">DPX</code><a class="headerlink" href="#cantera.PureFluid.DPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the density [kg/m^3], pressure [Pa], and vapor fraction.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.HPX">
-<code class="descname">HPX</code><a class="headerlink" href="#cantera.PureFluid.HPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">HPX</code><a class="headerlink" href="#cantera.PureFluid.HPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the enthalpy [J/kg or J/kmol], pressure [Pa] and vapor fraction.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.PV">
-<code class="descname">PV</code><a class="headerlink" href="#cantera.PureFluid.PV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">PV</code><a class="headerlink" href="#cantera.PureFluid.PV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the pressure [Pa] and specific volume [m^3/kg] of
 a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.PX">
-<code class="descname">PX</code><a class="headerlink" href="#cantera.PureFluid.PX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">PX</code><a class="headerlink" href="#cantera.PureFluid.PX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the pressure [Pa] and vapor fraction of a two-phase state.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.SH">
-<code class="descname">SH</code><a class="headerlink" href="#cantera.PureFluid.SH" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SH</code><a class="headerlink" href="#cantera.PureFluid.SH" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the specific entropy [J/kg/K] and the specific
 enthalpy [J/kg] of a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.SPX">
-<code class="descname">SPX</code><a class="headerlink" href="#cantera.PureFluid.SPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SPX</code><a class="headerlink" href="#cantera.PureFluid.SPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the entropy [J/kg/K or J/kmol/K], pressure [Pa], and vapor fraction.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.ST">
-<code class="descname">ST</code><a class="headerlink" href="#cantera.PureFluid.ST" title="Permalink to this definition">¶</a></dt>
+<code class="descname">ST</code><a class="headerlink" href="#cantera.PureFluid.ST" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the entropy [J/kg/K] and temperature [K] of a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.SVX">
-<code class="descname">SVX</code><a class="headerlink" href="#cantera.PureFluid.SVX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SVX</code><a class="headerlink" href="#cantera.PureFluid.SVX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
 m^3/kmol], and vapor fraction.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.TDX">
-<code class="descname">TDX</code><a class="headerlink" href="#cantera.PureFluid.TDX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TDX</code><a class="headerlink" href="#cantera.PureFluid.TDX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the temperature [K], density [kg/m^3 or kmol/m^3], and vapor
 fraction.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.TH">
-<code class="descname">TH</code><a class="headerlink" href="#cantera.PureFluid.TH" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TH</code><a class="headerlink" href="#cantera.PureFluid.TH" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the temperature [K] and the specific enthalpy [J/kg]
 of a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.TPX">
-<code class="descname">TPX</code><a class="headerlink" href="#cantera.PureFluid.TPX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TPX</code><a class="headerlink" href="#cantera.PureFluid.TPX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the temperature [K], pressure [Pa], and vapor fraction.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.TV">
-<code class="descname">TV</code><a class="headerlink" href="#cantera.PureFluid.TV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TV</code><a class="headerlink" href="#cantera.PureFluid.TV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the temperature [K] and specific volume [m^3/kg] of
 a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.TX">
-<code class="descname">TX</code><a class="headerlink" href="#cantera.PureFluid.TX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">TX</code><a class="headerlink" href="#cantera.PureFluid.TX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the temperature [K] and vapor fraction of a two-phase state.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.UP">
-<code class="descname">UP</code><a class="headerlink" href="#cantera.PureFluid.UP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UP</code><a class="headerlink" href="#cantera.PureFluid.UP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the specific internal energy [J/kg] and the
 pressure [Pa] of a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.UVX">
-<code class="descname">UVX</code><a class="headerlink" href="#cantera.PureFluid.UVX" title="Permalink to this definition">¶</a></dt>
+<code class="descname">UVX</code><a class="headerlink" href="#cantera.PureFluid.UVX" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the internal energy [J/kg or J/kmol], specific volume
 [m^3/kg or m^3/kmol], and vapor fraction.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.VH">
-<code class="descname">VH</code><a class="headerlink" href="#cantera.PureFluid.VH" title="Permalink to this definition">¶</a></dt>
+<code class="descname">VH</code><a class="headerlink" href="#cantera.PureFluid.VH" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the specfic volume [m^3/kg] and the specific
 enthalpy [J/kg] of a PureFluid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.PureFluid.X">
-<code class="descname">X</code><a class="headerlink" href="#cantera.PureFluid.X" title="Permalink to this definition">¶</a></dt>
+<code class="descname">X</code><a class="headerlink" href="#cantera.PureFluid.X" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set vapor fraction (quality). Can be set only when in the two-phase
 region.</p>
 </dd></dl>
@@ -1125,66 +1121,66 @@ region.</p>
 </div>
 </div>
 <div class="section" id="mixture">
-<h2><a class="toc-backref" href="#id9">Mixture</a><a class="headerlink" href="#mixture" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id9">Mixture</a><a class="headerlink" href="#mixture" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.Mixture">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Mixture</code><a class="headerlink" href="#cantera.Mixture" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Mixture</code><a class="headerlink" href="#cantera.Mixture" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>Class Mixture represents mixtures of one or more phases of matter.  To
 construct a mixture, supply a list of phases to the constructor, each
 paired with the number of moles for that phase:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">cantera</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;gas.cti&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">cantera</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">'gas.cti'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span><span class="o">.</span><span class="n">species_names</span>
-<span class="go">[&#39;H2&#39;, &#39;H&#39;, &#39;O2&#39;, &#39;O&#39;, &#39;OH&#39;]</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">graphite</span> <span class="o">=</span> <span class="n">cantera</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;graphite.cti&#39;</span><span class="p">)</span>
+<span class="go">['H2', 'H', 'O2', 'O', 'OH']</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">graphite</span> <span class="o">=</span> <span class="n">cantera</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="s1">'graphite.cti'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">graphite</span><span class="o">.</span><span class="n">species_names</span>
-<span class="go">[&#39;C(g)&#39;]</span>
+<span class="go">['C(g)']</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">mix</span> <span class="o">=</span> <span class="n">cantera</span><span class="o">.</span><span class="n">Mixture</span><span class="p">([(</span><span class="n">gas</span><span class="p">,</span> <span class="mf">1.0</span><span class="p">),</span> <span class="p">(</span><span class="n">graphite</span><span class="p">,</span> <span class="mf">0.1</span><span class="p">)])</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">mix</span><span class="o">.</span><span class="n">species_names</span>
-<span class="go">[&#39;H2&#39;, &#39;H&#39;, &#39;O2&#39;, &#39;O&#39;, &#39;OH&#39;, &#39;C(g)&#39;]</span>
+<span class="go">['H2', 'H', 'O2', 'O', 'OH', 'C(g)']</span>
 </pre></div>
 </div>
 <p>Note that the objects representing each phase compute only the intensive
-state of the phase – they do not store any information on the amount of
+state of the phase &#8211; they do not store any information on the amount of
 this phase. Mixture objects, on the other hand, represent the full
 extensive state.</p>
-<p>Mixture objects are ‘lightweight’ in the sense that they do not store
+<p>Mixture objects are &#8216;lightweight&#8217; in the sense that they do not store
 parameters needed to compute thermodynamic or kinetic properties of the
-phases. These are contained in the (‘heavyweight’) phase objects. Multiple
+phases. These are contained in the (&#8216;heavyweight&#8217;) phase objects. Multiple
 mixture objects may be constructed using the same set of phase objects.
 Each one stores its own state information locally, and synchronizes the
 phases objects whenever it requires phase properties.</p>
 <dl class="attribute">
 <dt id="cantera.Mixture.P">
-<code class="descname">P</code><a class="headerlink" href="#cantera.Mixture.P" title="Permalink to this definition">¶</a></dt>
+<code class="descname">P</code><a class="headerlink" href="#cantera.Mixture.P" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get or set the Pressure [Pa] of all phases in the mixture. When set,
 the temperature of the mixture is held fixed.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Mixture.T">
-<code class="descname">T</code><a class="headerlink" href="#cantera.Mixture.T" title="Permalink to this definition">¶</a></dt>
+<code class="descname">T</code><a class="headerlink" href="#cantera.Mixture.T" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get or set the Temperature [K] of all phases in the mixture. When set,
 the pressure of the mixture is held fixed.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Mixture.charge">
-<code class="descname">charge</code><a class="headerlink" href="#cantera.Mixture.charge" title="Permalink to this definition">¶</a></dt>
+<code class="descname">charge</code><a class="headerlink" href="#cantera.Mixture.charge" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The total charge in Coulombs, summed over all phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Mixture.chemical_potentials">
-<code class="descname">chemical_potentials</code><a class="headerlink" href="#cantera.Mixture.chemical_potentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">chemical_potentials</code><a class="headerlink" href="#cantera.Mixture.chemical_potentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The chemical potentials of all species [J/kmol].</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Mixture.element_index">
-<code class="descname">element_index</code><span class="sig-paren">(</span><em>self</em>, <em>element</em><span class="sig-paren">)</span> &#x2192; int<a class="headerlink" href="#cantera.Mixture.element_index" title="Permalink to this definition">¶</a></dt>
-<dd><p>Index of element with name ‘element’.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">mix</span><span class="o">.</span><span class="n">element_index</span><span class="p">(</span><span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<code class="descname">element_index</code><span class="sig-paren">(</span><em>self</em>, <em>element</em><span class="sig-paren">)</span> &#8594; int<a class="headerlink" href="#cantera.Mixture.element_index" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Index of element with name &#8216;element&#8217;.</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">mix</span><span class="o">.</span><span class="n">element_index</span><span class="p">(</span><span class="s1">'H'</span><span class="p">)</span>
 <span class="go">2</span>
 </pre></div>
 </div>
@@ -1192,50 +1188,50 @@ the pressure of the mixture is held fixed.</p>
 
 <dl class="method">
 <dt id="cantera.Mixture.element_moles">
-<code class="descname">element_moles</code><span class="sig-paren">(</span><em>self</em>, <em>e</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.element_moles" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_moles</code><span class="sig-paren">(</span><em>self</em>, <em>e</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.element_moles" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Total number of moles of element <em>e</em>, summed over all species.
 The element may be referenced either by index number or by name.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Mixture.equilibrate">
-<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>self</em>, <em>XY</em>, <em>solver='auto'</em>, <em>rtol=1e-9</em>, <em>max_steps=1000</em>, <em>max_iter=100</em>, <em>estimate_equil=0</em>, <em>log_level=0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.equilibrate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>self</em>, <em>XY</em>, <em>solver='auto'</em>, <em>rtol=1e-9</em>, <em>max_steps=1000</em>, <em>max_iter=100</em>, <em>estimate_equil=0</em>, <em>log_level=0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.equilibrate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set to a state of chemical equilibrium holding property pair <em>XY</em>
 constant. This method uses a version of the VCS algorithm to find the
 composition that minimizes the total Gibbs free energy of the mixture,
 subject to element conservation constraints. For a description of the
-theory, see Smith and Missen, “Chemical Reaction Equilibrium.”</p>
+theory, see Smith and Missen, &#8220;Chemical Reaction Equilibrium.&#8221;</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>XY</strong> – <p>A two-letter string, which must be one of the set:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="p">[</span><span class="s1">&#39;TP&#39;</span><span class="p">,</span> <span class="s1">&#39;HP&#39;</span><span class="p">,</span> <span class="s1">&#39;SP&#39;</span><span class="p">]</span>
+<li><strong>XY</strong> &#8211; <p>A two-letter string, which must be one of the set:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="p">[</span><span class="s1">'TP'</span><span class="p">,</span> <span class="s1">'HP'</span><span class="p">,</span> <span class="s1">'SP'</span><span class="p">]</span>
 </pre></div>
 </div>
 </li>
-<li><strong>solver</strong> – Set to either ‘auto’, ‘vcs’, or ‘gibbs’ to choose
-implementation of the solver to use. ‘vcs’ uses the solver
-implemented in the C++ class ‘VCSnonideal’, ‘gibbs’ uses the one
-implemented in class ‘MultiPhaseEquil’. ‘auto’ will try the ‘vcs’
-solver first and then the ‘gibbs’ solver if that fails.</li>
-<li><strong>rtol</strong> – Error tolerance. Iteration will continue until (Delta mu)/RT is
+<li><strong>solver</strong> &#8211; Set to either &#8216;auto&#8217;, &#8216;vcs&#8217;, or &#8216;gibbs&#8217; to choose
+implementation of the solver to use. &#8216;vcs&#8217; uses the solver
+implemented in the C++ class &#8216;VCSnonideal&#8217;, &#8216;gibbs&#8217; uses the one
+implemented in class &#8216;MultiPhaseEquil&#8217;. &#8216;auto&#8217; will try the &#8216;vcs&#8217;
+solver first and then the &#8216;gibbs&#8217; solver if that fails.</li>
+<li><strong>rtol</strong> &#8211; Error tolerance. Iteration will continue until (Delta mu)/RT is
 less than this value for each reaction. Note that this default is
 very conservative, and good equilibrium solutions may be obtained
 with larger error tolerances.</li>
-<li><strong>max_steps</strong> – Maximum number of steps to take while solving the equilibrium
+<li><strong>max_steps</strong> &#8211; Maximum number of steps to take while solving the equilibrium
 problem for specified <em>T</em> and <em>P</em>.</li>
-<li><strong>max_iter</strong> – Maximum number of temperature and/or pressure iterations.
+<li><strong>max_iter</strong> &#8211; Maximum number of temperature and/or pressure iterations.
 This is only relevant if a property pair other than (T,P) is
 specified.</li>
-<li><strong>estimate_equil</strong> – Flag indicating whether the solver should estimate its own initial
+<li><strong>estimate_equil</strong> &#8211; Flag indicating whether the solver should estimate its own initial
 condition. If 0, the initial mole fraction vector in the phase
 objects are used as the initial condition. If 1, the initial mole
 fraction vector is used if the element abundances are satisfied.
 if -1, the initial mole fraction vector is thrown out, and an
 estimate is formulated.</li>
-<li><strong>log_level</strong> – Determines the amount of output displayed during the solution
+<li><strong>log_level</strong> &#8211; Determines the amount of output displayed during the solution
 process. 0 indicates no output, while larger numbers produce
 successively more verbose information.</li>
 </ul>
@@ -1247,7 +1243,7 @@ successively more verbose information.</li>
 
 <dl class="attribute">
 <dt id="cantera.Mixture.max_temp">
-<code class="descname">max_temp</code><a class="headerlink" href="#cantera.Mixture.max_temp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">max_temp</code><a class="headerlink" href="#cantera.Mixture.max_temp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The maximum temperature for which all species in multi-species
 solutions have valid thermo data. Stoichiometric phases are not
 considered in determining max_temp.</p>
@@ -1255,7 +1251,7 @@ considered in determining max_temp.</p>
 
 <dl class="attribute">
 <dt id="cantera.Mixture.min_temp">
-<code class="descname">min_temp</code><a class="headerlink" href="#cantera.Mixture.min_temp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">min_temp</code><a class="headerlink" href="#cantera.Mixture.min_temp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The minimum temperature for which all species in multi-species
 solutions have valid thermo data. Stoichiometric phases are not
 considered in determining min_temp.</p>
@@ -1263,10 +1259,10 @@ considered in determining min_temp.</p>
 
 <dl class="method">
 <dt id="cantera.Mixture.n_atoms">
-<code class="descname">n_atoms</code><span class="sig-paren">(</span><em>self</em>, <em>k</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.n_atoms" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_atoms</code><span class="sig-paren">(</span><em>self</em>, <em>k</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.n_atoms" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of atoms of element <em>m</em> in the species with global index <em>k</em>.
 The element may be referenced either by name or by index.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">n</span> <span class="o">=</span> <span class="n">mix</span><span class="o">.</span><span class="n">n_atoms</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="s1">&#39;H&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">n</span> <span class="o">=</span> <span class="n">mix</span><span class="o">.</span><span class="n">n_atoms</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="s1">'H'</span><span class="p">)</span>
 <span class="go">4.0</span>
 </pre></div>
 </div>
@@ -1274,55 +1270,55 @@ The element may be referenced either by name or by index.</p>
 
 <dl class="attribute">
 <dt id="cantera.Mixture.n_elements">
-<code class="descname">n_elements</code><a class="headerlink" href="#cantera.Mixture.n_elements" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_elements</code><a class="headerlink" href="#cantera.Mixture.n_elements" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Total number of elements present in the mixture.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Mixture.n_phases">
-<code class="descname">n_phases</code><a class="headerlink" href="#cantera.Mixture.n_phases" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_phases</code><a class="headerlink" href="#cantera.Mixture.n_phases" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of phases</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Mixture.n_species">
-<code class="descname">n_species</code><a class="headerlink" href="#cantera.Mixture.n_species" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_species</code><a class="headerlink" href="#cantera.Mixture.n_species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Number of species.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Mixture.phase">
-<code class="descname">phase</code><span class="sig-paren">(</span><em>self</em>, <em>n</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.phase" title="Permalink to this definition">¶</a></dt>
+<code class="descname">phase</code><span class="sig-paren">(</span><em>self</em>, <em>n</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.phase" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.Mixture.phase_charge">
-<code class="descname">phase_charge</code><span class="sig-paren">(</span><em>self</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.phase_charge" title="Permalink to this definition">¶</a></dt>
+<code class="descname">phase_charge</code><span class="sig-paren">(</span><em>self</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.phase_charge" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The charge of phase <em>p</em> in Coulombs.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Mixture.phase_index">
-<code class="descname">phase_index</code><span class="sig-paren">(</span><em>self</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.phase_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">phase_index</code><span class="sig-paren">(</span><em>self</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.phase_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Index of the phase named <em>p</em>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Mixture.phase_moles">
-<code class="descname">phase_moles</code><span class="sig-paren">(</span><em>self</em>, <em>p=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.phase_moles" title="Permalink to this definition">¶</a></dt>
+<code class="descname">phase_moles</code><span class="sig-paren">(</span><em>self</em>, <em>p=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.phase_moles" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Moles in phase <em>p</em>, if <em>p</em> is specified, otherwise the number of
 moles in all phases.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Mixture.phase_names">
-<code class="descname">phase_names</code><a class="headerlink" href="#cantera.Mixture.phase_names" title="Permalink to this definition">¶</a></dt>
+<code class="descname">phase_names</code><a class="headerlink" href="#cantera.Mixture.phase_names" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Names of all phases in the order added.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Mixture.report">
-<code class="descname">report</code><span class="sig-paren">(</span><em>self</em>, <em>threshold=1e-14</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.report" title="Permalink to this definition">¶</a></dt>
+<code class="descname">report</code><span class="sig-paren">(</span><em>self</em>, <em>threshold=1e-14</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.report" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Generate a report describing the thermodynamic state of this mixture. To
 print the report to the screen, simply call the mixture object. The
 following two statements are equivalent:</p>
@@ -1334,20 +1330,20 @@ following two statements are equivalent:</p>
 
 <dl class="method">
 <dt id="cantera.Mixture.set_phase_moles">
-<code class="descname">set_phase_moles</code><span class="sig-paren">(</span><em>self</em>, <em>p</em>, <em>moles</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.set_phase_moles" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_phase_moles</code><span class="sig-paren">(</span><em>self</em>, <em>p</em>, <em>moles</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.set_phase_moles" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the number of moles of phase <em>p</em> to <em>moles</em></p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Mixture.species_index">
-<code class="descname">species_index</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.species_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_index</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.species_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>phase</strong> – Phase object, index or name</li>
-<li><strong>species</strong> – Species name or index</li>
+<li><strong>phase</strong> &#8211; Phase object, index or name</li>
+<li><strong>species</strong> &#8211; Species name or index</li>
 </ul>
 </td>
 </tr>
@@ -1358,65 +1354,65 @@ following two statements are equivalent:</p>
 
 <dl class="attribute">
 <dt id="cantera.Mixture.species_moles">
-<code class="descname">species_moles</code><a class="headerlink" href="#cantera.Mixture.species_moles" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_moles</code><a class="headerlink" href="#cantera.Mixture.species_moles" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get or set the number of moles of each species. May be set either as a
 string or as an array. If an array is used, it must be dimensioned at
 least as large as the total number of species in the mixture. Note that
 the species may belong to any phase, and unspecified species are set to
 zero.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">mix</span><span class="o">.</span><span class="n">species_moles</span> <span class="o">=</span> <span class="s1">&#39;C(s):1.0, CH4:2.0, O2:0.2&#39;</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">mix</span><span class="o">.</span><span class="n">species_moles</span> <span class="o">=</span> <span class="s1">'C(s):1.0, CH4:2.0, O2:0.2'</span>
 </pre></div>
 </div>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Mixture.species_name">
-<code class="descname">species_name</code><span class="sig-paren">(</span><em>self</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.species_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_name</code><span class="sig-paren">(</span><em>self</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Mixture.species_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Name of the species with index <em>k</em>. Note that index numbers
 are assigned in order as phases are added.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Mixture.species_names">
-<code class="descname">species_names</code><a class="headerlink" href="#cantera.Mixture.species_names" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_names</code><a class="headerlink" href="#cantera.Mixture.species_names" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="species">
-<h2><a class="toc-backref" href="#id10">Species</a><a class="headerlink" href="#species" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id10">Species</a><a class="headerlink" href="#species" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.Species">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Species</code><span class="sig-paren">(</span><em>name=None</em>, <em>composition=None</em>, <em>charge=None</em>, <em>size=None</em>, <em>init=True</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Species</code><span class="sig-paren">(</span><em>name=None</em>, <em>composition=None</em>, <em>charge=None</em>, <em>size=None</em>, <em>init=True</em>, <em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>A class which stores data about a single chemical species that may be
 needed to add it to a <a class="reference internal" href="importing.html#cantera.Solution" title="cantera.Solution"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Solution</span></code></a> or <a class="reference internal" href="importing.html#cantera.Interface" title="cantera.Interface"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Interface</span></code></a> object (and to the
 underlying <a class="reference internal" href="#cantera.ThermoPhase" title="cantera.ThermoPhase"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ThermoPhase</span></code></a> and <a class="reference internal" href="transport.html#cantera.Transport" title="cantera.Transport"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Transport</span></code></a> objects).</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>name</strong> – A string giving the name of the species, e.g. <code class="docutils literal notranslate"><span class="pre">'CH4'</span></code></li>
-<li><strong>composition</strong> – The elemental composition of the species, given either as a dict or a
+<li><strong>name</strong> &#8211; A string giving the name of the species, e.g. <code class="docutils literal notranslate"><span class="pre">'CH4'</span></code></li>
+<li><strong>composition</strong> &#8211; The elemental composition of the species, given either as a dict or a
 composition string, e.g. <code class="docutils literal notranslate"><span class="pre">{'C':1,</span> <span class="pre">'H':4}</span></code> or <code class="docutils literal notranslate"><span class="pre">'C:1,</span> <span class="pre">H:4'</span></code>.</li>
-<li><strong>charge</strong> – The electrical charge, in units of the elementary charge. Default 0.0.</li>
-<li><strong>size</strong> – The effective size [m] of the species. Default 1.0.</li>
-<li><strong>init</strong> – Used internally when wrapping <a class="reference external" href="../../../doxygen/html/d1/d8c/classCantera_1_1Species.html">Species</a> objects returned from C++</li>
+<li><strong>charge</strong> &#8211; The electrical charge, in units of the elementary charge. Default 0.0.</li>
+<li><strong>size</strong> &#8211; The effective size [m] of the species. Default 1.0.</li>
+<li><strong>init</strong> &#8211; Used internally when wrapping <a class="reference external" href="../../../doxygen/html/d1/d8c/classCantera_1_1Species.html">Species</a> objects returned from C++</li>
 </ul>
 </td>
 </tr>
 </tbody>
 </table>
 <p>Example: creating an ideal gas phase with a single species:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">ch4</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Species</span><span class="p">(</span><span class="s1">&#39;CH4&#39;</span><span class="p">,</span> <span class="s1">&#39;C:1, H:4&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">ch4</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Species</span><span class="p">(</span><span class="s1">'CH4'</span><span class="p">,</span> <span class="s1">'C:1, H:4'</span><span class="p">)</span>
 <span class="n">ch4</span><span class="o">.</span><span class="n">thermo</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">ConstantCp</span><span class="p">(</span><span class="mi">300</span><span class="p">,</span> <span class="mi">1000</span><span class="p">,</span> <span class="mi">101325</span><span class="p">,</span>
                            <span class="p">(</span><span class="mi">300</span><span class="p">,</span> <span class="o">-</span><span class="mf">7.453347e7</span><span class="p">,</span> <span class="mf">1.865912e5</span><span class="p">,</span> <span class="mf">3.576053e4</span><span class="p">))</span>
 <span class="n">tran</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">GasTransportData</span><span class="p">()</span>
-<span class="n">tran</span><span class="o">.</span><span class="n">set_customary_units</span><span class="p">(</span><span class="s1">&#39;nonlinear&#39;</span><span class="p">,</span> <span class="mf">3.75</span><span class="p">,</span> <span class="mf">141.40</span><span class="p">,</span> <span class="mf">0.0</span><span class="p">,</span> <span class="mf">2.60</span><span class="p">,</span> <span class="mf">13.00</span><span class="p">)</span>
+<span class="n">tran</span><span class="o">.</span><span class="n">set_customary_units</span><span class="p">(</span><span class="s1">'nonlinear'</span><span class="p">,</span> <span class="mf">3.75</span><span class="p">,</span> <span class="mf">141.40</span><span class="p">,</span> <span class="mf">0.0</span><span class="p">,</span> <span class="mf">2.60</span><span class="p">,</span> <span class="mf">13.00</span><span class="p">)</span>
 <span class="n">ch4</span><span class="o">.</span><span class="n">transport</span> <span class="o">=</span> <span class="n">tran</span>
-<span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="n">thermo</span><span class="o">=</span><span class="s1">&#39;IdealGas&#39;</span><span class="p">,</span> <span class="n">species</span><span class="o">=</span><span class="p">[</span><span class="n">ch4</span><span class="p">])</span>
+<span class="n">gas</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Solution</span><span class="p">(</span><span class="n">thermo</span><span class="o">=</span><span class="s1">'IdealGas'</span><span class="p">,</span> <span class="n">species</span><span class="o">=</span><span class="p">[</span><span class="n">ch4</span><span class="p">])</span>
 </pre></div>
 </div>
 <p>The static methods <a class="reference internal" href="#cantera.Species.fromCti" title="cantera.Species.fromCti"><code class="xref py py-obj docutils literal notranslate"><span class="pre">fromCti</span></code></a>, <a class="reference internal" href="#cantera.Species.fromXml" title="cantera.Species.fromXml"><code class="xref py py-obj docutils literal notranslate"><span class="pre">fromXml</span></code></a>, <a class="reference internal" href="#cantera.Species.listFromFile" title="cantera.Species.listFromFile"><code class="xref py py-obj docutils literal notranslate"><span class="pre">listFromFile</span></code></a>, <a class="reference internal" href="#cantera.Species.listFromCti" title="cantera.Species.listFromCti"><code class="xref py py-obj docutils literal notranslate"><span class="pre">listFromCti</span></code></a>, and
@@ -1424,49 +1420,49 @@ composition string, e.g. <code class="docutils literal notranslate"><span class=
 definitions in the CTI or XML formats. All of the following will produce a
 list of 53 <a class="reference internal" href="#cantera.Species" title="cantera.Species"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Species</span></code></a> objects containing the species defined in the GRI 3.0
 mechanism:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">S</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Species</span><span class="o">.</span><span class="n">listFromFile</span><span class="p">(</span><span class="s1">&#39;gri30.cti&#39;</span><span class="p">)</span>
-<span class="n">S</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Species</span><span class="o">.</span><span class="n">listFromCti</span><span class="p">(</span><span class="nb">open</span><span class="p">(</span><span class="s1">&#39;path/to/gri30.cti&#39;</span><span class="p">)</span><span class="o">.</span><span class="n">read</span><span class="p">())</span>
-<span class="n">S</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Species</span><span class="o">.</span><span class="n">listFromXml</span><span class="p">(</span><span class="nb">open</span><span class="p">(</span><span class="s1">&#39;path/to/gri30.xml&#39;</span><span class="p">)</span><span class="o">.</span><span class="n">read</span><span class="p">())</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">S</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Species</span><span class="o">.</span><span class="n">listFromFile</span><span class="p">(</span><span class="s1">'gri30.cti'</span><span class="p">)</span>
+<span class="n">S</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Species</span><span class="o">.</span><span class="n">listFromCti</span><span class="p">(</span><span class="nb">open</span><span class="p">(</span><span class="s1">'path/to/gri30.cti'</span><span class="p">)</span><span class="o">.</span><span class="n">read</span><span class="p">())</span>
+<span class="n">S</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Species</span><span class="o">.</span><span class="n">listFromXml</span><span class="p">(</span><span class="nb">open</span><span class="p">(</span><span class="s1">'path/to/gri30.xml'</span><span class="p">)</span><span class="o">.</span><span class="n">read</span><span class="p">())</span>
 </pre></div>
 </div>
 <dl class="attribute">
 <dt id="cantera.Species.charge">
-<code class="descname">charge</code><a class="headerlink" href="#cantera.Species.charge" title="Permalink to this definition">¶</a></dt>
+<code class="descname">charge</code><a class="headerlink" href="#cantera.Species.charge" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The electrical charge on the species, in units of the elementary charge.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Species.composition">
-<code class="descname">composition</code><a class="headerlink" href="#cantera.Species.composition" title="Permalink to this definition">¶</a></dt>
+<code class="descname">composition</code><a class="headerlink" href="#cantera.Species.composition" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>A dict containing the elemental composition of the species. Keys are
 element names; values are the corresponding atomicities.</p>
 </dd></dl>
 
 <dl class="staticmethod">
 <dt id="cantera.Species.fromCti">
-<em class="property">static </em><code class="descname">fromCti</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species.fromCti" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">fromCti</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species.fromCti" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a Species object from its CTI string representation.</p>
 </dd></dl>
 
 <dl class="staticmethod">
 <dt id="cantera.Species.fromXml">
-<em class="property">static </em><code class="descname">fromXml</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species.fromXml" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">fromXml</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species.fromXml" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a Species object from its XML string representation.</p>
 </dd></dl>
 
 <dl class="staticmethod">
 <dt id="cantera.Species.listFromCti">
-<em class="property">static </em><code class="descname">listFromCti</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species.listFromCti" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">listFromCti</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species.listFromCti" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a list of Species objects from all the species defined in a CTI
 string.</p>
 </dd></dl>
 
 <dl class="staticmethod">
 <dt id="cantera.Species.listFromFile">
-<em class="property">static </em><code class="descname">listFromFile</code><span class="sig-paren">(</span><em>filename</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species.listFromFile" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">listFromFile</code><span class="sig-paren">(</span><em>filename</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species.listFromFile" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a list of Species objects from all of the species defined in a
 CTI or XML file.</p>
-<p>Directories on Cantera’s input file path will be searched for the
+<p>Directories on Cantera&#8217;s input file path will be searched for the
 specified file.</p>
 <p>In the case of an XML file, the <code class="docutils literal notranslate"><span class="pre">&lt;species&gt;</span></code> nodes are assumed to be
 children of the <code class="docutils literal notranslate"><span class="pre">&lt;speciesData&gt;</span></code> node in a document with a <code class="docutils literal notranslate"><span class="pre">&lt;ctml&gt;</span></code>
@@ -1475,7 +1471,7 @@ root node, as in the XML files produced by conversion from CTI files.</p>
 
 <dl class="staticmethod">
 <dt id="cantera.Species.listFromXml">
-<em class="property">static </em><code class="descname">listFromXml</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species.listFromXml" title="Permalink to this definition">¶</a></dt>
+<em class="property">static </em><code class="descname">listFromXml</code><span class="sig-paren">(</span><em>text</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Species.listFromXml" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a list of Species objects from all the species defined in an XML
 string. The <code class="docutils literal notranslate"><span class="pre">&lt;species&gt;</span></code> nodes are assumed to be children of the
 <code class="docutils literal notranslate"><span class="pre">&lt;speciesData&gt;</span></code> node in a document with a <code class="docutils literal notranslate"><span class="pre">&lt;ctml&gt;</span></code> root node, as in
@@ -1484,26 +1480,26 @@ the XML files produced by conversion from CTI files.</p>
 
 <dl class="attribute">
 <dt id="cantera.Species.name">
-<code class="descname">name</code><a class="headerlink" href="#cantera.Species.name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">name</code><a class="headerlink" href="#cantera.Species.name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The name of the species.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Species.size">
-<code class="descname">size</code><a class="headerlink" href="#cantera.Species.size" title="Permalink to this definition">¶</a></dt>
+<code class="descname">size</code><a class="headerlink" href="#cantera.Species.size" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The effective size [m] of the species.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Species.thermo">
-<code class="descname">thermo</code><a class="headerlink" href="#cantera.Species.thermo" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermo</code><a class="headerlink" href="#cantera.Species.thermo" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species reference-state thermodynamic data, as an instance
 of class <a class="reference internal" href="#cantera.SpeciesThermo" title="cantera.SpeciesThermo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">SpeciesThermo</span></code></a>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Species.transport">
-<code class="descname">transport</code><a class="headerlink" href="#cantera.Species.transport" title="Permalink to this definition">¶</a></dt>
+<code class="descname">transport</code><a class="headerlink" href="#cantera.Species.transport" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the species transport parameters, as an instance of class
 <a class="reference internal" href="transport.html#cantera.GasTransportData" title="cantera.GasTransportData"><code class="xref py py-obj docutils literal notranslate"><span class="pre">GasTransportData</span></code></a>.</p>
 </dd></dl>
@@ -1512,28 +1508,28 @@ of class <a class="reference internal" href="#cantera.SpeciesThermo" title="cant
 
 </div>
 <div class="section" id="species-thermodynamic-properties">
-<h2><a class="toc-backref" href="#id11">Species Thermodynamic Properties</a><a class="headerlink" href="#species-thermodynamic-properties" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id11">Species Thermodynamic Properties</a><a class="headerlink" href="#species-thermodynamic-properties" title="Permalink to this headline">&#182;</a></h2>
 <p>These classes are used to describe the reference-state thermodynamic properties
 of a pure species.</p>
 <div class="section" id="speciesthermo">
-<h3><a class="toc-backref" href="#id12">SpeciesThermo</a><a class="headerlink" href="#speciesthermo" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id12">SpeciesThermo</a><a class="headerlink" href="#speciesthermo" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.SpeciesThermo">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">SpeciesThermo</code><span class="sig-paren">(</span><em>T_low</em>, <em>T_high</em>, <em>P_ref</em>, <em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SpeciesThermo" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">SpeciesThermo</code><span class="sig-paren">(</span><em>T_low</em>, <em>T_high</em>, <em>P_ref</em>, <em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SpeciesThermo" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>Base class for representing the reference-state thermodynamic properties of
 a pure species. These properties are a function of temperature. Derived
 classes implement a parameterization of this temperature dependence. This is
 a wrapper for the C++ class <a class="reference external" href="../../../doxygen/html/dc/de2/classCantera_1_1SpeciesThermoInterpType.html">SpeciesThermoInterpType</a>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>T_low</strong> – The minimum temperature [K] at which the parameterization is valid</li>
-<li><strong>T_high</strong> – The maximum temperature [K] at which the parameterization is valid</li>
-<li><strong>P_ref</strong> – The reference pressure [Pa] for the parameterization</li>
-<li><strong>coeffs</strong> – An array of coefficients for the parameterization. The length of this
+<li><strong>T_low</strong> &#8211; The minimum temperature [K] at which the parameterization is valid</li>
+<li><strong>T_high</strong> &#8211; The maximum temperature [K] at which the parameterization is valid</li>
+<li><strong>P_ref</strong> &#8211; The reference pressure [Pa] for the parameterization</li>
+<li><strong>coeffs</strong> &#8211; An array of coefficients for the parameterization. The length of this
 array and the meaning of each element depends on the specific
 parameterization.</li>
 </ul>
@@ -1543,7 +1539,7 @@ parameterization.</li>
 </table>
 <dl class="attribute">
 <dt id="cantera.SpeciesThermo.coeffs">
-<code class="descname">coeffs</code><a class="headerlink" href="#cantera.SpeciesThermo.coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">coeffs</code><a class="headerlink" href="#cantera.SpeciesThermo.coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Array of coefficients for the parameterization. The length of this
 array and the meaning of each element depends on the specific
 parameterization.</p>
@@ -1551,37 +1547,37 @@ parameterization.</p>
 
 <dl class="method">
 <dt id="cantera.SpeciesThermo.cp">
-<code class="descname">cp</code><span class="sig-paren">(</span><em>self</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SpeciesThermo.cp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp</code><span class="sig-paren">(</span><em>self</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SpeciesThermo.cp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar heat capacity at constant pressure [J/kmol/K] at temperature <em>T</em>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.SpeciesThermo.h">
-<code class="descname">h</code><span class="sig-paren">(</span><em>self</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SpeciesThermo.h" title="Permalink to this definition">¶</a></dt>
+<code class="descname">h</code><span class="sig-paren">(</span><em>self</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SpeciesThermo.h" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar enthalpy [J/kmol] at temperature <em>T</em></p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SpeciesThermo.max_temp">
-<code class="descname">max_temp</code><a class="headerlink" href="#cantera.SpeciesThermo.max_temp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">max_temp</code><a class="headerlink" href="#cantera.SpeciesThermo.max_temp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Maximum temperature [K] at which the parameterization is valid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SpeciesThermo.min_temp">
-<code class="descname">min_temp</code><a class="headerlink" href="#cantera.SpeciesThermo.min_temp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">min_temp</code><a class="headerlink" href="#cantera.SpeciesThermo.min_temp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Minimum temperature [K] at which the parameterization is valid.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.SpeciesThermo.reference_pressure">
-<code class="descname">reference_pressure</code><a class="headerlink" href="#cantera.SpeciesThermo.reference_pressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reference_pressure</code><a class="headerlink" href="#cantera.SpeciesThermo.reference_pressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reference pressure [Pa] for the parameterization.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.SpeciesThermo.s">
-<code class="descname">s</code><span class="sig-paren">(</span><em>self</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SpeciesThermo.s" title="Permalink to this definition">¶</a></dt>
+<code class="descname">s</code><span class="sig-paren">(</span><em>self</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.SpeciesThermo.s" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Molar entropy [J/kmol/K] at temperature <em>T</em></p>
 </dd></dl>
 
@@ -1589,18 +1585,18 @@ parameterization.</p>
 
 </div>
 <div class="section" id="constantcp">
-<h3><a class="toc-backref" href="#id13">ConstantCp</a><a class="headerlink" href="#constantcp" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id13">ConstantCp</a><a class="headerlink" href="#constantcp" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ConstantCp">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ConstantCp</code><span class="sig-paren">(</span><em>T_low</em>, <em>T_high</em>, <em>P_ref</em>, <em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ConstantCp" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ConstantCp</code><span class="sig-paren">(</span><em>T_low</em>, <em>T_high</em>, <em>P_ref</em>, <em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ConstantCp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.SpeciesThermo</span></code></p>
 <p>Thermodynamic properties for a species that has a constant specific heat
 capacity. This is a wrapper for the C++ class <a class="reference external" href="../../../doxygen/html/df/d7e/classCantera_1_1ConstCpPoly.html">ConstCpPoly</a>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>coeffs</strong> – <p>An array of 4 elements:</p>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>coeffs</strong> &#8211; <p>An array of 4 elements:</p>
 <blockquote>
 <div><ul class="simple">
 <li><code class="xref py py-obj docutils literal notranslate"><span class="pre">coeffs[0]</span></code> = <span class="math">\(T_0\)</span> [K]</li>
@@ -1617,19 +1613,19 @@ capacity. This is a wrapper for the C++ class <a class="reference external" href
 
 </div>
 <div class="section" id="nasapoly2">
-<h3><a class="toc-backref" href="#id14">NasaPoly2</a><a class="headerlink" href="#nasapoly2" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id14">NasaPoly2</a><a class="headerlink" href="#nasapoly2" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.NasaPoly2">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">NasaPoly2</code><span class="sig-paren">(</span><em>T_low</em>, <em>T_high</em>, <em>P_ref</em>, <em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.NasaPoly2" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">NasaPoly2</code><span class="sig-paren">(</span><em>T_low</em>, <em>T_high</em>, <em>P_ref</em>, <em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.NasaPoly2" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.SpeciesThermo</span></code></p>
 <p>Thermodynamic properties for a species which is parameterized using the
 7-coefficient NASA polynomial form in two temperature ranges. This is a
 wrapper for the C++ class <a class="reference external" href="../../../doxygen/html/db/ddd/classCantera_1_1NasaPoly2.html">NasaPoly2</a>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>coeffs</strong> – <p>An array of 15 elements, in the following order:</p>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>coeffs</strong> &#8211; <p>An array of 15 elements, in the following order:</p>
 <blockquote>
 <div><ul class="simple">
 <li><code class="xref py py-obj docutils literal notranslate"><span class="pre">coeffs[0]</span></code>: The mid-point temperature [K] between the two
@@ -1650,19 +1646,19 @@ input files.</p>
 
 </div>
 <div class="section" id="shomatepoly2">
-<h3><a class="toc-backref" href="#id15">ShomatePoly2</a><a class="headerlink" href="#shomatepoly2" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id15">ShomatePoly2</a><a class="headerlink" href="#shomatepoly2" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ShomatePoly2">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ShomatePoly2</code><span class="sig-paren">(</span><em>T_low</em>, <em>T_high</em>, <em>P_ref</em>, <em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ShomatePoly2" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ShomatePoly2</code><span class="sig-paren">(</span><em>T_low</em>, <em>T_high</em>, <em>P_ref</em>, <em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ShomatePoly2" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.SpeciesThermo</span></code></p>
 <p>Thermodynamic properties for a species which is parameterized using the
 Shomate equation in two temperature ranges. This is a wrapper for the C++
 class <a class="reference external" href="../../../doxygen/html/da/d9a/classCantera_1_1ShomatePoly2.html">ShomatePoly2</a>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>coeffs</strong> – <p>An array of 15 elements, in the following order:</p>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>coeffs</strong> &#8211; <p>An array of 15 elements, in the following order:</p>
 <blockquote>
 <div><ul class="simple">
 <li><code class="xref py py-obj docutils literal notranslate"><span class="pre">coeffs[0]</span></code>: The mid-point temperature [K] between the two
@@ -1685,10 +1681,10 @@ as in the NIST Chemistry WebBook).</p>
 </div>
 </div>
 <div class="section" id="element">
-<h2><a class="toc-backref" href="#id16">Element</a><a class="headerlink" href="#element" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id16">Element</a><a class="headerlink" href="#element" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.Element">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Element</code><span class="sig-paren">(</span><em>self</em>, <em>arg</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Element" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Element</code><span class="sig-paren">(</span><em>self</em>, <em>arg</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Element" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>An element or a named isotope defined in Cantera.</p>
 <p>Class <a class="reference internal" href="#cantera.Element" title="cantera.Element"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Element</span></code></a> gets data for the elements and isotopes defined in
@@ -1703,8 +1699,8 @@ Cantera. The three attributes <a class="reference internal" href="#cantera.Eleme
 </div>
 <p>Otherwise, if the class <a class="reference internal" href="#cantera.Element" title="cantera.Element"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Element</span></code></a> is called with an argument, it
 stores the data about that particular element. For example:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">ar_sym</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Element</span><span class="p">(</span><span class="s1">&#39;Ar&#39;</span><span class="p">)</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">ar_name</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Element</span><span class="p">(</span><span class="s1">&#39;argon&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">ar_sym</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Element</span><span class="p">(</span><span class="s1">'Ar'</span><span class="p">)</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">ar_name</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Element</span><span class="p">(</span><span class="s1">'argon'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">ar_num</span> <span class="o">=</span> <span class="n">ct</span><span class="o">.</span><span class="n">Element</span><span class="p">(</span><span class="mi">18</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -1715,53 +1711,53 @@ class with the element information are the <a class="reference internal" href="#
 <a class="reference internal" href="#cantera.Element.atomic_number" title="cantera.Element.atomic_number"><code class="xref py py-obj docutils literal notranslate"><span class="pre">atomic_number</span></code></a>, <a class="reference internal" href="#cantera.Element.symbol" title="cantera.Element.symbol"><code class="xref py py-obj docutils literal notranslate"><span class="pre">symbol</span></code></a>, and atomic <a class="reference internal" href="#cantera.Element.weight" title="cantera.Element.weight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">weight</span></code></a> can be accessed as
 attributes of the instance of the <a class="reference internal" href="#cantera.Element" title="cantera.Element"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Element</span></code></a> class.</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">ar_sym</span><span class="o">.</span><span class="n">name</span>
-<span class="go">&#39;argon&#39;</span>
+<span class="go">'argon'</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">ar_sym</span><span class="o">.</span><span class="n">weight</span>
 <span class="go">39.948</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">ar_sym</span><span class="o">.</span><span class="n">atomic_number</span>
 <span class="go">18</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">ar_sym</span><span class="o">.</span><span class="n">symbol</span>
-<span class="go">&#39;Ar&#39;</span>
+<span class="go">'Ar'</span>
 </pre></div>
 </div>
 <p>The elements available are listed below, in the <a class="reference internal" href="#cantera.Element.element_symbols" title="cantera.Element.element_symbols"><code class="xref py py-obj docutils literal notranslate"><span class="pre">element_symbols</span></code></a>
 and <a class="reference internal" href="#cantera.Element.element_names" title="cantera.Element.element_names"><code class="xref py py-obj docutils literal notranslate"><span class="pre">element_names</span></code></a> attribute documentation.</p>
 <dl class="attribute">
 <dt id="cantera.Element.num_elements_defined">
-<code class="descname">num_elements_defined</code><em class="property"> = 94</em><a class="headerlink" href="#cantera.Element.num_elements_defined" title="Permalink to this definition">¶</a></dt>
+<code class="descname">num_elements_defined</code><em class="property"> = 94</em><a class="headerlink" href="#cantera.Element.num_elements_defined" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Element.element_symbols">
-<code class="descname">element_symbols</code><em class="property"> = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne', 'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca', 'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Ga', 'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb', 'Sr', 'Y', 'Zr', 'Nb', 'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn', 'Sb', 'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd', 'Pm', 'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb', 'Lu', 'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg', 'Tl', 'Pb', 'Bi', 'Po', 'At', 'Rn', 'Fr', 'Ra', 'Ac', 'Th', 'Pa', 'U', 'Np', 'Pu']</em><a class="headerlink" href="#cantera.Element.element_symbols" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_symbols</code><em class="property"> = ['H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne', 'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca', 'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn', 'Ga', 'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb', 'Sr', 'Y', 'Zr', 'Nb', 'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn', 'Sb', 'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd', 'Pm', 'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb', 'Lu', 'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg', 'Tl', 'Pb', 'Bi', 'Po', 'At', 'Rn', 'Fr', 'Ra', 'Ac', 'Th', 'Pa', 'U', 'Np', 'Pu']</em><a class="headerlink" href="#cantera.Element.element_symbols" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Element.element_names">
-<code class="descname">element_names</code><em class="property"> = ['hydrogen', 'helium', 'lithium', 'beryllium', 'boron', 'carbon', 'nitrogen', 'oxygen', 'fluorine', 'neon', 'sodium', 'magnesium', 'aluminum', 'silicon', 'phosphorus', 'sulfur', 'chlorine', 'argon', 'potassium', 'calcium', 'scandium', 'titanium', 'vanadium', 'chromium', 'manganese', 'iron', 'cobalt', 'nickel', 'copper', 'zinc', 'gallium', 'germanium', 'arsenic', 'selenium', 'bromine', 'krypton', 'rubidium', 'strontium', 'yttrium', 'zirconium', 'nobelium', 'molybdenum', 'technetium', 'ruthenium', 'rhodium', 'palladium', 'silver', 'cadmium', 'indium', 'tin', 'antimony', 'tellurium', 'iodine', 'xenon', 'cesium', 'barium', 'lanthanum', 'cerium', 'praseodymium', 'neodymium', 'promethium', 'samarium', 'europium', 'gadolinium', 'terbium', 'dysprosium', 'holmium', 'erbium', 'thulium', 'ytterbium', 'lutetium', 'hafnium', 'tantalum', 'tungsten', 'rhenium', 'osmium', 'iridium', 'platinum', 'gold', 'mercury', 'thallium', 'lead', 'bismuth', 'polonium', 'astatine', 'radon', 'francium', 'radium', 'actinium', 'thorium', 'protactinium', 'uranium', 'neptunium', 'plutonium']</em><a class="headerlink" href="#cantera.Element.element_names" title="Permalink to this definition">¶</a></dt>
+<code class="descname">element_names</code><em class="property"> = ['hydrogen', 'helium', 'lithium', 'beryllium', 'boron', 'carbon', 'nitrogen', 'oxygen', 'fluorine', 'neon', 'sodium', 'magnesium', 'aluminum', 'silicon', 'phosphorus', 'sulfur', 'chlorine', 'argon', 'potassium', 'calcium', 'scandium', 'titanium', 'vanadium', 'chromium', 'manganese', 'iron', 'cobalt', 'nickel', 'copper', 'zinc', 'gallium', 'germanium', 'arsenic', 'selenium', 'bromine', 'krypton', 'rubidium', 'strontium', 'yttrium', 'zirconium', 'nobelium', 'molybdenum', 'technetium', 'ruthenium', 'rhodium', 'palladium', 'silver', 'cadmium', 'indium', 'tin', 'antimony', 'tellurium', 'iodine', 'xenon', 'cesium', 'barium', 'lanthanum', 'cerium', 'praseodymium', 'neodymium', 'promethium', 'samarium', 'europium', 'gadolinium', 'terbium', 'dysprosium', 'holmium', 'erbium', 'thulium', 'ytterbium', 'lutetium', 'hafnium', 'tantalum', 'tungsten', 'rhenium', 'osmium', 'iridium', 'platinum', 'gold', 'mercury', 'thallium', 'lead', 'bismuth', 'polonium', 'astatine', 'radon', 'francium', 'radium', 'actinium', 'thorium', 'protactinium', 'uranium', 'neptunium', 'plutonium']</em><a class="headerlink" href="#cantera.Element.element_names" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Element.atomic_number">
-<code class="descname">atomic_number</code><a class="headerlink" href="#cantera.Element.atomic_number" title="Permalink to this definition">¶</a></dt>
+<code class="descname">atomic_number</code><a class="headerlink" href="#cantera.Element.atomic_number" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The atomic number of the element or isotope.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Element.name">
-<code class="descname">name</code><a class="headerlink" href="#cantera.Element.name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">name</code><a class="headerlink" href="#cantera.Element.name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The name of the element or isotope.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Element.symbol">
-<code class="descname">symbol</code><a class="headerlink" href="#cantera.Element.symbol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">symbol</code><a class="headerlink" href="#cantera.Element.symbol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The symbol of the element or isotope.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Element.weight">
-<code class="descname">weight</code><a class="headerlink" href="#cantera.Element.weight" title="Permalink to this definition">¶</a></dt>
+<code class="descname">weight</code><a class="headerlink" href="#cantera.Element.weight" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The atomic weight of the element or isotope.</p>
 </dd></dl>
 
@@ -1813,25 +1809,24 @@ and <a class="reference internal" href="#cantera.Element.element_names" title="c
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/cython/thermo.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/cython/thermo.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -1840,15 +1835,14 @@ and <a class="reference internal" href="#cantera.Element.element_names" title="c
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/cython/thermo.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/cython/thermo.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/cython/thermo.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/thermo.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/cython/transport.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/transport.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Transport Properties | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,29 +77,29 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="transport-properties">
-<h1>Transport Properties<a class="headerlink" href="#transport-properties" title="Permalink to this headline">¶</a></h1>
+<h1>Transport Properties<a class="headerlink" href="#transport-properties" title="Permalink to this headline">&#182;</a></h1>
 <dl class="class">
 <dt id="cantera.Transport">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Transport</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Transport" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Transport</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Transport" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera._SolutionBase</span></code></p>
 <p>Transport(<a href="#id1"><span class="problematic" id="id2">*</span></a>args, <a href="#id3"><span class="problematic" id="id4">**</span></a>kwargs)</p>
 <p>This class is used to compute transport properties for a phase of matter.</p>
 <p>Not all transport properties are implemented in all transport models.</p>
 <dl class="attribute">
 <dt id="cantera.Transport.binary_diff_coeffs">
-<code class="descname">binary_diff_coeffs</code><a class="headerlink" href="#cantera.Transport.binary_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">binary_diff_coeffs</code><a class="headerlink" href="#cantera.Transport.binary_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Binary diffusion coefficients [m^2/s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Transport.electrical_conductivity">
-<code class="descname">electrical_conductivity</code><a class="headerlink" href="#cantera.Transport.electrical_conductivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electrical_conductivity</code><a class="headerlink" href="#cantera.Transport.electrical_conductivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Electrical conductivity. [S/m].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Transport.mix_diff_coeffs">
-<code class="descname">mix_diff_coeffs</code><a class="headerlink" href="#cantera.Transport.mix_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs</code><a class="headerlink" href="#cantera.Transport.mix_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 mass-averaged diffusive fluxes (with respect to the mass averaged
 velocity) to gradients in the species mole fractions.</p>
@@ -111,46 +107,46 @@ velocity) to gradients in the species mole fractions.</p>
 
 <dl class="attribute">
 <dt id="cantera.Transport.mix_diff_coeffs_mass">
-<code class="descname">mix_diff_coeffs_mass</code><a class="headerlink" href="#cantera.Transport.mix_diff_coeffs_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs_mass</code><a class="headerlink" href="#cantera.Transport.mix_diff_coeffs_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 diffusive mass fluxes to gradients in the species mass fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Transport.mix_diff_coeffs_mole">
-<code class="descname">mix_diff_coeffs_mole</code><a class="headerlink" href="#cantera.Transport.mix_diff_coeffs_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mix_diff_coeffs_mole</code><a class="headerlink" href="#cantera.Transport.mix_diff_coeffs_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mixture-averaged diffusion coefficients [m^2/s] relating the
 molar diffusive fluxes to gradients in the species mole fractions.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Transport.multi_diff_coeffs">
-<code class="descname">multi_diff_coeffs</code><a class="headerlink" href="#cantera.Transport.multi_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">multi_diff_coeffs</code><a class="headerlink" href="#cantera.Transport.multi_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Multicomponent diffusion coefficients [m^2/s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Transport.species_viscosities">
-<code class="descname">species_viscosities</code><a class="headerlink" href="#cantera.Transport.species_viscosities" title="Permalink to this definition">¶</a></dt>
+<code class="descname">species_viscosities</code><a class="headerlink" href="#cantera.Transport.species_viscosities" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Pure species viscosities [Pa-s]</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Transport.thermal_conductivity">
-<code class="descname">thermal_conductivity</code><a class="headerlink" href="#cantera.Transport.thermal_conductivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_conductivity</code><a class="headerlink" href="#cantera.Transport.thermal_conductivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Thermal conductivity. [W/m/K].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Transport.thermal_diff_coeffs">
-<code class="descname">thermal_diff_coeffs</code><a class="headerlink" href="#cantera.Transport.thermal_diff_coeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermal_diff_coeffs</code><a class="headerlink" href="#cantera.Transport.thermal_diff_coeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return a one-dimensional array of the species thermal diffusion
 coefficients [kg/m/s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Transport.transport_model">
-<code class="descname">transport_model</code><a class="headerlink" href="#cantera.Transport.transport_model" title="Permalink to this definition">¶</a></dt>
+<code class="descname">transport_model</code><a class="headerlink" href="#cantera.Transport.transport_model" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the transport model associated with this transport model.</p>
 <p>Setting a new transport model deletes the underlying C++ Transport
 object and replaces it with a new one implementing the specified model.</p>
@@ -158,7 +154,7 @@ object and replaces it with a new one implementing the specified model.</p>
 
 <dl class="attribute">
 <dt id="cantera.Transport.viscosity">
-<code class="descname">viscosity</code><a class="headerlink" href="#cantera.Transport.viscosity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">viscosity</code><a class="headerlink" href="#cantera.Transport.viscosity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Viscosity [Pa-s].</p>
 </dd></dl>
 
@@ -166,42 +162,42 @@ object and replaces it with a new one implementing the specified model.</p>
 
 <dl class="class">
 <dt id="cantera.DustyGasTransport">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">DustyGasTransport</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.DustyGasTransport" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">DustyGasTransport</code><span class="sig-paren">(</span><em>infile=''</em>, <em>phaseid=''</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.DustyGasTransport" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Transport</span></code></p>
 <p>DustyGasTransport(<a href="#id5"><span class="problematic" id="id6">*</span></a>args, <a href="#id7"><span class="problematic" id="id8">**</span></a>kwargs)</p>
-<p>Implements the “dusty gas” model for transport in porous media.</p>
+<p>Implements the &#8220;dusty gas&#8221; model for transport in porous media.</p>
 <p>As implemented here, only species transport (<a class="reference internal" href="#cantera.Transport.multi_diff_coeffs" title="cantera.Transport.multi_diff_coeffs"><code class="xref py py-obj docutils literal notranslate"><span class="pre">multi_diff_coeffs</span></code></a>)
 is handled. The viscosity, thermal conductivity, and thermal diffusion
 coefficients are not implemented.</p>
 <dl class="attribute">
 <dt id="cantera.DustyGasTransport.mean_particle_diameter">
-<code class="descname">mean_particle_diameter</code><a class="headerlink" href="#cantera.DustyGasTransport.mean_particle_diameter" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mean_particle_diameter</code><a class="headerlink" href="#cantera.DustyGasTransport.mean_particle_diameter" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mean particle diameter of the porous medium [m].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.DustyGasTransport.mean_pore_radius">
-<code class="descname">mean_pore_radius</code><a class="headerlink" href="#cantera.DustyGasTransport.mean_pore_radius" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mean_pore_radius</code><a class="headerlink" href="#cantera.DustyGasTransport.mean_pore_radius" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mean pore radius of the porous medium [m].</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.DustyGasTransport.molar_fluxes">
-<code class="descname">molar_fluxes</code><span class="sig-paren">(</span><em>self</em>, <em>T1</em>, <em>T2</em>, <em>rho1</em>, <em>rho2</em>, <em>Y1</em>, <em>Y2</em>, <em>delta</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.DustyGasTransport.molar_fluxes" title="Permalink to this definition">¶</a></dt>
+<code class="descname">molar_fluxes</code><span class="sig-paren">(</span><em>self</em>, <em>T1</em>, <em>T2</em>, <em>rho1</em>, <em>rho2</em>, <em>Y1</em>, <em>Y2</em>, <em>delta</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.DustyGasTransport.molar_fluxes" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the molar fluxes [kmol/m^2/s], given the thermodynamic state at
 two nearby points.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>T1</strong> – Temperature [K] at the first point</li>
-<li><strong>T2</strong> – Temperature [K] at the second point</li>
-<li><strong>rho1</strong> – Density [kg/m^3] at the first point</li>
-<li><strong>rho2</strong> – Density [kg/m^3] at the second point</li>
-<li><strong>Y1</strong> – Array of mass fractions at the first point. Length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code>.</li>
-<li><strong>Y2</strong> – Array of mass fractions at the second point. Length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code>.</li>
-<li><strong>delta</strong> – Distance [m] between the two points.</li>
+<li><strong>T1</strong> &#8211; Temperature [K] at the first point</li>
+<li><strong>T2</strong> &#8211; Temperature [K] at the second point</li>
+<li><strong>rho1</strong> &#8211; Density [kg/m^3] at the first point</li>
+<li><strong>rho2</strong> &#8211; Density [kg/m^3] at the second point</li>
+<li><strong>Y1</strong> &#8211; Array of mass fractions at the first point. Length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code>.</li>
+<li><strong>Y2</strong> &#8211; Array of mass fractions at the second point. Length <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code>.</li>
+<li><strong>delta</strong> &#8211; Distance [m] between the two points.</li>
 </ul>
 </td>
 </tr>
@@ -211,29 +207,29 @@ two nearby points.</p>
 
 <dl class="attribute">
 <dt id="cantera.DustyGasTransport.permeability">
-<code class="descname">permeability</code><a class="headerlink" href="#cantera.DustyGasTransport.permeability" title="Permalink to this definition">¶</a></dt>
+<code class="descname">permeability</code><a class="headerlink" href="#cantera.DustyGasTransport.permeability" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Permeability of the porous medium [m^2].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.DustyGasTransport.porosity">
-<code class="descname">porosity</code><a class="headerlink" href="#cantera.DustyGasTransport.porosity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">porosity</code><a class="headerlink" href="#cantera.DustyGasTransport.porosity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Porosity of the porous medium [dimensionless].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.DustyGasTransport.tortuosity">
-<code class="descname">tortuosity</code><a class="headerlink" href="#cantera.DustyGasTransport.tortuosity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">tortuosity</code><a class="headerlink" href="#cantera.DustyGasTransport.tortuosity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Tortuosity of the porous medium [dimensionless].</p>
 </dd></dl>
 
 </dd></dl>
 
 <div class="section" id="species-transport-properties">
-<h2>Species Transport Properties<a class="headerlink" href="#species-transport-properties" title="Permalink to this headline">¶</a></h2>
+<h2>Species Transport Properties<a class="headerlink" href="#species-transport-properties" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.GasTransportData">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">GasTransportData</code><span class="sig-paren">(</span><em>geometry=''</em>, <em>diameter=-1</em>, <em>well_depth=-1</em>, <em>dipole=0.0</em>, <em>polarizability=0.0</em>, <em>rotational_relaxation=0.0</em>, <em>acentric_factor=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.GasTransportData" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">GasTransportData</code><span class="sig-paren">(</span><em>geometry=''</em>, <em>diameter=-1</em>, <em>well_depth=-1</em>, <em>dipole=0.0</em>, <em>polarizability=0.0</em>, <em>rotational_relaxation=0.0</em>, <em>acentric_factor=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.GasTransportData" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>Transport data for a single gas-phase species which can be used in
 mixture-averaged or multicomponent transport models.</p>
@@ -242,50 +238,50 @@ the object, with values in MKS units. To set properties in non-MKS units,
 use the <a class="reference internal" href="#cantera.GasTransportData.set_customary_units" title="cantera.GasTransportData.set_customary_units"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_customary_units</span></code></a> method.</p>
 <dl class="attribute">
 <dt id="cantera.GasTransportData.acentric_factor">
-<code class="descname">acentric_factor</code><a class="headerlink" href="#cantera.GasTransportData.acentric_factor" title="Permalink to this definition">¶</a></dt>
-<dd><p>Get/Set Pitzer’s acentric factor. [dimensionless]</p>
+<code class="descname">acentric_factor</code><a class="headerlink" href="#cantera.GasTransportData.acentric_factor" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Get/Set Pitzer&#8217;s acentric factor. [dimensionless]</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.GasTransportData.diameter">
-<code class="descname">diameter</code><a class="headerlink" href="#cantera.GasTransportData.diameter" title="Permalink to this definition">¶</a></dt>
+<code class="descname">diameter</code><a class="headerlink" href="#cantera.GasTransportData.diameter" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the Lennard-Jones collision diameter [m]</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.GasTransportData.dipole">
-<code class="descname">dipole</code><a class="headerlink" href="#cantera.GasTransportData.dipole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">dipole</code><a class="headerlink" href="#cantera.GasTransportData.dipole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the permanent dipole moment of the molecule [Coulomb-m].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.GasTransportData.dispersion_coefficient">
-<code class="descname">dispersion_coefficient</code><a class="headerlink" href="#cantera.GasTransportData.dispersion_coefficient" title="Permalink to this definition">¶</a></dt>
+<code class="descname">dispersion_coefficient</code><a class="headerlink" href="#cantera.GasTransportData.dispersion_coefficient" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set dispersion coefficient. [m^5]</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.GasTransportData.geometry">
-<code class="descname">geometry</code><a class="headerlink" href="#cantera.GasTransportData.geometry" title="Permalink to this definition">¶</a></dt>
+<code class="descname">geometry</code><a class="headerlink" href="#cantera.GasTransportData.geometry" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the string specifying the molecular geometry. One of <code class="xref py py-obj docutils literal notranslate"><span class="pre">atom</span></code>,
 <code class="xref py py-obj docutils literal notranslate"><span class="pre">linear</span></code>, or <code class="xref py py-obj docutils literal notranslate"><span class="pre">nonlinear</span></code>.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.GasTransportData.polarizability">
-<code class="descname">polarizability</code><a class="headerlink" href="#cantera.GasTransportData.polarizability" title="Permalink to this definition">¶</a></dt>
+<code class="descname">polarizability</code><a class="headerlink" href="#cantera.GasTransportData.polarizability" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the polarizability of the molecule [m^3].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.GasTransportData.quadrupole_polarizability">
-<code class="descname">quadrupole_polarizability</code><a class="headerlink" href="#cantera.GasTransportData.quadrupole_polarizability" title="Permalink to this definition">¶</a></dt>
+<code class="descname">quadrupole_polarizability</code><a class="headerlink" href="#cantera.GasTransportData.quadrupole_polarizability" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set quadrupole polarizability. [m^5]</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.GasTransportData.rotational_relaxation">
-<code class="descname">rotational_relaxation</code><a class="headerlink" href="#cantera.GasTransportData.rotational_relaxation" title="Permalink to this definition">¶</a></dt>
+<code class="descname">rotational_relaxation</code><a class="headerlink" href="#cantera.GasTransportData.rotational_relaxation" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the rotational relaxation number (the number of collisions it
 takes to equilibrate the rotational degrees of freedom with the
 temperature).</p>
@@ -293,15 +289,15 @@ temperature).</p>
 
 <dl class="method">
 <dt id="cantera.GasTransportData.set_customary_units">
-<code class="descname">set_customary_units</code><span class="sig-paren">(</span><em>self</em>, <em>geometry</em>, <em>diameter</em>, <em>well_depth</em>, <em>dipole=0.0</em>, <em>polarizability=0.0</em>, <em>rotational_relaxation=0.0</em>, <em>acentric_factor=0.0</em>, <em>dispersion_coefficient=0.0</em>, <em>quadrupole_polarizability=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.GasTransportData.set_customary_units" title="Permalink to this definition">¶</a></dt>
-<dd><p>Set the parameters using “customary” units: diameter in Angstroms, well
+<code class="descname">set_customary_units</code><span class="sig-paren">(</span><em>self</em>, <em>geometry</em>, <em>diameter</em>, <em>well_depth</em>, <em>dipole=0.0</em>, <em>polarizability=0.0</em>, <em>rotational_relaxation=0.0</em>, <em>acentric_factor=0.0</em>, <em>dispersion_coefficient=0.0</em>, <em>quadrupole_polarizability=0.0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.GasTransportData.set_customary_units" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Set the parameters using &#8220;customary&#8221; units: diameter in Angstroms, well
 depth in Kelvin, dipole in Debye, and polarizability in Angstroms^3.
 These are the units used in in CK-style input files.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.GasTransportData.well_depth">
-<code class="descname">well_depth</code><a class="headerlink" href="#cantera.GasTransportData.well_depth" title="Permalink to this definition">¶</a></dt>
+<code class="descname">well_depth</code><a class="headerlink" href="#cantera.GasTransportData.well_depth" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get/Set the Lennard-Jones well depth [J]</p>
 </dd></dl>
 
@@ -338,25 +334,24 @@ These are the units used in in CK-style input files.</p>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/cython/transport.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/cython/transport.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -365,15 +360,14 @@ These are the units used in in CK-style input files.</p>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/cython/transport.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/cython/transport.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/cython/transport.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/transport.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/cython/zerodim.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/zerodim.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Zero-Dimensional Reactor Networks | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,7 +77,7 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="zero-dimensional-reactor-networks">
-<span id="sec-cython-zerodim"></span><h1>Zero-Dimensional Reactor Networks<a class="headerlink" href="#zero-dimensional-reactor-networks" title="Permalink to this headline">¶</a></h1>
+<span id="sec-cython-zerodim"></span><h1>Zero-Dimensional Reactor Networks<a class="headerlink" href="#zero-dimensional-reactor-networks" title="Permalink to this headline">&#182;</a></h1>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#defining-functions" id="id19">Defining Functions</a></li>
@@ -118,10 +114,10 @@ lang="en">
 </ul>
 </div>
 <div class="section" id="defining-functions">
-<h2><a class="toc-backref" href="#id19">Defining Functions</a><a class="headerlink" href="#defining-functions" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id19">Defining Functions</a><a class="headerlink" href="#defining-functions" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.Func1">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Func1</code><a class="headerlink" href="#cantera.Func1" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Func1</code><a class="headerlink" href="#cantera.Func1" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>This class is used as a wrapper for a function of one variable, i.e.
 <span class="math">\(y = f(t)\)</span>, that is defined in Python and can be called by the
@@ -159,72 +155,72 @@ unnecessary to explicitly create a <a class="reference internal" href="#cantera.
 
 </div>
 <div class="section" id="base-classes">
-<h2><a class="toc-backref" href="#id20">Base Classes</a><a class="headerlink" href="#base-classes" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id20">Base Classes</a><a class="headerlink" href="#base-classes" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="reactorbase">
-<h3><a class="toc-backref" href="#id21">ReactorBase</a><a class="headerlink" href="#reactorbase" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id21">ReactorBase</a><a class="headerlink" href="#reactorbase" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ReactorBase">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ReactorBase</code><span class="sig-paren">(</span><em>contents=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorBase" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ReactorBase</code><span class="sig-paren">(</span><em>contents=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorBase" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>ReactorBase(ThermoPhase contents=None, name=None, volume=None, <a href="#id1"><span class="problematic" id="id2">*</span></a>)</p>
 <p>Common base class for reactors and reservoirs.</p>
 <dl class="attribute">
 <dt id="cantera.ReactorBase.T">
-<code class="descname">T</code><a class="headerlink" href="#cantera.ReactorBase.T" title="Permalink to this definition">¶</a></dt>
-<dd><p>The temperature [K] of the reactor’s contents.</p>
+<code class="descname">T</code><a class="headerlink" href="#cantera.ReactorBase.T" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>The temperature [K] of the reactor&#8217;s contents.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorBase.Y">
-<code class="descname">Y</code><a class="headerlink" href="#cantera.ReactorBase.Y" title="Permalink to this definition">¶</a></dt>
-<dd><p>The mass fractions of the reactor’s contents.</p>
+<code class="descname">Y</code><a class="headerlink" href="#cantera.ReactorBase.Y" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>The mass fractions of the reactor&#8217;s contents.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorBase.density">
-<code class="descname">density</code><a class="headerlink" href="#cantera.ReactorBase.density" title="Permalink to this definition">¶</a></dt>
-<dd><p>The density [kg/m^3 or kmol/m^3] of the reactor’s contents.</p>
+<code class="descname">density</code><a class="headerlink" href="#cantera.ReactorBase.density" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>The density [kg/m^3 or kmol/m^3] of the reactor&#8217;s contents.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorBase.inlets">
-<code class="descname">inlets</code><a class="headerlink" href="#cantera.ReactorBase.inlets" title="Permalink to this definition">¶</a></dt>
+<code class="descname">inlets</code><a class="headerlink" href="#cantera.ReactorBase.inlets" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>List of flow devices installed as inlets to this reactor</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactorBase.insert">
-<code class="descname">insert</code><span class="sig-paren">(</span><em>self</em>, <em>_SolutionBase solution</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorBase.insert" title="Permalink to this definition">¶</a></dt>
+<code class="descname">insert</code><span class="sig-paren">(</span><em>self</em>, <em>_SolutionBase solution</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorBase.insert" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set <em>solution</em> to be the object used to compute thermodynamic
 properties and kinetic rates for this reactor.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorBase.mass">
-<code class="descname">mass</code><a class="headerlink" href="#cantera.ReactorBase.mass" title="Permalink to this definition">¶</a></dt>
-<dd><p>The mass of the reactor’s contents.</p>
+<code class="descname">mass</code><a class="headerlink" href="#cantera.ReactorBase.mass" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>The mass of the reactor&#8217;s contents.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorBase.name">
-<code class="descname">name</code><a class="headerlink" href="#cantera.ReactorBase.name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">name</code><a class="headerlink" href="#cantera.ReactorBase.name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The name of the reactor.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorBase.outlets">
-<code class="descname">outlets</code><a class="headerlink" href="#cantera.ReactorBase.outlets" title="Permalink to this definition">¶</a></dt>
+<code class="descname">outlets</code><a class="headerlink" href="#cantera.ReactorBase.outlets" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>List of flow devices installed as outlets to this reactor</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorBase.reactor_type">
-<code class="descname">reactor_type</code><em class="property"> = 'None'</em><a class="headerlink" href="#cantera.ReactorBase.reactor_type" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactor_type</code><em class="property"> = 'None'</em><a class="headerlink" href="#cantera.ReactorBase.reactor_type" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactorBase.syncState">
-<code class="descname">syncState</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorBase.syncState" title="Permalink to this definition">¶</a></dt>
+<code class="descname">syncState</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorBase.syncState" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the state of the Reactor to match that of the associated
 <a class="reference internal" href="thermo.html#cantera.ThermoPhase" title="cantera.ThermoPhase"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ThermoPhase</span></code></a> object. After calling syncState(), call
 ReactorNet.reinitialize() before further integration.</p>
@@ -232,19 +228,19 @@ ReactorNet.reinitialize() before further integration.</p>
 
 <dl class="attribute">
 <dt id="cantera.ReactorBase.thermo">
-<code class="descname">thermo</code><a class="headerlink" href="#cantera.ReactorBase.thermo" title="Permalink to this definition">¶</a></dt>
-<dd><p>The <a class="reference internal" href="thermo.html#cantera.ThermoPhase" title="cantera.ThermoPhase"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ThermoPhase</span></code></a> object representing the reactor’s contents.</p>
+<code class="descname">thermo</code><a class="headerlink" href="#cantera.ReactorBase.thermo" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>The <a class="reference internal" href="thermo.html#cantera.ThermoPhase" title="cantera.ThermoPhase"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ThermoPhase</span></code></a> object representing the reactor&#8217;s contents.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorBase.volume">
-<code class="descname">volume</code><a class="headerlink" href="#cantera.ReactorBase.volume" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume</code><a class="headerlink" href="#cantera.ReactorBase.volume" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The volume [m^3] of the reactor.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorBase.walls">
-<code class="descname">walls</code><a class="headerlink" href="#cantera.ReactorBase.walls" title="Permalink to this definition">¶</a></dt>
+<code class="descname">walls</code><a class="headerlink" href="#cantera.ReactorBase.walls" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>List of walls installed on this reactor</p>
 </dd></dl>
 
@@ -252,10 +248,10 @@ ReactorNet.reinitialize() before further integration.</p>
 
 </div>
 <div class="section" id="flowdevice">
-<h3><a class="toc-backref" href="#id22">FlowDevice</a><a class="headerlink" href="#flowdevice" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id22">FlowDevice</a><a class="headerlink" href="#flowdevice" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.FlowDevice">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FlowDevice</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em>, <em>*</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlowDevice" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FlowDevice</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em>, <em>*</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlowDevice" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>FlowDevice(upstream, downstream, name=None, <a href="#id3"><span class="problematic" id="id4">*</span></a>)</p>
 <p>Base class for devices that allow flow between reactors.</p>
@@ -267,7 +263,7 @@ across a FlowDevice, and the pressure difference equals the difference in
 pressure between the upstream and downstream reactors.</p>
 <dl class="method">
 <dt id="cantera.FlowDevice.mdot">
-<code class="descname">mdot</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlowDevice.mdot" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mdot</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlowDevice.mdot" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The mass flow rate [kg/s] through this device at time <em>t</em> [s].</p>
 </dd></dl>
 
@@ -276,10 +272,10 @@ pressure between the upstream and downstream reactors.</p>
 </div>
 </div>
 <div class="section" id="reactor-networks">
-<h2><a class="toc-backref" href="#id23">Reactor Networks</a><a class="headerlink" href="#reactor-networks" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id23">Reactor Networks</a><a class="headerlink" href="#reactor-networks" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="cantera.ReactorNet">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ReactorNet</code><span class="sig-paren">(</span><em>reactors=()</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ReactorNet</code><span class="sig-paren">(</span><em>reactors=()</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>ReactorNet(reactors=())</p>
 <p>Networks of reactors. ReactorNet objects are used to simultaneously
@@ -296,20 +292,20 @@ advance the state of one or more coupled reactors.</p>
 </div>
 <dl class="method">
 <dt id="cantera.ReactorNet.add_reactor">
-<code class="descname">add_reactor</code><span class="sig-paren">(</span><em>self</em>, <em>Reactor r</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.add_reactor" title="Permalink to this definition">¶</a></dt>
+<code class="descname">add_reactor</code><span class="sig-paren">(</span><em>self</em>, <em>Reactor r</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.add_reactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Add a reactor to the network.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactorNet.advance">
-<code class="descname">advance</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.advance" title="Permalink to this definition">¶</a></dt>
+<code class="descname">advance</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.advance" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Advance the state of the reactor network in time from the current
 time to time <em>t</em> [s], taking as many integrator timesteps as necessary.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactorNet.advance_to_steady_state">
-<code class="descname">advance_to_steady_state</code><span class="sig-paren">(</span><em>self</em>, <em>int max_steps=10000</em>, <em>double residual_threshold=0.</em>, <em>double atol=0.</em>, <em>bool return_residuals=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.advance_to_steady_state" title="Permalink to this definition">¶</a></dt>
+<code class="descname">advance_to_steady_state</code><span class="sig-paren">(</span><em>self</em>, <em>int max_steps=10000</em>, <em>double residual_threshold=0.</em>, <em>double atol=0.</em>, <em>bool return_residuals=False</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.advance_to_steady_state" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Advance the reactor network in time until steady state is reached.</p>
 <p>The steady state is defined by requiring that the state of the system
 only changes below a certain threshold. The residual is computed using
@@ -319,17 +315,17 @@ feature scaling:</p>
 
 \]</div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>max_steps</strong> – Maximum number of steps to be taken</li>
-<li><strong>residual_threshold</strong> – Threshold below which the feature-scaled residual r should drop such
+<li><strong>max_steps</strong> &#8211; Maximum number of steps to be taken</li>
+<li><strong>residual_threshold</strong> &#8211; Threshold below which the feature-scaled residual r should drop such
 that the network is defines as steady state. By default,
 residual_threshold is 10 times the solver rtol.</li>
-<li><strong>atol</strong> – The smallest expected value of interest. Used for feature scaling.
+<li><strong>atol</strong> &#8211; The smallest expected value of interest. Used for feature scaling.
 By default, this atol is identical to the solver atol.</li>
-<li><strong>return_residuals</strong> – If set to <code class="xref py py-obj docutils literal notranslate"><span class="pre">True</span></code>, this function returns the residual time series
+<li><strong>return_residuals</strong> &#8211; If set to <code class="xref py py-obj docutils literal notranslate"><span class="pre">True</span></code>, this function returns the residual time series
 as a vector with length <code class="xref py py-obj docutils literal notranslate"><span class="pre">max_steps</span></code>.</li>
 </ul>
 </td>
@@ -340,20 +336,20 @@ as a vector with length <code class="xref py py-obj docutils literal notranslate
 
 <dl class="attribute">
 <dt id="cantera.ReactorNet.atol">
-<code class="descname">atol</code><a class="headerlink" href="#cantera.ReactorNet.atol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">atol</code><a class="headerlink" href="#cantera.ReactorNet.atol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The absolute error tolerance used while integrating the reactor
 equations.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorNet.atol_sensitivity">
-<code class="descname">atol_sensitivity</code><a class="headerlink" href="#cantera.ReactorNet.atol_sensitivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">atol_sensitivity</code><a class="headerlink" href="#cantera.ReactorNet.atol_sensitivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The absolute error tolerance for sensitivity analysis.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactorNet.component_name">
-<code class="descname">component_name</code><span class="sig-paren">(</span><em>self</em>, <em>int i</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.component_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">component_name</code><span class="sig-paren">(</span><em>self</em>, <em>int i</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.component_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return the name of the i-th component of the global state vector. The
 name returned includes both the name of the reactor and the specific
 component, e.g. <code class="xref py py-obj docutils literal notranslate"><span class="pre">'reactor1:</span> <span class="pre">CH4'</span></code>.</p>
@@ -361,7 +357,7 @@ component, e.g. <code class="xref py py-obj docutils literal notranslate"><span 
 
 <dl class="method">
 <dt id="cantera.ReactorNet.get_state">
-<code class="descname">get_state</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.get_state" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_state</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.get_state" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the combined state vector of the reactor network.</p>
 <p>The combined state vector consists of the concatenated state vectors of
 all entities contained.</p>
@@ -369,20 +365,20 @@ all entities contained.</p>
 
 <dl class="attribute">
 <dt id="cantera.ReactorNet.max_err_test_fails">
-<code class="descname">max_err_test_fails</code><a class="headerlink" href="#cantera.ReactorNet.max_err_test_fails" title="Permalink to this definition">¶</a></dt>
+<code class="descname">max_err_test_fails</code><a class="headerlink" href="#cantera.ReactorNet.max_err_test_fails" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The maximum number of error test failures permitted by the CVODES
 integrator in a single time step.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorNet.n_sensitivity_params">
-<code class="descname">n_sensitivity_params</code><a class="headerlink" href="#cantera.ReactorNet.n_sensitivity_params" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_sensitivity_params</code><a class="headerlink" href="#cantera.ReactorNet.n_sensitivity_params" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The number of registered sensitivity parameters.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorNet.n_vars">
-<code class="descname">n_vars</code><a class="headerlink" href="#cantera.ReactorNet.n_vars" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_vars</code><a class="headerlink" href="#cantera.ReactorNet.n_vars" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The number of state variables in the system. This is the sum of the
 number of variables for each <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reactor</span></code></a> and <a class="reference internal" href="#cantera.Wall" title="cantera.Wall"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Wall</span></code></a> in the system.
 Equal to:</p>
@@ -395,7 +391,7 @@ internal energy or temperature).</p>
 
 <dl class="method">
 <dt id="cantera.ReactorNet.reinitialize">
-<code class="descname">reinitialize</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.reinitialize" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reinitialize</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.reinitialize" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reinitialize the integrator after making changing to the state of the
 system. Changes to Reactor contents will automatically trigger
 reinitialization.</p>
@@ -403,20 +399,20 @@ reinitialization.</p>
 
 <dl class="attribute">
 <dt id="cantera.ReactorNet.rtol">
-<code class="descname">rtol</code><a class="headerlink" href="#cantera.ReactorNet.rtol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">rtol</code><a class="headerlink" href="#cantera.ReactorNet.rtol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The relative error tolerance used while integrating the reactor
 equations.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorNet.rtol_sensitivity">
-<code class="descname">rtol_sensitivity</code><a class="headerlink" href="#cantera.ReactorNet.rtol_sensitivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">rtol_sensitivity</code><a class="headerlink" href="#cantera.ReactorNet.rtol_sensitivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The relative error tolerance for sensitivity analysis.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactorNet.sensitivities">
-<code class="descname">sensitivities</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.sensitivities" title="Permalink to this definition">¶</a></dt>
+<code class="descname">sensitivities</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.sensitivities" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Returns the sensitivities of all of the solution variables with respect
 to all of the registered parameters. The normalized sensitivity
 coefficient <span class="math">\(S_{ki}\)</span> of the solution variable <span class="math">\(y_k\)</span> with
@@ -449,7 +445,7 @@ variables (i.e., rows) is:</p>
 
 <dl class="method">
 <dt id="cantera.ReactorNet.sensitivity">
-<code class="descname">sensitivity</code><span class="sig-paren">(</span><em>self</em>, <em>component</em>, <em>int p</em>, <em>int r=0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.sensitivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">sensitivity</code><span class="sig-paren">(</span><em>self</em>, <em>component</em>, <em>int p</em>, <em>int r=0</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.sensitivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Returns the sensitivity of the solution variable <em>component</em> in
 reactor <em>r</em> with respect to the parameter <em>p</em>. <em>component</em> can be a
 string or an integer. See <code class="xref py py-obj docutils literal notranslate"><span class="pre">component_index</span></code> and <a class="reference internal" href="#cantera.ReactorNet.sensitivities" title="cantera.ReactorNet.sensitivities"><code class="xref py py-obj docutils literal notranslate"><span class="pre">sensitivities</span></code></a> to
@@ -461,40 +457,40 @@ taken.</p>
 
 <dl class="method">
 <dt id="cantera.ReactorNet.sensitivity_parameter_name">
-<code class="descname">sensitivity_parameter_name</code><span class="sig-paren">(</span><em>self</em>, <em>int p</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.sensitivity_parameter_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">sensitivity_parameter_name</code><span class="sig-paren">(</span><em>self</em>, <em>int p</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.sensitivity_parameter_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Name of the sensitivity parameter with index <em>p</em>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactorNet.set_initial_time">
-<code class="descname">set_initial_time</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.set_initial_time" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_initial_time</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.set_initial_time" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the initial time. Restarts integration from this time using the
 current state as the initial condition. Default: 0.0 s.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactorNet.set_max_time_step">
-<code class="descname">set_max_time_step</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.set_max_time_step" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_max_time_step</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.set_max_time_step" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the maximum time step <em>t</em> [s] that the integrator is allowed
 to use.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactorNet.step">
-<code class="descname">step</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.step" title="Permalink to this definition">¶</a></dt>
+<code class="descname">step</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorNet.step" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Take a single internal time step. The time after taking the step is
 returned.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorNet.time">
-<code class="descname">time</code><a class="headerlink" href="#cantera.ReactorNet.time" title="Permalink to this definition">¶</a></dt>
+<code class="descname">time</code><a class="headerlink" href="#cantera.ReactorNet.time" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The current time [s].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorNet.verbose">
-<code class="descname">verbose</code><a class="headerlink" href="#cantera.ReactorNet.verbose" title="Permalink to this definition">¶</a></dt>
+<code class="descname">verbose</code><a class="headerlink" href="#cantera.ReactorNet.verbose" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>If <em>True</em>, verbose debug information will be printed during
 integration. The default is <em>False</em>.</p>
 </dd></dl>
@@ -503,46 +499,46 @@ integration. The default is <em>False</em>.</p>
 
 </div>
 <div class="section" id="reactors">
-<h2><a class="toc-backref" href="#id24">Reactors</a><a class="headerlink" href="#reactors" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id24">Reactors</a><a class="headerlink" href="#reactors" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="reservoir">
-<h3><a class="toc-backref" href="#id25">Reservoir</a><a class="headerlink" href="#reservoir" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id25">Reservoir</a><a class="headerlink" href="#reservoir" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Reservoir">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Reservoir</code><span class="sig-paren">(</span><em>contents=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reservoir" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Reservoir</code><span class="sig-paren">(</span><em>contents=None</em>, <em>name=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reservoir" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.ReactorBase</span></code></p>
 <p>A reservoir is a reactor with a constant state. The temperature,
 pressure, and chemical composition in a reservoir never change from
 their initial values.</p>
 <dl class="attribute">
 <dt id="cantera.Reservoir.reactor_type">
-<code class="descname">reactor_type</code><em class="property"> = 'Reservoir'</em><a class="headerlink" href="#cantera.Reservoir.reactor_type" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactor_type</code><em class="property"> = 'Reservoir'</em><a class="headerlink" href="#cantera.Reservoir.reactor_type" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="reactor">
-<h3><a class="toc-backref" href="#id26">Reactor</a><a class="headerlink" href="#reactor" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id26">Reactor</a><a class="headerlink" href="#reactor" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Reactor">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Reactor</code><span class="sig-paren">(</span><em>contents=None</em>, <em>*</em>, <em>name=None</em>, <em>energy='on'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Reactor</code><span class="sig-paren">(</span><em>contents=None</em>, <em>*</em>, <em>name=None</em>, <em>energy='on'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.ReactorBase</span></code></p>
-<p>Reactor(contents=None, name=None, <a href="#id5"><span class="problematic" id="id6">*</span></a>, energy=’on’, <a href="#id7"><span class="problematic" id="id8">**</span></a>kwargs)</p>
+<p>Reactor(contents=None, name=None, <a href="#id5"><span class="problematic" id="id6">*</span></a>, energy=&#8217;on&#8217;, <a href="#id7"><span class="problematic" id="id8">**</span></a>kwargs)</p>
 <p>A homogeneous zero-dimensional reactor. By default, they are closed
 (no inlets or outlets), have fixed volume, and have adiabatic,
 chemically-inert walls. These properties may all be changed by adding
 appropriate components, e.g. <a class="reference internal" href="#cantera.Wall" title="cantera.Wall"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Wall</span></code></a>, <a class="reference internal" href="#cantera.MassFlowController" title="cantera.MassFlowController"><code class="xref py py-obj docutils literal notranslate"><span class="pre">MassFlowController</span></code></a> and <a class="reference internal" href="#cantera.Valve" title="cantera.Valve"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Valve</span></code></a>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>contents</strong> – Reactor contents. If not specified, the reactor is initially empty.
+<li><strong>contents</strong> &#8211; Reactor contents. If not specified, the reactor is initially empty.
 In this case, call <a class="reference internal" href="#cantera.Reactor.insert" title="cantera.Reactor.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a> to specify the contents.</li>
-<li><strong>name</strong> – Used only to identify this reactor in output. If not specified,
+<li><strong>name</strong> &#8211; Used only to identify this reactor in output. If not specified,
 defaults to <code class="docutils literal notranslate"><span class="pre">'Reactor_n'</span></code>, where <em>n</em> is an integer assigned in
 the order <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reactor</span></code></a> objects are created.</li>
-<li><strong>energy</strong> – Set to <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code>. If set to <code class="docutils literal notranslate"><span class="pre">'off'</span></code>, the energy
+<li><strong>energy</strong> &#8211; Set to <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code>. If set to <code class="docutils literal notranslate"><span class="pre">'off'</span></code>, the energy
 equation is not solved, and the temperature is held at its
 initial value..</li>
 </ul>
@@ -552,7 +548,7 @@ initial value..</li>
 </table>
 <p>Some examples showing how to create <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-class docutils literal notranslate"><span class="pre">Reactor</span></code></a> objects are
 shown below.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;gri30.xml&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">'gri30.xml'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">r1</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">gas</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -562,14 +558,14 @@ shown below.</p>
 </pre></div>
 </div>
 <p>Arguments may be specified using keywords in any order:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">r2</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">,</span> <span class="n">energy</span><span class="o">=</span><span class="s1">&#39;off&#39;</span><span class="p">,</span>
-<span class="gp">... </span>             <span class="n">name</span><span class="o">=</span><span class="s1">&#39;isothermal_reactor&#39;</span><span class="p">)</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">r3</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">&#39;adiabatic_reactor&#39;</span><span class="p">,</span> <span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">r2</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">,</span> <span class="n">energy</span><span class="o">=</span><span class="s1">'off'</span><span class="p">,</span>
+<span class="gp">... </span>             <span class="n">name</span><span class="o">=</span><span class="s1">'isothermal_reactor'</span><span class="p">)</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">r3</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">'adiabatic_reactor'</span><span class="p">,</span> <span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">)</span>
 </pre></div>
 </div>
 <dl class="method">
 <dt id="cantera.Reactor.add_sensitivity_reaction">
-<code class="descname">add_sensitivity_reaction</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.add_sensitivity_reaction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">add_sensitivity_reaction</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.add_sensitivity_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specifies that the sensitivity of the state variables with respect to
 reaction <em>m</em> should be computed. <em>m</em> is the 0-based reaction index.
 The reactor must be part of a network first. Specifying the same
@@ -578,7 +574,7 @@ reaction more than one time raises an exception.</p>
 
 <dl class="method">
 <dt id="cantera.Reactor.add_sensitivity_species_enthalpy">
-<code class="descname">add_sensitivity_species_enthalpy</code><span class="sig-paren">(</span><em>self</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.add_sensitivity_species_enthalpy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">add_sensitivity_species_enthalpy</code><span class="sig-paren">(</span><em>self</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.add_sensitivity_species_enthalpy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specifies that the sensitivity of the state variables with respect to
 species <em>k</em> should be computed. The reactor must be part of a network
 first.</p>
@@ -586,7 +582,7 @@ first.</p>
 
 <dl class="attribute">
 <dt id="cantera.Reactor.chemistry_enabled">
-<code class="descname">chemistry_enabled</code><a class="headerlink" href="#cantera.Reactor.chemistry_enabled" title="Permalink to this definition">¶</a></dt>
+<code class="descname">chemistry_enabled</code><a class="headerlink" href="#cantera.Reactor.chemistry_enabled" title="Permalink to this definition">&#182;</a></dt>
 <dd><p><em>True</em> when the reactor composition is allowed to change due to
 chemical reactions in this reactor. When this is <em>False</em>, the
 reactor composition is held constant.</p>
@@ -594,17 +590,17 @@ reactor composition is held constant.</p>
 
 <dl class="method">
 <dt id="cantera.Reactor.component_index">
-<code class="descname">component_index</code><span class="sig-paren">(</span><em>self</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.component_index" title="Permalink to this definition">¶</a></dt>
+<code class="descname">component_index</code><span class="sig-paren">(</span><em>self</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.component_index" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Returns the index of the component named <em>name</em> in the system. This
 determines the (relative) index of the component in the vector of
 sensitivity coefficients. <em>name</em> is either a species name or the name of
-a reactor state variable, e.g. ‘int_energy’, ‘temperature’, depending on
-the reactor’s equations.</p>
+a reactor state variable, e.g. &#8216;int_energy&#8217;, &#8216;temperature&#8217;, depending on
+the reactor&#8217;s equations.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Reactor.component_name">
-<code class="descname">component_name</code><span class="sig-paren">(</span><em>self</em>, <em>int i</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.component_name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">component_name</code><span class="sig-paren">(</span><em>self</em>, <em>int i</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.component_name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Returns the name of the component with index <em>i</em> within the array of
 variables returned by <a class="reference internal" href="#cantera.Reactor.get_state" title="cantera.Reactor.get_state"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_state</span></code></a>. This is the inverse of
 <a class="reference internal" href="#cantera.Reactor.component_index" title="cantera.Reactor.component_index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">component_index</span></code></a>.</p>
@@ -612,14 +608,14 @@ variables returned by <a class="reference internal" href="#cantera.Reactor.get_s
 
 <dl class="attribute">
 <dt id="cantera.Reactor.energy_enabled">
-<code class="descname">energy_enabled</code><a class="headerlink" href="#cantera.Reactor.energy_enabled" title="Permalink to this definition">¶</a></dt>
+<code class="descname">energy_enabled</code><a class="headerlink" href="#cantera.Reactor.energy_enabled" title="Permalink to this definition">&#182;</a></dt>
 <dd><p><em>True</em> when the energy equation is being solved for this reactor.
 When this is <em>False</em>, the reactor temperature is held constant.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Reactor.get_state">
-<code class="descname">get_state</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.get_state" title="Permalink to this definition">¶</a></dt>
+<code class="descname">get_state</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.get_state" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the state vector of the reactor.</p>
 <p>The order of the variables (i.e. rows) is:</p>
 <p><a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reactor</span></code></a> or <a class="reference internal" href="#cantera.IdealGasReactor" title="cantera.IdealGasReactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">IdealGasReactor</span></code></a>:</p>
@@ -646,19 +642,19 @@ name from the index.</p>
 
 <dl class="method">
 <dt id="cantera.Reactor.insert">
-<code class="descname">insert</code><span class="sig-paren">(</span><em>self</em>, <em>_SolutionBase solution</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.insert" title="Permalink to this definition">¶</a></dt>
+<code class="descname">insert</code><span class="sig-paren">(</span><em>self</em>, <em>_SolutionBase solution</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Reactor.insert" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Reactor.kinetics">
-<code class="descname">kinetics</code><a class="headerlink" href="#cantera.Reactor.kinetics" title="Permalink to this definition">¶</a></dt>
+<code class="descname">kinetics</code><a class="headerlink" href="#cantera.Reactor.kinetics" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The <a class="reference internal" href="kinetics.html#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> object used for calculating kinetic rates in
 this reactor.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Reactor.n_vars">
-<code class="descname">n_vars</code><a class="headerlink" href="#cantera.Reactor.n_vars" title="Permalink to this definition">¶</a></dt>
+<code class="descname">n_vars</code><a class="headerlink" href="#cantera.Reactor.n_vars" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The number of state variables in the reactor.
 Equal to:</p>
 <p><a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reactor</span></code></a> and <a class="reference internal" href="#cantera.IdealGasReactor" title="cantera.IdealGasReactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">IdealGasReactor</span></code></a>: <code class="xref py py-obj docutils literal notranslate"><span class="pre">n_species</span></code> + 3 (mass, volume,
@@ -669,30 +665,30 @@ internal energy or temperature).</p>
 
 <dl class="attribute">
 <dt id="cantera.Reactor.reactor_type">
-<code class="descname">reactor_type</code><em class="property"> = 'Reactor'</em><a class="headerlink" href="#cantera.Reactor.reactor_type" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactor_type</code><em class="property"> = 'Reactor'</em><a class="headerlink" href="#cantera.Reactor.reactor_type" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="idealgasreactor">
-<h3><a class="toc-backref" href="#id27">IdealGasReactor</a><a class="headerlink" href="#idealgasreactor" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id27">IdealGasReactor</a><a class="headerlink" href="#idealgasreactor" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.IdealGasReactor">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IdealGasReactor</code><span class="sig-paren">(</span><em>contents=None</em>, <em>*</em>, <em>name=None</em>, <em>energy='on'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasReactor" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IdealGasReactor</code><span class="sig-paren">(</span><em>contents=None</em>, <em>*</em>, <em>name=None</em>, <em>energy='on'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasReactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Reactor</span></code></p>
 <p>A constant volume, zero-dimensional reactor for ideal gas mixtures.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>contents</strong> – Reactor contents. If not specified, the reactor is initially empty.
+<li><strong>contents</strong> &#8211; Reactor contents. If not specified, the reactor is initially empty.
 In this case, call <code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code> to specify the contents.</li>
-<li><strong>name</strong> – Used only to identify this reactor in output. If not specified,
+<li><strong>name</strong> &#8211; Used only to identify this reactor in output. If not specified,
 defaults to <code class="docutils literal notranslate"><span class="pre">'Reactor_n'</span></code>, where <em>n</em> is an integer assigned in
 the order <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reactor</span></code></a> objects are created.</li>
-<li><strong>energy</strong> – Set to <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code>. If set to <code class="docutils literal notranslate"><span class="pre">'off'</span></code>, the energy
+<li><strong>energy</strong> &#8211; Set to <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code>. If set to <code class="docutils literal notranslate"><span class="pre">'off'</span></code>, the energy
 equation is not solved, and the temperature is held at its
 initial value..</li>
 </ul>
@@ -702,7 +698,7 @@ initial value..</li>
 </table>
 <p>Some examples showing how to create <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-class docutils literal notranslate"><span class="pre">Reactor</span></code></a> objects are
 shown below.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;gri30.xml&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">'gri30.xml'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">r1</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">gas</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -712,39 +708,39 @@ shown below.</p>
 </pre></div>
 </div>
 <p>Arguments may be specified using keywords in any order:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">r2</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">,</span> <span class="n">energy</span><span class="o">=</span><span class="s1">&#39;off&#39;</span><span class="p">,</span>
-<span class="gp">... </span>             <span class="n">name</span><span class="o">=</span><span class="s1">&#39;isothermal_reactor&#39;</span><span class="p">)</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">r3</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">&#39;adiabatic_reactor&#39;</span><span class="p">,</span> <span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">r2</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">,</span> <span class="n">energy</span><span class="o">=</span><span class="s1">'off'</span><span class="p">,</span>
+<span class="gp">... </span>             <span class="n">name</span><span class="o">=</span><span class="s1">'isothermal_reactor'</span><span class="p">)</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">r3</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">'adiabatic_reactor'</span><span class="p">,</span> <span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">)</span>
 </pre></div>
 </div>
 <dl class="attribute">
 <dt id="cantera.IdealGasReactor.reactor_type">
-<code class="descname">reactor_type</code><em class="property"> = 'IdealGasReactor'</em><a class="headerlink" href="#cantera.IdealGasReactor.reactor_type" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactor_type</code><em class="property"> = 'IdealGasReactor'</em><a class="headerlink" href="#cantera.IdealGasReactor.reactor_type" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="constpressurereactor">
-<h3><a class="toc-backref" href="#id28">ConstPressureReactor</a><a class="headerlink" href="#constpressurereactor" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id28">ConstPressureReactor</a><a class="headerlink" href="#constpressurereactor" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ConstPressureReactor">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ConstPressureReactor</code><span class="sig-paren">(</span><em>contents=None</em>, <em>*</em>, <em>name=None</em>, <em>energy='on'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ConstPressureReactor" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ConstPressureReactor</code><span class="sig-paren">(</span><em>contents=None</em>, <em>*</em>, <em>name=None</em>, <em>energy='on'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ConstPressureReactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Reactor</span></code></p>
 <p>A homogeneous, constant pressure, zero-dimensional reactor. The volume
 of the reactor changes as a function of time in order to keep the
 pressure constant.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>contents</strong> – Reactor contents. If not specified, the reactor is initially empty.
+<li><strong>contents</strong> &#8211; Reactor contents. If not specified, the reactor is initially empty.
 In this case, call <code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code> to specify the contents.</li>
-<li><strong>name</strong> – Used only to identify this reactor in output. If not specified,
+<li><strong>name</strong> &#8211; Used only to identify this reactor in output. If not specified,
 defaults to <code class="docutils literal notranslate"><span class="pre">'Reactor_n'</span></code>, where <em>n</em> is an integer assigned in
 the order <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reactor</span></code></a> objects are created.</li>
-<li><strong>energy</strong> – Set to <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code>. If set to <code class="docutils literal notranslate"><span class="pre">'off'</span></code>, the energy
+<li><strong>energy</strong> &#8211; Set to <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code>. If set to <code class="docutils literal notranslate"><span class="pre">'off'</span></code>, the energy
 equation is not solved, and the temperature is held at its
 initial value..</li>
 </ul>
@@ -754,7 +750,7 @@ initial value..</li>
 </table>
 <p>Some examples showing how to create <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-class docutils literal notranslate"><span class="pre">Reactor</span></code></a> objects are
 shown below.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;gri30.xml&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">'gri30.xml'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">r1</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">gas</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -764,39 +760,39 @@ shown below.</p>
 </pre></div>
 </div>
 <p>Arguments may be specified using keywords in any order:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">r2</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">,</span> <span class="n">energy</span><span class="o">=</span><span class="s1">&#39;off&#39;</span><span class="p">,</span>
-<span class="gp">... </span>             <span class="n">name</span><span class="o">=</span><span class="s1">&#39;isothermal_reactor&#39;</span><span class="p">)</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">r3</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">&#39;adiabatic_reactor&#39;</span><span class="p">,</span> <span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">r2</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">,</span> <span class="n">energy</span><span class="o">=</span><span class="s1">'off'</span><span class="p">,</span>
+<span class="gp">... </span>             <span class="n">name</span><span class="o">=</span><span class="s1">'isothermal_reactor'</span><span class="p">)</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">r3</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">'adiabatic_reactor'</span><span class="p">,</span> <span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">)</span>
 </pre></div>
 </div>
 <dl class="attribute">
 <dt id="cantera.ConstPressureReactor.reactor_type">
-<code class="descname">reactor_type</code><em class="property"> = 'ConstPressureReactor'</em><a class="headerlink" href="#cantera.ConstPressureReactor.reactor_type" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactor_type</code><em class="property"> = 'ConstPressureReactor'</em><a class="headerlink" href="#cantera.ConstPressureReactor.reactor_type" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="idealgasconstpressurereactor">
-<h3><a class="toc-backref" href="#id29">IdealGasConstPressureReactor</a><a class="headerlink" href="#idealgasconstpressurereactor" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id29">IdealGasConstPressureReactor</a><a class="headerlink" href="#idealgasconstpressurereactor" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.IdealGasConstPressureReactor">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IdealGasConstPressureReactor</code><span class="sig-paren">(</span><em>contents=None</em>, <em>*</em>, <em>name=None</em>, <em>energy='on'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasConstPressureReactor" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">IdealGasConstPressureReactor</code><span class="sig-paren">(</span><em>contents=None</em>, <em>*</em>, <em>name=None</em>, <em>energy='on'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.IdealGasConstPressureReactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Reactor</span></code></p>
 <p>A homogeneous, constant pressure, zero-dimensional reactor for ideal gas
 mixtures. The volume of the reactor changes as a function of time in order
 to keep the pressure constant.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>contents</strong> – Reactor contents. If not specified, the reactor is initially empty.
+<li><strong>contents</strong> &#8211; Reactor contents. If not specified, the reactor is initially empty.
 In this case, call <code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code> to specify the contents.</li>
-<li><strong>name</strong> – Used only to identify this reactor in output. If not specified,
+<li><strong>name</strong> &#8211; Used only to identify this reactor in output. If not specified,
 defaults to <code class="docutils literal notranslate"><span class="pre">'Reactor_n'</span></code>, where <em>n</em> is an integer assigned in
 the order <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reactor</span></code></a> objects are created.</li>
-<li><strong>energy</strong> – Set to <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code>. If set to <code class="docutils literal notranslate"><span class="pre">'off'</span></code>, the energy
+<li><strong>energy</strong> &#8211; Set to <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code>. If set to <code class="docutils literal notranslate"><span class="pre">'off'</span></code>, the energy
 equation is not solved, and the temperature is held at its
 initial value..</li>
 </ul>
@@ -806,7 +802,7 @@ initial value..</li>
 </table>
 <p>Some examples showing how to create <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-class docutils literal notranslate"><span class="pre">Reactor</span></code></a> objects are
 shown below.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;gri30.xml&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">'gri30.xml'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">r1</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">gas</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -816,39 +812,39 @@ shown below.</p>
 </pre></div>
 </div>
 <p>Arguments may be specified using keywords in any order:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">r2</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">,</span> <span class="n">energy</span><span class="o">=</span><span class="s1">&#39;off&#39;</span><span class="p">,</span>
-<span class="gp">... </span>             <span class="n">name</span><span class="o">=</span><span class="s1">&#39;isothermal_reactor&#39;</span><span class="p">)</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">r3</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">&#39;adiabatic_reactor&#39;</span><span class="p">,</span> <span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">r2</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">,</span> <span class="n">energy</span><span class="o">=</span><span class="s1">'off'</span><span class="p">,</span>
+<span class="gp">... </span>             <span class="n">name</span><span class="o">=</span><span class="s1">'isothermal_reactor'</span><span class="p">)</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">r3</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">'adiabatic_reactor'</span><span class="p">,</span> <span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">)</span>
 </pre></div>
 </div>
 <dl class="attribute">
 <dt id="cantera.IdealGasConstPressureReactor.reactor_type">
-<code class="descname">reactor_type</code><em class="property"> = 'IdealGasConstPressureReactor'</em><a class="headerlink" href="#cantera.IdealGasConstPressureReactor.reactor_type" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactor_type</code><em class="property"> = 'IdealGasConstPressureReactor'</em><a class="headerlink" href="#cantera.IdealGasConstPressureReactor.reactor_type" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="flowreactor">
-<h3><a class="toc-backref" href="#id30">FlowReactor</a><a class="headerlink" href="#flowreactor" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id30">FlowReactor</a><a class="headerlink" href="#flowreactor" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.FlowReactor">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FlowReactor</code><span class="sig-paren">(</span><em>contents=None</em>, <em>*</em>, <em>name=None</em>, <em>energy='on'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlowReactor" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">FlowReactor</code><span class="sig-paren">(</span><em>contents=None</em>, <em>*</em>, <em>name=None</em>, <em>energy='on'</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.FlowReactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.Reactor</span></code></p>
 <p>A steady-state plug flow reactor with constant cross sectional area.
 Time integration follows a fluid element along the length of the reactor.
 The reactor is assumed to be frictionless and adiabatic.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>contents</strong> – Reactor contents. If not specified, the reactor is initially empty.
+<li><strong>contents</strong> &#8211; Reactor contents. If not specified, the reactor is initially empty.
 In this case, call <code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code> to specify the contents.</li>
-<li><strong>name</strong> – Used only to identify this reactor in output. If not specified,
+<li><strong>name</strong> &#8211; Used only to identify this reactor in output. If not specified,
 defaults to <code class="docutils literal notranslate"><span class="pre">'Reactor_n'</span></code>, where <em>n</em> is an integer assigned in
 the order <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reactor</span></code></a> objects are created.</li>
-<li><strong>energy</strong> – Set to <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code>. If set to <code class="docutils literal notranslate"><span class="pre">'off'</span></code>, the energy
+<li><strong>energy</strong> &#8211; Set to <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code>. If set to <code class="docutils literal notranslate"><span class="pre">'off'</span></code>, the energy
 equation is not solved, and the temperature is held at its
 initial value..</li>
 </ul>
@@ -858,7 +854,7 @@ initial value..</li>
 </table>
 <p>Some examples showing how to create <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-class docutils literal notranslate"><span class="pre">Reactor</span></code></a> objects are
 shown below.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;gri30.xml&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">'gri30.xml'</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">r1</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">gas</span><span class="p">)</span>
 </pre></div>
 </div>
@@ -868,31 +864,31 @@ shown below.</p>
 </pre></div>
 </div>
 <p>Arguments may be specified using keywords in any order:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">r2</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">,</span> <span class="n">energy</span><span class="o">=</span><span class="s1">&#39;off&#39;</span><span class="p">,</span>
-<span class="gp">... </span>             <span class="n">name</span><span class="o">=</span><span class="s1">&#39;isothermal_reactor&#39;</span><span class="p">)</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">r3</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">&#39;adiabatic_reactor&#39;</span><span class="p">,</span> <span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">r2</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">,</span> <span class="n">energy</span><span class="o">=</span><span class="s1">'off'</span><span class="p">,</span>
+<span class="gp">... </span>             <span class="n">name</span><span class="o">=</span><span class="s1">'isothermal_reactor'</span><span class="p">)</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">r3</span> <span class="o">=</span> <span class="n">Reactor</span><span class="p">(</span><span class="n">name</span><span class="o">=</span><span class="s1">'adiabatic_reactor'</span><span class="p">,</span> <span class="n">contents</span><span class="o">=</span><span class="n">gas</span><span class="p">)</span>
 </pre></div>
 </div>
 <dl class="attribute">
 <dt id="cantera.FlowReactor.distance">
-<code class="descname">distance</code><a class="headerlink" href="#cantera.FlowReactor.distance" title="Permalink to this definition">¶</a></dt>
+<code class="descname">distance</code><a class="headerlink" href="#cantera.FlowReactor.distance" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The distance of the fluid element from the inlet of the reactor.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlowReactor.mass_flow_rate">
-<code class="descname">mass_flow_rate</code><a class="headerlink" href="#cantera.FlowReactor.mass_flow_rate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mass_flow_rate</code><a class="headerlink" href="#cantera.FlowReactor.mass_flow_rate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Mass flow rate per unit area [kg/m^2*s]</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlowReactor.reactor_type">
-<code class="descname">reactor_type</code><em class="property"> = 'FlowReactor'</em><a class="headerlink" href="#cantera.FlowReactor.reactor_type" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactor_type</code><em class="property"> = 'FlowReactor'</em><a class="headerlink" href="#cantera.FlowReactor.reactor_type" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.FlowReactor.speed">
-<code class="descname">speed</code><a class="headerlink" href="#cantera.FlowReactor.speed" title="Permalink to this definition">¶</a></dt>
+<code class="descname">speed</code><a class="headerlink" href="#cantera.FlowReactor.speed" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Speed [m/s] of the flow in the reactor at the current position</p>
 </dd></dl>
 
@@ -901,12 +897,12 @@ shown below.</p>
 </div>
 </div>
 <div class="section" id="walls">
-<h2><a class="toc-backref" href="#id31">Walls</a><a class="headerlink" href="#walls" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id31">Walls</a><a class="headerlink" href="#walls" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="wall">
-<h3><a class="toc-backref" href="#id32">Wall</a><a class="headerlink" href="#wall" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id32">Wall</a><a class="headerlink" href="#wall" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Wall">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Wall</code><span class="sig-paren">(</span><em>left</em>, <em>right</em>, <em>*</em>, <em>name=None</em>, <em>A=None</em>, <em>K=None</em>, <em>U=None</em>, <em>Q=None</em>, <em>velocity=None</em>, <em>kinetics=(None</em>, <em>None)</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Wall" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Wall</code><span class="sig-paren">(</span><em>left</em>, <em>right</em>, <em>*</em>, <em>name=None</em>, <em>A=None</em>, <em>K=None</em>, <em>U=None</em>, <em>Q=None</em>, <em>velocity=None</em>, <em>kinetics=(None</em>, <em>None)</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Wall" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>Wall(left, right, name=None, <a href="#id9"><span class="problematic" id="id10">*</span></a>, A=None, K=None, U=None, Q=None, velocity=None)</p>
 <p>A Wall separates two reactors, or a reactor and a reservoir. A wall has a
@@ -934,21 +930,21 @@ conduction/convection, and <span class="math">\(\epsilon\)</span> is the emissiv
 <span class="math">\(q_0(t)\)</span> is a specified function of time. The heat flux is positive
 when heat flows from the reactor on the left to the reactor on the right.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>left</strong> – Reactor or reservoir on the left. Required.</li>
-<li><strong>right</strong> – Reactor or reservoir on the right. Required.</li>
-<li><strong>name</strong> – Name string. If omitted, the name is <code class="docutils literal notranslate"><span class="pre">'Wall_n'</span></code>, where <code class="docutils literal notranslate"><span class="pre">'n'</span></code>
+<li><strong>left</strong> &#8211; Reactor or reservoir on the left. Required.</li>
+<li><strong>right</strong> &#8211; Reactor or reservoir on the right. Required.</li>
+<li><strong>name</strong> &#8211; Name string. If omitted, the name is <code class="docutils literal notranslate"><span class="pre">'Wall_n'</span></code>, where <code class="docutils literal notranslate"><span class="pre">'n'</span></code>
 is an integer assigned in the order walls are created.</li>
-<li><strong>A</strong> – Wall area [m^2]. Defaults to 1.0 m^2.</li>
-<li><strong>K</strong> – Wall expansion rate parameter [m/s/Pa]. Defaults to 0.0.</li>
-<li><strong>U</strong> – Overall heat transfer coefficient [W/m^2]. Defaults to 0.0
+<li><strong>A</strong> &#8211; Wall area [m^2]. Defaults to 1.0 m^2.</li>
+<li><strong>K</strong> &#8211; Wall expansion rate parameter [m/s/Pa]. Defaults to 0.0.</li>
+<li><strong>U</strong> &#8211; Overall heat transfer coefficient [W/m^2]. Defaults to 0.0
 (adiabatic wall).</li>
-<li><strong>Q</strong> – Heat flux function <span class="math">\(q_0(t)\)</span> [W/m^2]. Optional. Default:
+<li><strong>Q</strong> &#8211; Heat flux function <span class="math">\(q_0(t)\)</span> [W/m^2]. Optional. Default:
 <span class="math">\(q_0(t) = 0.0\)</span>.</li>
-<li><strong>velocity</strong> – Wall velocity function <span class="math">\(v_0(t)\)</span> [m/s].
+<li><strong>velocity</strong> &#8211; Wall velocity function <span class="math">\(v_0(t)\)</span> [m/s].
 Default: <span class="math">\(v_0(t) = 0.0\)</span>.</li>
 </ul>
 </td>
@@ -957,38 +953,38 @@ Default: <span class="math">\(v_0(t) = 0.0\)</span>.</li>
 </table>
 <dl class="attribute">
 <dt id="cantera.Wall.area">
-<code class="descname">area</code><a class="headerlink" href="#cantera.Wall.area" title="Permalink to this definition">¶</a></dt>
+<code class="descname">area</code><a class="headerlink" href="#cantera.Wall.area" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The wall area [m^2].</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Wall.emissivity">
-<code class="descname">emissivity</code><a class="headerlink" href="#cantera.Wall.emissivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">emissivity</code><a class="headerlink" href="#cantera.Wall.emissivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The emissivity (nondimensional)</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Wall.expansion_rate_coeff">
-<code class="descname">expansion_rate_coeff</code><a class="headerlink" href="#cantera.Wall.expansion_rate_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">expansion_rate_coeff</code><a class="headerlink" href="#cantera.Wall.expansion_rate_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The coefficient <em>K</em> [m/s/Pa] that determines the velocity of the wall
 as a function of the pressure difference between the adjacent reactors.</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Wall.heat_transfer_coeff">
-<code class="descname">heat_transfer_coeff</code><a class="headerlink" href="#cantera.Wall.heat_transfer_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">heat_transfer_coeff</code><a class="headerlink" href="#cantera.Wall.heat_transfer_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>the overall heat transfer coefficient [W/m^2/K]</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.Wall.left">
-<code class="descname">left</code><a class="headerlink" href="#cantera.Wall.left" title="Permalink to this definition">¶</a></dt>
+<code class="descname">left</code><a class="headerlink" href="#cantera.Wall.left" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The left surface of this wall.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Wall.qdot">
-<code class="descname">qdot</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Wall.qdot" title="Permalink to this definition">¶</a></dt>
+<code class="descname">qdot</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Wall.qdot" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Total heat flux [W] through the wall at time <em>t</em>. A positive value
 corresponds to heat flowing from the left-hand reactor to the
 right-hand one.</p>
@@ -996,27 +992,27 @@ right-hand one.</p>
 
 <dl class="attribute">
 <dt id="cantera.Wall.right">
-<code class="descname">right</code><a class="headerlink" href="#cantera.Wall.right" title="Permalink to this definition">¶</a></dt>
+<code class="descname">right</code><a class="headerlink" href="#cantera.Wall.right" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The right surface of this wall.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Wall.set_heat_flux">
-<code class="descname">set_heat_flux</code><span class="sig-paren">(</span><em>self</em>, <em>q</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Wall.set_heat_flux" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_heat_flux</code><span class="sig-paren">(</span><em>self</em>, <em>q</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Wall.set_heat_flux" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Heat flux [W/m^2] across the wall. May be either a constant or
 an arbitrary function of time. See <a class="reference internal" href="#cantera.Func1" title="cantera.Func1"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Func1</span></code></a>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Wall.set_velocity">
-<code class="descname">set_velocity</code><span class="sig-paren">(</span><em>self</em>, <em>v</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Wall.set_velocity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_velocity</code><span class="sig-paren">(</span><em>self</em>, <em>v</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Wall.set_velocity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The wall velocity [m/s]. May be either a constant or an arbitrary
 function of time. See <a class="reference internal" href="#cantera.Func1" title="cantera.Func1"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Func1</span></code></a>.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.Wall.vdot">
-<code class="descname">vdot</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Wall.vdot" title="Permalink to this definition">¶</a></dt>
+<code class="descname">vdot</code><span class="sig-paren">(</span><em>self</em>, <em>double t</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Wall.vdot" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The rate of volumetric change [m^3/s] associated with the wall
 at time <em>t</em>. A positive value corresponds to the left-hand reactor
 volume increasing, and the right-hand reactor volume decreasing.</p>
@@ -1026,34 +1022,34 @@ volume increasing, and the right-hand reactor volume decreasing.</p>
 
 </div>
 <div class="section" id="wallsurface">
-<h3><a class="toc-backref" href="#id33">WallSurface</a><a class="headerlink" href="#wallsurface" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id33">WallSurface</a><a class="headerlink" href="#wallsurface" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.WallSurface">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">WallSurface</code><span class="sig-paren">(</span><em>wall</em>, <em>side</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.WallSurface" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">WallSurface</code><span class="sig-paren">(</span><em>wall</em>, <em>side</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.WallSurface" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 </dd></dl>
 
 </div>
 </div>
 <div class="section" id="surfaces">
-<h2><a class="toc-backref" href="#id34">Surfaces</a><a class="headerlink" href="#surfaces" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id34">Surfaces</a><a class="headerlink" href="#surfaces" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="reactorsurface">
-<h3><a class="toc-backref" href="#id35">ReactorSurface</a><a class="headerlink" href="#reactorsurface" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id35">ReactorSurface</a><a class="headerlink" href="#reactorsurface" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.ReactorSurface">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ReactorSurface</code><span class="sig-paren">(</span><em>kin=None</em>, <em>r=None</em>, <em>*</em>, <em>A=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorSurface" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">ReactorSurface</code><span class="sig-paren">(</span><em>kin=None</em>, <em>r=None</em>, <em>*</em>, <em>A=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorSurface" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">object</span></code></p>
 <p>ReactorSurface(kin=None, Reactor r=None, A=None, <a href="#id11"><span class="problematic" id="id12">*</span></a>)</p>
 <p>Represents a surface in contact with the contents of a reactor.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>kin</strong> – The <a class="reference internal" href="kinetics.html#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> or <a class="reference internal" href="importing.html#cantera.Interface" title="cantera.Interface"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Interface</span></code></a> object representing reactions on this
+<li><strong>kin</strong> &#8211; The <a class="reference internal" href="kinetics.html#cantera.Kinetics" title="cantera.Kinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Kinetics</span></code></a> or <a class="reference internal" href="importing.html#cantera.Interface" title="cantera.Interface"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Interface</span></code></a> object representing reactions on this
 surface.</li>
-<li><strong>r</strong> – The <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reactor</span></code></a> into which this surface should be installed.</li>
-<li><strong>A</strong> – The area of the reacting surface [m^2]</li>
+<li><strong>r</strong> &#8211; The <a class="reference internal" href="#cantera.Reactor" title="cantera.Reactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Reactor</span></code></a> into which this surface should be installed.</li>
+<li><strong>A</strong> &#8211; The area of the reacting surface [m^2]</li>
 </ul>
 </td>
 </tr>
@@ -1061,7 +1057,7 @@ surface.</li>
 </table>
 <dl class="method">
 <dt id="cantera.ReactorSurface.add_sensitivity_reaction">
-<code class="descname">add_sensitivity_reaction</code><span class="sig-paren">(</span><em>self</em>, <em>int m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorSurface.add_sensitivity_reaction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">add_sensitivity_reaction</code><span class="sig-paren">(</span><em>self</em>, <em>int m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorSurface.add_sensitivity_reaction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specifies that the sensitivity of the state variables with respect to
 reaction <em>m</em> should be computed. <em>m</em> is the 0-based reaction index.
 The Surface must be installed on a reactor and part of a network first.</p>
@@ -1069,24 +1065,24 @@ The Surface must be installed on a reactor and part of a network first.</p>
 
 <dl class="attribute">
 <dt id="cantera.ReactorSurface.area">
-<code class="descname">area</code><a class="headerlink" href="#cantera.ReactorSurface.area" title="Permalink to this definition">¶</a></dt>
+<code class="descname">area</code><a class="headerlink" href="#cantera.ReactorSurface.area" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Area on which reactions can occur [m^2]</p>
 </dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorSurface.coverages">
-<code class="descname">coverages</code><a class="headerlink" href="#cantera.ReactorSurface.coverages" title="Permalink to this definition">¶</a></dt>
+<code class="descname">coverages</code><a class="headerlink" href="#cantera.ReactorSurface.coverages" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The fraction of sites covered by each surface species.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.ReactorSurface.install">
-<code class="descname">install</code><span class="sig-paren">(</span><em>self</em>, <em>Reactor r</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorSurface.install" title="Permalink to this definition">¶</a></dt>
+<code class="descname">install</code><span class="sig-paren">(</span><em>self</em>, <em>Reactor r</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.ReactorSurface.install" title="Permalink to this definition">&#182;</a></dt>
 <dd></dd></dl>
 
 <dl class="attribute">
 <dt id="cantera.ReactorSurface.kinetics">
-<code class="descname">kinetics</code><a class="headerlink" href="#cantera.ReactorSurface.kinetics" title="Permalink to this definition">¶</a></dt>
+<code class="descname">kinetics</code><a class="headerlink" href="#cantera.ReactorSurface.kinetics" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The <a class="reference internal" href="kinetics.html#cantera.InterfaceKinetics" title="cantera.InterfaceKinetics"><code class="xref py py-obj docutils literal notranslate"><span class="pre">InterfaceKinetics</span></code></a> object used for calculating reaction rates on
 this surface.</p>
 </dd></dl>
@@ -1096,12 +1092,12 @@ this surface.</p>
 </div>
 </div>
 <div class="section" id="flow-controllers">
-<h2><a class="toc-backref" href="#id36">Flow Controllers</a><a class="headerlink" href="#flow-controllers" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id36">Flow Controllers</a><a class="headerlink" href="#flow-controllers" title="Permalink to this headline">&#182;</a></h2>
 <div class="section" id="massflowcontroller">
-<h3><a class="toc-backref" href="#id37">MassFlowController</a><a class="headerlink" href="#massflowcontroller" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id37">MassFlowController</a><a class="headerlink" href="#massflowcontroller" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.MassFlowController">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">MassFlowController</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em>, <em>*</em>, <em>name=None</em>, <em>mdot=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.MassFlowController" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">MassFlowController</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em>, <em>*</em>, <em>name=None</em>, <em>mdot=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.MassFlowController" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.FlowDevice</span></code></p>
 <p>MassFlowController(upstream, downstream, name=None, <a href="#id13"><span class="problematic" id="id14">*</span></a>, mdot=None)</p>
 <p>A mass flow controller maintains a specified mass
@@ -1120,7 +1116,7 @@ that this capability should be used with caution, since no account is
 taken of the work required to do this.</p>
 <dl class="method">
 <dt id="cantera.MassFlowController.set_mass_flow_rate">
-<code class="descname">set_mass_flow_rate</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.MassFlowController.set_mass_flow_rate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_mass_flow_rate</code><span class="sig-paren">(</span><em>self</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.MassFlowController.set_mass_flow_rate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mass flow rate [kg/s] through this controller to be either
 a constant or an arbitrary function of time. See <a class="reference internal" href="#cantera.Func1" title="cantera.Func1"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Func1</span></code></a>.</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">mfc</span><span class="o">.</span><span class="n">set_mass_flow_rate</span><span class="p">(</span><span class="mf">0.3</span><span class="p">)</span>
@@ -1133,10 +1129,10 @@ a constant or an arbitrary function of time. See <a class="reference internal" h
 
 </div>
 <div class="section" id="valve">
-<h3><a class="toc-backref" href="#id38">Valve</a><a class="headerlink" href="#valve" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id38">Valve</a><a class="headerlink" href="#valve" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.Valve">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Valve</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em>, <em>*</em>, <em>name=None</em>, <em>K=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Valve" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">Valve</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em>, <em>*</em>, <em>name=None</em>, <em>K=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Valve" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.FlowDevice</span></code></p>
 <p>Valve(upstream, downstream, name=None, <a href="#id15"><span class="problematic" id="id16">*</span></a>, K=None)</p>
 <p>In Cantera, a <a class="reference internal" href="#cantera.Valve" title="cantera.Valve"><code class="xref py py-obj docutils literal notranslate"><span class="pre">Valve</span></code></a> is a flow device with mass flow rate that is a
@@ -1165,7 +1161,7 @@ value, very small pressure differences will result in flow between the
 reactors that counteracts the pressure difference.</p>
 <dl class="method">
 <dt id="cantera.Valve.set_valve_coeff">
-<code class="descname">set_valve_coeff</code><span class="sig-paren">(</span><em>self</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Valve.set_valve_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_valve_coeff</code><span class="sig-paren">(</span><em>self</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.Valve.set_valve_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the relationship between mass flow rate and the pressure drop across
 the valve. If a number is given, it is the proportionality constant
 [kg/s/Pa]. If a function is given, it should compute the mass flow
@@ -1181,14 +1177,14 @@ rate [kg/s] given the pressure drop [Pa].</p>
 
 </div>
 <div class="section" id="pressurecontroller">
-<h3><a class="toc-backref" href="#id39">PressureController</a><a class="headerlink" href="#pressurecontroller" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id39">PressureController</a><a class="headerlink" href="#pressurecontroller" title="Permalink to this headline">&#182;</a></h3>
 <dl class="class">
 <dt id="cantera.PressureController">
-<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">PressureController</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em>, <em>*</em>, <em>name=None</em>, <em>master=None</em>, <em>K=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.PressureController" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">cantera.</code><code class="descname">PressureController</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em>, <em>*</em>, <em>name=None</em>, <em>master=None</em>, <em>K=None</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.PressureController" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Bases: <code class="xref py py-class docutils literal notranslate"><span class="pre">cantera._cantera.FlowDevice</span></code></p>
 <p>PressureController(upstream, downstream, name=None, <a href="#id17"><span class="problematic" id="id18">*</span></a>, master=None, K=None)</p>
 <p>A PressureController is designed to be used in conjunction with another
-‘master’ flow controller, typically a <a class="reference internal" href="#cantera.MassFlowController" title="cantera.MassFlowController"><code class="xref py py-obj docutils literal notranslate"><span class="pre">MassFlowController</span></code></a>. The master
+&#8216;master&#8217; flow controller, typically a <a class="reference internal" href="#cantera.MassFlowController" title="cantera.MassFlowController"><code class="xref py py-obj docutils literal notranslate"><span class="pre">MassFlowController</span></code></a>. The master
 flow controller is installed on the inlet of the reactor, and the
 corresponding <a class="reference internal" href="#cantera.PressureController" title="cantera.PressureController"><code class="xref py py-obj docutils literal notranslate"><span class="pre">PressureController</span></code></a> is installed on on outlet of the
 reactor. The <a class="reference internal" href="#cantera.PressureController" title="cantera.PressureController"><code class="xref py py-obj docutils literal notranslate"><span class="pre">PressureController</span></code></a> mass flow rate is equal to the master
@@ -1200,14 +1196,14 @@ difference:</p>
 \]</div>
 <dl class="method">
 <dt id="cantera.PressureController.set_master">
-<code class="descname">set_master</code><span class="sig-paren">(</span><em>self</em>, <em>FlowDevice d</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.PressureController.set_master" title="Permalink to this definition">¶</a></dt>
-<dd><p>Set the “master” <a class="reference internal" href="#cantera.FlowDevice" title="cantera.FlowDevice"><code class="xref py py-obj docutils literal notranslate"><span class="pre">FlowDevice</span></code></a> used to compute this device’s mass flow
+<code class="descname">set_master</code><span class="sig-paren">(</span><em>self</em>, <em>FlowDevice d</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.PressureController.set_master" title="Permalink to this definition">&#182;</a></dt>
+<dd><p>Set the &#8220;master&#8221; <a class="reference internal" href="#cantera.FlowDevice" title="cantera.FlowDevice"><code class="xref py py-obj docutils literal notranslate"><span class="pre">FlowDevice</span></code></a> used to compute this device&#8217;s mass flow
 rate.</p>
 </dd></dl>
 
 <dl class="method">
 <dt id="cantera.PressureController.set_pressure_coeff">
-<code class="descname">set_pressure_coeff</code><span class="sig-paren">(</span><em>self</em>, <em>double k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.PressureController.set_pressure_coeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set_pressure_coeff</code><span class="sig-paren">(</span><em>self</em>, <em>double k</em><span class="sig-paren">)</span><a class="headerlink" href="#cantera.PressureController.set_pressure_coeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the proportionality constant <span class="math">\(K_v\)</span> [kg/s/Pa] between the pressure
 drop and the mass flow rate.</p>
 </dd></dl>
@@ -1276,25 +1272,24 @@ drop and the mass flow rate.</p>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/cython/zerodim.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/cython/zerodim.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -1303,15 +1298,14 @@ drop and the mass flow rate.</p>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/cython/zerodim.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/cython/zerodim.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/cython/zerodim.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/zerodim.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/genindex.html
+++ b/api-docs/docs-2.4/sphinx/html/genindex.html
@@ -15,14 +15,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
     <script type="text/javascript" src="_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/genindex.html
+++ b/api-docs/docs-2.4/sphinx/html/genindex.html
@@ -1,22 +1,17 @@
-
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Index | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -24,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="search.html" />
+    <link rel="search" title="Search" href="search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -3478,17 +3473,17 @@ lang="en">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -3497,7 +3492,7 @@ lang="en">
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>

--- a/api-docs/docs-2.4/sphinx/html/index.html
+++ b/api-docs/docs-2.4/sphinx/html/index.html
@@ -14,15 +14,15 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="_static/katex-math.css" type="text/css" />
-    <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
-    <script type="text/javascript" src="_static/jquery.js"></script>
-    <script type="text/javascript" src="_static/underscore.js"></script>
-    <script type="text/javascript" src="_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
-    <script type="text/javascript" src="_static/katex_autorenderer.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+    <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
+    <script type="text/javascript" src="../_static/jquery.js"></script>
+    <script type="text/javascript" src="../_static/underscore.js"></script>
+    <script type="text/javascript" src="../_static/doctools.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 
     <link rel="search" title="Search" href="search.html" />

--- a/api-docs/docs-2.4/sphinx/html/index.html
+++ b/api-docs/docs-2.4/sphinx/html/index.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Documentation | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="search.html" />
+    <link rel="search" title="Search" href="search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,7 +77,7 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="documentation">
-<h1>Documentation<a class="headerlink" href="#documentation" title="Permalink to this headline">¶</a></h1>
+<h1>Documentation<a class="headerlink" href="#documentation" title="Permalink to this headline">&#182;</a></h1>
 <p>These are the detailed API documentation pages for the Python and Matlab
 interfaces for Cantera. There is also documentation of the CTI input file
 format.</p>
@@ -106,7 +102,7 @@ format.</p>
 <li class="toctree-l2"><a class="reference internal" href="cython/constants.html">Physical Constants</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="matlab/index.html">Matlab Interface User’s Guide</a><ul>
+<li class="toctree-l1"><a class="reference internal" href="matlab/index.html">Matlab Interface User&#8217;s Guide</a><ul>
 <li class="toctree-l2"><a class="reference internal" href="matlab/importing.html">Objects Representing Phases</a></li>
 <li class="toctree-l2"><a class="reference internal" href="matlab/thermodynamics.html">Thermodynamic Properties</a></li>
 <li class="toctree-l2"><a class="reference internal" href="matlab/kinetics.html">Chemical Kinetics</a></li>
@@ -138,25 +134,24 @@ format.</p>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="_sources/index.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="_sources/index.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -165,15 +160,14 @@ format.</p>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="_sources/index.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="_sources/index.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/matlab/data.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/data.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Physical Constants | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,17 +77,17 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="physical-constants">
-<h1>Physical Constants<a class="headerlink" href="#physical-constants" title="Permalink to this headline">¶</a></h1>
+<h1>Physical Constants<a class="headerlink" href="#physical-constants" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="data">
-<h2>Data<a class="headerlink" href="#data" title="Permalink to this headline">¶</a></h2>
+<h2>Data<a class="headerlink" href="#data" title="Permalink to this headline">&#182;</a></h2>
 <blockquote>
 <div><dl class="function">
 <dt id="gasconstant">
-<code class="descname">gasconstant</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#gasconstant" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gasconstant</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#gasconstant" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the universal gas constant in J/kmol-K.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">The universal gas constant in J/kmol-K.</td>
 </tr>
@@ -101,11 +97,11 @@ lang="en">
 
 <dl class="function">
 <dt id="oneatm">
-<code class="descname">oneatm</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#oneatm" title="Permalink to this definition">¶</a></dt>
+<code class="descname">oneatm</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#oneatm" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get one atmosphere in Pa.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">One atmosphere in Pascals.</td>
 </tr>
@@ -135,7 +131,7 @@ lang="en">
 <h3>Related Topics</h3>
 <ul>
   <li><a href="../index.html">Documentation overview</a><ul>
-  <li><a href="index.html">Matlab Interface User’s Guide</a><ul>
+  <li><a href="index.html">Matlab Interface User&#8217;s Guide</a><ul>
       <li>Previous: <a href="one-dim.html" title="previous chapter">One-Dimensional Reacting Flows</a></li>
       <li>Next: <a href="utilities.html" title="next chapter">Utility Functions</a></li>
   </ul></li>
@@ -145,25 +141,24 @@ lang="en">
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/matlab/data.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/matlab/data.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -172,15 +167,14 @@ lang="en">
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/matlab/data.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/matlab/data.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/matlab/data.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/data.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/matlab/importing.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/importing.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Objects Representing Phases | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,12 +77,12 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="objects-representing-phases">
-<h1>Objects Representing Phases<a class="headerlink" href="#objects-representing-phases" title="Permalink to this headline">¶</a></h1>
+<h1>Objects Representing Phases<a class="headerlink" href="#objects-representing-phases" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="solution">
-<h2>Solution<a class="headerlink" href="#solution" title="Permalink to this headline">¶</a></h2>
+<h2>Solution<a class="headerlink" href="#solution" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="Solution">
-<em class="property">class </em><code class="descname">Solution</code><span class="sig-paren">(</span><em>src</em>, <em>id</em>, <em>trans</em><span class="sig-paren">)</span><a class="headerlink" href="#Solution" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">Solution</code><span class="sig-paren">(</span><em>src</em>, <em>id</em>, <em>trans</em><span class="sig-paren">)</span><a class="headerlink" href="#Solution" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Solution class constructor.</p>
 <p>Class <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> represents solutions of multiple species. A
 solution is defined as a mixture of two or more constituents
@@ -96,7 +92,7 @@ solution is specified by two thermodynamic properties (for
 example, the temperature and pressure), and the relative amounts
 of each species, which may be given as mole fractions or mass
 fractions.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">s</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;input.xml&#39;</span><span class="p">[,</span> <span class="n">phase_name</span><span class="p">[,</span> <span class="n">transport_model</span><span class="p">]])</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">s</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">'input.xml'</span><span class="p">[,</span> <span class="n">phase_name</span><span class="p">[,</span> <span class="n">transport_model</span><span class="p">]])</span>
 </pre></div>
 </div>
 <p>constructs a Solution object from a specification contained in
@@ -121,14 +117,14 @@ its methods are inherited from these classes. These are:</p>
 </div></blockquote>
 <p>See also: <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a>, <a class="reference internal" href="kinetics.html#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a>, <a class="reference internal" href="transport.html#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>src</strong> – Input string of CTI or CTML file name.</li>
-<li><strong>id</strong> – Optional unless <code class="docutils literal notranslate"><span class="pre">trans</span></code> is specified. ID of the phase to
+<li><strong>src</strong> &#8211; Input string of CTI or CTML file name.</li>
+<li><strong>id</strong> &#8211; Optional unless <code class="docutils literal notranslate"><span class="pre">trans</span></code> is specified. ID of the phase to
 import as specified in the CTML or CTI file.</li>
-<li><strong>trans</strong> – String, transport modeling. Possible values are <code class="docutils literal notranslate"><span class="pre">'default'</span></code>,
+<li><strong>trans</strong> &#8211; String, transport modeling. Possible values are <code class="docutils literal notranslate"><span class="pre">'default'</span></code>,
 <code class="docutils literal notranslate"><span class="pre">'Mix'</span></code>, or <code class="docutils literal notranslate"><span class="pre">'Multi'</span></code>. If not specified, <code class="docutils literal notranslate"><span class="pre">'default'</span></code> is used.</li>
 </ul>
 </td>
@@ -140,14 +136,14 @@ import as specified in the CTML or CTI file.</li>
 </table>
 <dl class="function">
 <dt id="Solution.Air">
-<code class="descname">Air</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Solution.Air" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Air</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Solution.Air" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create an object representing air.</p>
 <p>Air is modeled as an ideal gas mixture. The specification is taken
 from file <code class="docutils literal notranslate"><span class="pre">air.xml</span></code>. Several reactions among oxygen and nitrogen are
 defined.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></td>
 </tr>
@@ -157,7 +153,7 @@ defined.</p>
 
 <dl class="function">
 <dt id="Solution.GRI30">
-<code class="descname">GRI30</code><span class="sig-paren">(</span><em>tr</em><span class="sig-paren">)</span><a class="headerlink" href="#Solution.GRI30" title="Permalink to this definition">¶</a></dt>
+<code class="descname">GRI30</code><span class="sig-paren">(</span><em>tr</em><span class="sig-paren">)</span><a class="headerlink" href="#Solution.GRI30" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create an object with the GRI-Mech 3.0 reaction mechanism.</p>
 <p>Create a Solution instance representing
 reaction mechanism GRI-Mech 3.0.</p>
@@ -173,15 +169,15 @@ state is used. Transport property evaluation is disabled by
 default. To enable transport properties, supply the name of
 the transport model to use.</p>
 <div class="highlight-matlab notranslate"><div class="highlight"><pre><span></span><span class="n">g1</span> <span class="p">=</span> <span class="n">GRI30</span>           <span class="c">% no transport properties</span>
-<span class="n">g2</span> <span class="p">=</span> <span class="n">GRI30</span><span class="p">(</span><span class="s">&#39;Mix&#39;</span><span class="p">)</span>    <span class="c">% mixture-averaged transport properties</span>
-<span class="n">g3</span> <span class="p">=</span> <span class="n">GRI30</span><span class="p">(</span><span class="s">&#39;Multi&#39;</span><span class="p">)</span>  <span class="c">% miulticomponent transport properties</span>
+<span class="n">g2</span> <span class="p">=</span> <span class="n">GRI30</span><span class="p">(</span><span class="s">'Mix'</span><span class="p">)</span>    <span class="c">% mixture-averaged transport properties</span>
+<span class="n">g3</span> <span class="p">=</span> <span class="n">GRI30</span><span class="p">(</span><span class="s">'Multi'</span><span class="p">)</span>  <span class="c">% miulticomponent transport properties</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tr</strong> – Transport modeling, <code class="docutils literal notranslate"><span class="pre">'Mix'</span></code> or <code class="docutils literal notranslate"><span class="pre">'Multi'</span></code></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tr</strong> &#8211; Transport modeling, <code class="docutils literal notranslate"><span class="pre">'Mix'</span></code> or <code class="docutils literal notranslate"><span class="pre">'Multi'</span></code></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></td>
 </tr>
@@ -191,31 +187,31 @@ the transport model to use.</p>
 
 <dl class="function">
 <dt id="Solution.IdealGasMix">
-<code class="descname">IdealGasMix</code><span class="sig-paren">(</span><em>infile</em>, <em>b</em>, <em>c</em><span class="sig-paren">)</span><a class="headerlink" href="#Solution.IdealGasMix" title="Permalink to this definition">¶</a></dt>
+<code class="descname">IdealGasMix</code><span class="sig-paren">(</span><em>infile</em>, <em>b</em>, <em>c</em><span class="sig-paren">)</span><a class="headerlink" href="#Solution.IdealGasMix" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a mixture of ideal gases.</p>
 <p>Create a <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> instance representing an ideal gas mixture.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">gas1</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">&#39;ctml_file&#39;</span><span class="p">[,</span><span class="s1">&#39;transport_model&#39;</span><span class="p">])</span>
-<span class="n">gas2</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">&#39;ck_file&#39;</span><span class="p">[,</span><span class="s1">&#39;thermo_db&#39;</span><span class="p">[,</span><span class="s1">&#39;tran_db&#39;</span><span class="p">[,</span><span class="s1">&#39;transport_model&#39;</span><span class="p">]]])</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">gas1</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">'ctml_file'</span><span class="p">[,</span><span class="s1">'transport_model'</span><span class="p">])</span>
+<span class="n">gas2</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">'ck_file'</span><span class="p">[,</span><span class="s1">'thermo_db'</span><span class="p">[,</span><span class="s1">'tran_db'</span><span class="p">[,</span><span class="s1">'transport_model'</span><span class="p">]]])</span>
 </pre></div>
 </div>
 <p>creates an object that represents an ideal gas mixture. The
 species in the mixture, their properties, and the reactions among
-the species, if any, are specified in file ‘ctml_file’ and ‘ck_file’.  Two
+the species, if any, are specified in file &#8216;ctml_file&#8217; and &#8216;ck_file&#8217;.  Two
 input file formats are supported - CTML and CK
 (CHEMKIN-compatible).  Examples:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">g1a</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">&#39;mech.xml&#39;</span><span class="p">)</span>
-<span class="n">g1b</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">&#39;mech.xml&#39;</span><span class="p">,</span> <span class="s1">&#39;Multi&#39;</span><span class="p">)</span>
-<span class="n">g2</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">&#39;mech2.inp&#39;</span><span class="p">)</span>
-<span class="n">g3</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">&#39;mech3.inp&#39;</span><span class="p">,</span> <span class="s1">&#39;therm.dat&#39;</span><span class="p">)</span>
-<span class="n">g4</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">&#39;mech4.inp&#39;</span><span class="p">,</span> <span class="s1">&#39;therm.dat&#39;</span><span class="p">,</span> <span class="s1">&#39;tran.dat&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">g1a</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">'mech.xml'</span><span class="p">)</span>
+<span class="n">g1b</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">'mech.xml'</span><span class="p">,</span> <span class="s1">'Multi'</span><span class="p">)</span>
+<span class="n">g2</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">'mech2.inp'</span><span class="p">)</span>
+<span class="n">g3</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">'mech3.inp'</span><span class="p">,</span> <span class="s1">'therm.dat'</span><span class="p">)</span>
+<span class="n">g4</span> <span class="o">=</span> <span class="n">IdealGasMix</span><span class="p">(</span><span class="s1">'mech4.inp'</span><span class="p">,</span> <span class="s1">'therm.dat'</span><span class="p">,</span> <span class="s1">'tran.dat'</span><span class="p">)</span>
 </pre></div>
 </div>
 <p>Objects <code class="docutils literal notranslate"><span class="pre">g1a</span></code> and <code class="docutils literal notranslate"><span class="pre">g1b</span></code> are created from a CTML file. CTML files
 contain all data required to build the object, and do not require
 any additional database files. Objects <code class="docutils literal notranslate"><span class="pre">g2</span></code> - <code class="docutils literal notranslate"><span class="pre">g4</span></code> are created
-from CK-format input files. For <code class="docutils literal notranslate"><span class="pre">g2</span></code>, ‘mech2.inp’ contains all required
-species thermo data. File ‘mech3.inp’ is missing some or all
-species thermo data, and requires database file ‘therm.dat.’
+from CK-format input files. For <code class="docutils literal notranslate"><span class="pre">g2</span></code>, &#8216;mech2.inp&#8217; contains all required
+species thermo data. File &#8216;mech3.inp&#8217; is missing some or all
+species thermo data, and requires database file &#8216;therm.dat.&#8217;
 Object <code class="docutils literal notranslate"><span class="pre">g4</span></code> is created including transport data.</p>
 <p>Note that calling <a class="reference internal" href="#Solution.IdealGasMix" title="Solution.IdealGasMix"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">IdealGasMix()</span></code></a> with a CK-format input file
 also creates an equivalent CTML file that may be used in future
@@ -223,16 +219,16 @@ calls. If the initial call includes a transport database, then
 the CTML file will contain transport data.</p>
 <p>See also: <a class="reference internal" href="utilities.html#ck2cti" title="ck2cti"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ck2cti()</span></code></a>, <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>infile</strong> – Input file, either CTI, CTML, or CHEMKIN format</li>
-<li><strong>b</strong> – If a CTI or CTML file is specified with <code class="docutils literal notranslate"><span class="pre">infile</span></code>, this can be
+<li><strong>infile</strong> &#8211; Input file, either CTI, CTML, or CHEMKIN format</li>
+<li><strong>b</strong> &#8211; If a CTI or CTML file is specified with <code class="docutils literal notranslate"><span class="pre">infile</span></code>, this can be
 the transport modeling to be used. If a CHEMKIN format file is
 specified with <code class="docutils literal notranslate"><span class="pre">infile</span></code>, this is the filename of the
 thermodynamic database, if required.</li>
-<li><strong>c</strong> – If a CHEMKIN format file is specified with <code class="docutils literal notranslate"><span class="pre">infile</span></code>, this is the
+<li><strong>c</strong> &#8211; If a CHEMKIN format file is specified with <code class="docutils literal notranslate"><span class="pre">infile</span></code>, this is the
 filename of the transport database, if required.</li>
 </ul>
 </td>
@@ -248,21 +244,21 @@ filename of the transport database, if required.</li>
 
 </div>
 <div class="section" id="mixture">
-<h2>Mixture<a class="headerlink" href="#mixture" title="Permalink to this headline">¶</a></h2>
+<h2>Mixture<a class="headerlink" href="#mixture" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="Mixture">
-<em class="property">class </em><code class="descname">Mixture</code><span class="sig-paren">(</span><em>phases</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">Mixture</code><span class="sig-paren">(</span><em>phases</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Multiphase mixture class constructor.</p>
 <p>Class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a> represents mixtures of one or more phases of matter.
 To construct a mixture, supply a cell array of phases and
 mole numbers:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;gas.cti&#39;</span><span class="p">);</span>
-<span class="o">&gt;&gt;</span> <span class="n">graphite</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;graphite.cti&#39;</span><span class="p">);</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">gas</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">'gas.cti'</span><span class="p">);</span>
+<span class="o">&gt;&gt;</span> <span class="n">graphite</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">'graphite.cti'</span><span class="p">);</span>
 <span class="o">&gt;&gt;</span> <span class="n">mix</span> <span class="o">=</span> <span class="n">Mixture</span><span class="p">({</span><span class="n">gas</span><span class="p">,</span> <span class="mf">1.0</span><span class="p">;</span> <span class="n">graphite</span><span class="p">,</span> <span class="mf">0.1</span><span class="p">});</span>
 </pre></div>
 </div>
 <p>Phases may also be added later using the addPhase method:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">water</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">&#39;water.cti&#39;</span><span class="p">);</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">water</span> <span class="o">=</span> <span class="n">Solution</span><span class="p">(</span><span class="s1">'water.cti'</span><span class="p">);</span>
 <span class="o">&gt;&gt;</span> <span class="n">addPhase</span><span class="p">(</span><span class="n">mix</span><span class="p">,</span> <span class="n">water</span><span class="p">,</span> <span class="mf">3.0</span><span class="p">);</span>
 </pre></div>
 </div>
@@ -270,18 +266,18 @@ mole numbers:</p>
 intensive state of the phase - they do not store any information
 on the amount of this phase. Mixture objects, on the other hand,
 represent the full extensive state.</p>
-<p>Mixture objects are ‘lightweight’ in the sense that they do not
+<p>Mixture objects are &#8216;lightweight&#8217; in the sense that they do not
 store parameters needed to compute thermodynamic or kinetic
 properties of the phases. These are contained in the
-(‘heavyweight’) phase objects. Multiple mixture objects may be
+(&#8216;heavyweight&#8217;) phase objects. Multiple mixture objects may be
 constructed using the same set of phase objects. Each one stores
 its own state information locally, and synchronizes the phase
 objects whenever it requires phase properties.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>phases</strong> – Cell array of phases and mole numbers</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>phases</strong> &#8211; Cell array of phases and mole numbers</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
 </tr>
@@ -289,17 +285,17 @@ objects whenever it requires phase properties.</p>
 </table>
 <dl class="function">
 <dt id="Mixture.addPhase">
-<code class="descname">addPhase</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em>, <em>moles</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.addPhase" title="Permalink to this definition">¶</a></dt>
+<code class="descname">addPhase</code><span class="sig-paren">(</span><em>self</em>, <em>phase</em>, <em>moles</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.addPhase" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Add a phase to a mixture.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a> to which phases should be
+<li><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a> to which phases should be
 added</li>
-<li><strong>phase</strong> – Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> which should be added</li>
-<li><strong>moles</strong> – Number of moles of the <code class="docutils literal notranslate"><span class="pre">phase</span></code> to be added to this mixture.
+<li><strong>phase</strong> &#8211; Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> which should be added</li>
+<li><strong>moles</strong> &#8211; Number of moles of the <code class="docutils literal notranslate"><span class="pre">phase</span></code> to be added to this mixture.
 Units: kmol</li>
 </ul>
 </td>
@@ -310,13 +306,13 @@ Units: kmol</li>
 
 <dl class="function">
 <dt id="Mixture.chemPotentials">
-<code class="descname">chemPotentials</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.chemPotentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">chemPotentials</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.chemPotentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the chemical potentials of species in a mixture.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of chemical potentials. Units: J/kmol</td>
 </tr>
@@ -326,15 +322,15 @@ Units: kmol</li>
 
 <dl class="function">
 <dt id="Mixture.elementIndex">
-<code class="descname">elementIndex</code><span class="sig-paren">(</span><em>self</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.elementIndex" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elementIndex</code><span class="sig-paren">(</span><em>self</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.elementIndex" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the index of an element.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
-<li><strong>name</strong> – Name of the element whose index is desired</li>
+<li><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
+<li><strong>name</strong> &#8211; Name of the element whose index is desired</li>
 </ul>
 </td>
 </tr>
@@ -347,43 +343,43 @@ Units: kmol</li>
 
 <dl class="function">
 <dt id="Mixture.equilibrate">
-<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>self</em>, <em>XY</em>, <em>err</em>, <em>maxsteps</em>, <em>maxiter</em>, <em>loglevel</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.equilibrate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>self</em>, <em>XY</em>, <em>err</em>, <em>maxsteps</em>, <em>maxiter</em>, <em>loglevel</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.equilibrate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mixture to a state of chemical equilibrium.</p>
 <p>This method uses a version of the VCS algorithm to find the
 composition that minimizes the total Gibbs free energy of the
 mixture, subject to element conservation constraints. For a
-description of the theory, see Smith and Missen, “Chemical
-Reaction Equilibrium.”  The VCS algorithm is implemented in
+description of the theory, see Smith and Missen, &#8220;Chemical
+Reaction Equilibrium.&#8221;  The VCS algorithm is implemented in
 Cantera kernel class MultiPhaseEquil.</p>
 <p>The VCS algorithm solves for the equilibrium composition for
 specified temperature and pressure. If any other property pair
-other than “TP” is specified, then an outer iteration loop is
+other than &#8220;TP&#8221; is specified, then an outer iteration loop is
 used to adjust T and/or P so that the specified property
 values are obtained.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">equilibrate</span><span class="p">(</span><span class="n">mix</span><span class="p">,</span> <span class="s1">&#39;TP&#39;</span><span class="p">)</span>
-<span class="o">&gt;&gt;</span> <span class="n">equilibrate</span><span class="p">(</span><span class="s1">&#39;TP&#39;</span><span class="p">,</span> <span class="mf">1.0e-6</span><span class="p">,</span> <span class="mi">500</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">equilibrate</span><span class="p">(</span><span class="n">mix</span><span class="p">,</span> <span class="s1">'TP'</span><span class="p">)</span>
+<span class="o">&gt;&gt;</span> <span class="n">equilibrate</span><span class="p">(</span><span class="s1">'TP'</span><span class="p">,</span> <span class="mf">1.0e-6</span><span class="p">,</span> <span class="mi">500</span><span class="p">)</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
-<li><strong>XY</strong> – Two-letter string specifying the two properties to hold
+<li><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
+<li><strong>XY</strong> &#8211; Two-letter string specifying the two properties to hold
 fixed.  Currently, <code class="docutils literal notranslate"><span class="pre">'TP'</span></code>, <code class="docutils literal notranslate"><span class="pre">'HP'</span></code>, <code class="docutils literal notranslate"><span class="pre">'TV'</span></code>, and <code class="docutils literal notranslate"><span class="pre">'SP'</span></code> are
 implemented. Default: <code class="docutils literal notranslate"><span class="pre">'TP'</span></code>.</li>
-<li><strong>err</strong> – Error tolerance. Iteration will continue until <span class="math">\(\Delta\mu)/RT\)</span>
+<li><strong>err</strong> &#8211; Error tolerance. Iteration will continue until <span class="math">\(\Delta\mu)/RT\)</span>
 is less than this value for each reaction. Default:
 1.0e-9. Note that this default is very conservative, and good
 equilibrium solutions may be obtained with larger error
 tolerances.</li>
-<li><strong>maxsteps</strong> – Maximum number of steps to take while solving the
+<li><strong>maxsteps</strong> &#8211; Maximum number of steps to take while solving the
 equilibrium problem for specified T and P. Default: 1000.</li>
-<li><strong>maxiter</strong> – Maximum number of temperature and/or pressure
+<li><strong>maxiter</strong> &#8211; Maximum number of temperature and/or pressure
 iterations.  This is only relevant if a property pair other
 than (T,P) is specified. Default: 200.</li>
-<li><strong>loglevel</strong> – Set to a value &gt; 0 to write diagnostic output.
+<li><strong>loglevel</strong> &#8211; Set to a value &gt; 0 to write diagnostic output.
 Larger values generate more detailed information.</li>
 </ul>
 </td>
@@ -397,13 +393,13 @@ Larger values generate more detailed information.</li>
 
 <dl class="function">
 <dt id="Mixture.nElements">
-<code class="descname">nElements</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.nElements" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nElements</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.nElements" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the number of elements in a mixture.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Number of elements in the input</td>
 </tr>
@@ -413,13 +409,13 @@ Larger values generate more detailed information.</li>
 
 <dl class="function">
 <dt id="Mixture.nPhases">
-<code class="descname">nPhases</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.nPhases" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nPhases</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.nPhases" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the number of phases in a mixture.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Number of phases in the input</td>
 </tr>
@@ -429,13 +425,13 @@ Larger values generate more detailed information.</li>
 
 <dl class="function">
 <dt id="Mixture.nSpecies">
-<code class="descname">nSpecies</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.nSpecies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nSpecies</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.nSpecies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the number of species in a mixture.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Number of species in the input</td>
 </tr>
@@ -445,15 +441,15 @@ Larger values generate more detailed information.</li>
 
 <dl class="function">
 <dt id="Mixture.phaseMoles">
-<code class="descname">phaseMoles</code><span class="sig-paren">(</span><em>self</em>, <em>n</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.phaseMoles" title="Permalink to this definition">¶</a></dt>
+<code class="descname">phaseMoles</code><span class="sig-paren">(</span><em>self</em>, <em>n</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.phaseMoles" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the number of moles of a phase in a mixture.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
-<li><strong>n</strong> – Integer phase number in the input</li>
+<li><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
+<li><strong>n</strong> &#8211; Integer phase number in the input</li>
 </ul>
 </td>
 </tr>
@@ -466,13 +462,13 @@ Larger values generate more detailed information.</li>
 
 <dl class="function">
 <dt id="Mixture.pressure">
-<code class="descname">pressure</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.pressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">pressure</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.pressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the pressure of the mixture.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Pressure. Units: Pa</td>
 </tr>
@@ -482,16 +478,16 @@ Larger values generate more detailed information.</li>
 
 <dl class="function">
 <dt id="Mixture.setPhaseMoles">
-<code class="descname">setPhaseMoles</code><span class="sig-paren">(</span><em>self</em>, <em>n</em>, <em>moles</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.setPhaseMoles" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setPhaseMoles</code><span class="sig-paren">(</span><em>self</em>, <em>n</em>, <em>moles</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.setPhaseMoles" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the number of moles of a phase in a mixture.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
-<li><strong>n</strong> – Phase number in the input</li>
-<li><strong>moles</strong> – Number of moles to add. Units: kmol</li>
+<li><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
+<li><strong>n</strong> &#8211; Phase number in the input</li>
+<li><strong>moles</strong> &#8211; Number of moles to add. Units: kmol</li>
 </ul>
 </td>
 </tr>
@@ -501,15 +497,15 @@ Larger values generate more detailed information.</li>
 
 <dl class="function">
 <dt id="Mixture.setPressure">
-<code class="descname">setPressure</code><span class="sig-paren">(</span><em>self</em>, <em>P</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.setPressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setPressure</code><span class="sig-paren">(</span><em>self</em>, <em>P</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.setPressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the pressure of the mixture.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
-<li><strong>P</strong> – Pressure. Units: Pa</li>
+<li><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
+<li><strong>P</strong> &#8211; Pressure. Units: Pa</li>
 </ul>
 </td>
 </tr>
@@ -519,23 +515,23 @@ Larger values generate more detailed information.</li>
 
 <dl class="function">
 <dt id="Mixture.setSpeciesMoles">
-<code class="descname">setSpeciesMoles</code><span class="sig-paren">(</span><em>self</em>, <em>moles</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.setSpeciesMoles" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setSpeciesMoles</code><span class="sig-paren">(</span><em>self</em>, <em>moles</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.setSpeciesMoles" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the moles of the species.</p>
 <p>Set the moles of the species in kmol. The moles may
 be specified either as a string, or as an vector. If a vector is
 used, it must be dimensioned at least as large as the total number
 of species in the mixture. Note that the species may belong to any
 phase, and unspecified species are set to zero.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">setSpeciesMoles</span><span class="p">(</span><span class="n">mix</span><span class="p">,</span> <span class="s1">&#39;C(s):1.0, CH4:2.0, O2:0.2&#39;</span><span class="p">);</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">setSpeciesMoles</span><span class="p">(</span><span class="n">mix</span><span class="p">,</span> <span class="s1">'C(s):1.0, CH4:2.0, O2:0.2'</span><span class="p">);</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
-<li><strong>moles</strong> – Vector or string specifying the moles of species</li>
+<li><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
+<li><strong>moles</strong> &#8211; Vector or string specifying the moles of species</li>
 </ul>
 </td>
 </tr>
@@ -545,15 +541,15 @@ phase, and unspecified species are set to zero.</p>
 
 <dl class="function">
 <dt id="Mixture.setTemperature">
-<code class="descname">setTemperature</code><span class="sig-paren">(</span><em>self</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.setTemperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setTemperature</code><span class="sig-paren">(</span><em>self</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.setTemperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mixture temperature.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
-<li><strong>T</strong> – Temperature. Units: K</li>
+<li><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
+<li><strong>T</strong> &#8211; Temperature. Units: K</li>
 </ul>
 </td>
 </tr>
@@ -563,15 +559,15 @@ phase, and unspecified species are set to zero.</p>
 
 <dl class="function">
 <dt id="Mixture.speciesIndex">
-<code class="descname">speciesIndex</code><span class="sig-paren">(</span><em>self</em>, <em>k</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.speciesIndex" title="Permalink to this definition">¶</a></dt>
+<code class="descname">speciesIndex</code><span class="sig-paren">(</span><em>self</em>, <em>k</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.speciesIndex" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the index of a species in a mixture.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
-<li><strong>name</strong> – Name of the speces whose index is desired</li>
+<li><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></li>
+<li><strong>name</strong> &#8211; Name of the speces whose index is desired</li>
 </ul>
 </td>
 </tr>
@@ -584,13 +580,13 @@ phase, and unspecified species are set to zero.</p>
 
 <dl class="function">
 <dt id="Mixture.temperature">
-<code class="descname">temperature</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.temperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">temperature</code><span class="sig-paren">(</span><em>self</em><span class="sig-paren">)</span><a class="headerlink" href="#Mixture.temperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the temperature of a mixture.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> – Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>self</strong> &#8211; Instance of class <a class="reference internal" href="#Mixture" title="Mixture"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Mixture()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Temperature (K)</td>
 </tr>
@@ -602,24 +598,24 @@ phase, and unspecified species are set to zero.</p>
 
 </div>
 <div class="section" id="interface">
-<h2>Interface<a class="headerlink" href="#interface" title="Permalink to this headline">¶</a></h2>
+<h2>Interface<a class="headerlink" href="#interface" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="Interface">
-<em class="property">class </em><code class="descname">Interface</code><span class="sig-paren">(</span><em>src</em>, <em>id</em>, <em>p1</em>, <em>p2</em>, <em>p3</em>, <em>p4</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">Interface</code><span class="sig-paren">(</span><em>src</em>, <em>id</em>, <em>p1</em>, <em>p2</em>, <em>p3</em>, <em>p4</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Interface class constructor.</p>
 <p>See <a class="reference external" href="https://cantera.org/tutorials/cti/phases.html#interfaces">Interfaces</a>.</p>
 <p>See also: <a class="reference internal" href="#Interface.importEdge" title="Interface.importEdge"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">importEdge()</span></code></a>, <a class="reference internal" href="#Interface.importInterface" title="Interface.importInterface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">importInterface()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>src</strong> – CTI or CTML file containing the interface or edge phase.</li>
-<li><strong>id</strong> – Name of the interface or edge phase in the CTI or CTML file.</li>
-<li><strong>p1</strong> – Adjoining phase to the interface.</li>
-<li><strong>p2</strong> – Adjoining phase to the interface.</li>
-<li><strong>p3</strong> – Adjoining phase to the interface.</li>
-<li><strong>p4</strong> – Adjoining phase to the interface.</li>
+<li><strong>src</strong> &#8211; CTI or CTML file containing the interface or edge phase.</li>
+<li><strong>id</strong> &#8211; Name of the interface or edge phase in the CTI or CTML file.</li>
+<li><strong>p1</strong> &#8211; Adjoining phase to the interface.</li>
+<li><strong>p2</strong> &#8211; Adjoining phase to the interface.</li>
+<li><strong>p3</strong> &#8211; Adjoining phase to the interface.</li>
+<li><strong>p4</strong> &#8211; Adjoining phase to the interface.</li>
 </ul>
 </td>
 </tr>
@@ -630,13 +626,13 @@ phase, and unspecified species are set to zero.</p>
 </table>
 <dl class="function">
 <dt id="Interface.concentrations">
-<code class="descname">concentrations</code><span class="sig-paren">(</span><em>s</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface.concentrations" title="Permalink to this definition">¶</a></dt>
+<code class="descname">concentrations</code><span class="sig-paren">(</span><em>s</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface.concentrations" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the concentrations of the species on an interface.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>s</strong> – Instance of class <a class="reference internal" href="#Interface" title="Interface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Interface()</span></code></a> with surface species</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Interface" title="Interface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Interface()</span></code></a> with surface species</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">If no output value is assigned, a bar graph will be plotted.
 Otherwise, a vector of length <code class="docutils literal notranslate"><span class="pre">n_surf_species</span></code> will be
@@ -648,13 +644,13 @@ returned.</td>
 
 <dl class="function">
 <dt id="Interface.coverages">
-<code class="descname">coverages</code><span class="sig-paren">(</span><em>s</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface.coverages" title="Permalink to this definition">¶</a></dt>
+<code class="descname">coverages</code><span class="sig-paren">(</span><em>s</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface.coverages" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the surface coverages of the species on an interface.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>s</strong> – Instance of class <a class="reference internal" href="#Interface" title="Interface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Interface()</span></code></a> with surface species</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Interface" title="Interface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Interface()</span></code></a> with surface species</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">If no output value is assigned, a bar graph will be plotted.
 Otherwise, a vector of length <code class="docutils literal notranslate"><span class="pre">n_surf_species</span></code> will be
@@ -666,21 +662,21 @@ returned.</td>
 
 <dl class="function">
 <dt id="Interface.importEdge">
-<code class="descname">importEdge</code><span class="sig-paren">(</span><em>file</em>, <em>name</em>, <em>phase1</em>, <em>phase2</em>, <em>phase3</em>, <em>phase4</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface.importEdge" title="Permalink to this definition">¶</a></dt>
+<code class="descname">importEdge</code><span class="sig-paren">(</span><em>file</em>, <em>name</em>, <em>phase1</em>, <em>phase2</em>, <em>phase3</em>, <em>phase4</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface.importEdge" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Import edges between phases.</p>
 <p>Supports up to four neighbor phases. See
 <a class="reference external" href="https://cantera.org/tutorials/cti/phases.html#interfaces">Interfaces</a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>file</strong> – File containing phases</li>
-<li><strong>name</strong> – Name of phase</li>
-<li><strong>phase1</strong> – First neighbor phase</li>
-<li><strong>phase2</strong> – Second neighbor phase</li>
-<li><strong>phase3</strong> – Third neighbor phase</li>
-<li><strong>phase4</strong> – Fourth neighbor phase</li>
+<li><strong>file</strong> &#8211; File containing phases</li>
+<li><strong>name</strong> &#8211; Name of phase</li>
+<li><strong>phase1</strong> &#8211; First neighbor phase</li>
+<li><strong>phase2</strong> &#8211; Second neighbor phase</li>
+<li><strong>phase3</strong> &#8211; Third neighbor phase</li>
+<li><strong>phase4</strong> &#8211; Fourth neighbor phase</li>
 </ul>
 </td>
 </tr>
@@ -693,18 +689,18 @@ returned.</td>
 
 <dl class="function">
 <dt id="Interface.importInterface">
-<code class="descname">importInterface</code><span class="sig-paren">(</span><em>file</em>, <em>name</em>, <em>phase1</em>, <em>phase2</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface.importInterface" title="Permalink to this definition">¶</a></dt>
+<code class="descname">importInterface</code><span class="sig-paren">(</span><em>file</em>, <em>name</em>, <em>phase1</em>, <em>phase2</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface.importInterface" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Import an interface between phases.</p>
 <p>See <a class="reference external" href="https://cantera.org/tutorials/cti/phases.html#interfaces">Interfaces</a>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>file</strong> – CTI or CTML file containing the interface</li>
-<li><strong>name</strong> – Name of the interface to import</li>
-<li><strong>phase1</strong> – First phase in the interface</li>
-<li><strong>phase2</strong> – Second phase in the interface</li>
+<li><strong>file</strong> &#8211; CTI or CTML file containing the interface</li>
+<li><strong>name</strong> &#8211; Name of the interface to import</li>
+<li><strong>phase1</strong> &#8211; First phase in the interface</li>
+<li><strong>phase2</strong> &#8211; Second phase in the interface</li>
 </ul>
 </td>
 </tr>
@@ -717,18 +713,18 @@ returned.</td>
 
 <dl class="function">
 <dt id="Interface.setCoverages">
-<code class="descname">setCoverages</code><span class="sig-paren">(</span><em>s</em>, <em>cov</em>, <em>norm</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface.setCoverages" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setCoverages</code><span class="sig-paren">(</span><em>s</em>, <em>cov</em>, <em>norm</em><span class="sig-paren">)</span><a class="headerlink" href="#Interface.setCoverages" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set surface coverages of the species on an interface.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Interface" title="Interface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Interface()</span></code></a></li>
-<li><strong>cov</strong> – Coverage of the species. <code class="docutils literal notranslate"><span class="pre">cov</span></code> can be either a vector of
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Interface" title="Interface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Interface()</span></code></a></li>
+<li><strong>cov</strong> &#8211; Coverage of the species. <code class="docutils literal notranslate"><span class="pre">cov</span></code> can be either a vector of
 length <code class="docutils literal notranslate"><span class="pre">n_surf_species</span></code>, or a string in the format
 <code class="docutils literal notranslate"><span class="pre">'Species:Coverage,</span> <span class="pre">Species:Coverage'</span></code></li>
-<li><strong>norm</strong> – Optional flag that denotes whether or not to normalize the species
+<li><strong>norm</strong> &#8211; Optional flag that denotes whether or not to normalize the species
 coverages. <code class="docutils literal notranslate"><span class="pre">norm</span></code> is either of the two strings <code class="docutils literal notranslate"><span class="pre">'nonorm'`</span></code> or
 <code class="docutils literal notranslate"><span class="pre">'norm'</span></code>. If left unset, the default is <code class="xref py py-obj docutils literal notranslate"><span class="pre">norm</span></code>. This only works if
 <code class="docutils literal notranslate"><span class="pre">s</span></code> is a vector, not a string. Since unnormalized coverages can lead to
@@ -745,11 +741,11 @@ as computing partial derivatives with respect to a species coverage.</li>
 
 </div>
 <div class="section" id="pure-fluid-phases">
-<h2>Pure Fluid Phases<a class="headerlink" href="#pure-fluid-phases" title="Permalink to this headline">¶</a></h2>
+<h2>Pure Fluid Phases<a class="headerlink" href="#pure-fluid-phases" title="Permalink to this headline">&#182;</a></h2>
 <blockquote>
 <div><dl class="function">
 <dt id="CarbonDioxide">
-<code class="descname">CarbonDioxide</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#CarbonDioxide" title="Permalink to this definition">¶</a></dt>
+<code class="descname">CarbonDioxide</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#CarbonDioxide" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return an object representing carbon dioxide.</p>
 <p>The object returned by this method implements an accurate equation of
 state for carbon dioxide that can be used in the liquid, vapor, saturated
@@ -761,8 +757,8 @@ University, 1979. Print.</p>
 <p>For more details, see classes Cantera::PureFluid and tpx::CarbonDioxide in the
 Cantera C++ source code documentation.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></td>
 </tr>
@@ -772,22 +768,22 @@ Cantera C++ source code documentation.</p>
 
 <dl class="function">
 <dt id="HFC134a">
-<code class="descname">HFC134a</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#HFC134a" title="Permalink to this definition">¶</a></dt>
+<code class="descname">HFC134a</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#HFC134a" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return an object representing refrigerant HFC134a.</p>
 <p>The object returned by this method implements an accurate equation of
 state for refrigerant HFC134a (R134a)  that can be used in the liquid,
 vapor, saturated liquid/vapor, and supercritical regions of the phase
 diagram. Implements the equation of state given in:
-R. Tillner-Roth and H.D. Baehr. “An International Standard Formulation for
+R. Tillner-Roth and H.D. Baehr. &#8220;An International Standard Formulation for
 The Thermodynamic Properties of 1,1,1,2-Tetrafluoroethane (HFC-134a) for
-Temperatures From 170 K to 455 K and Pressures up to 70 MPa”. J. Phys.
-Chem. Ref. Data, Vol. 23, No. 5, 1994. pp. 657–729.
+Temperatures From 170 K to 455 K and Pressures up to 70 MPa&#8221;. J. Phys.
+Chem. Ref. Data, Vol. 23, No. 5, 1994. pp. 657&#8211;729.
 <a class="reference external" href="http://dx.doi.org/10.1063/1.555958">http://dx.doi.org/10.1063/1.555958</a></p>
 <p>For more details, see classes Cantera::PureFluid and tpx::HFC134a in the
 Cantera C++ source code documentation.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></td>
 </tr>
@@ -797,7 +793,7 @@ Cantera C++ source code documentation.</p>
 
 <dl class="function">
 <dt id="Hydrogen">
-<code class="descname">Hydrogen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Hydrogen" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Hydrogen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Hydrogen" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return an object representing hydrogen.</p>
 <p>The object returned by this method implements an accurate equation of
 state for hydrogen that can be used in the liquid, vapor, saturated
@@ -809,8 +805,8 @@ University, 1979. Print.</p>
 <p>For more details, see classes Cantera::PureFluid and tpx::hydrogen in the
 Cantera C++ source code documentation.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></td>
 </tr>
@@ -820,7 +816,7 @@ Cantera C++ source code documentation.</p>
 
 <dl class="function">
 <dt id="Methane">
-<code class="descname">Methane</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Methane" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Methane</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Methane" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return an object representing methane.</p>
 <p>The object returned by this method implements an accurate equation of
 state for methane that can be used in the liquid, vapor, saturated
@@ -830,8 +826,8 @@ equation of state is taken from</p>
 computational equations for forty substances</em> Stanford: Stanford
 University, 1979. Print.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></td>
 </tr>
@@ -841,7 +837,7 @@ University, 1979. Print.</p>
 
 <dl class="function">
 <dt id="Nitrogen">
-<code class="descname">Nitrogen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Nitrogen" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Nitrogen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Nitrogen" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return an object representing nitrogen.</p>
 <p>The object returned by this method implements an accurate equation of
 state for nitrogen that can be used in the liquid, vapor, saturated
@@ -851,8 +847,8 @@ equation of state is taken from</p>
 computational equations for forty substances</em> Stanford: Stanford
 University, 1979. Print.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></td>
 </tr>
@@ -862,7 +858,7 @@ University, 1979. Print.</p>
 
 <dl class="function">
 <dt id="Oxygen">
-<code class="descname">Oxygen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Oxygen" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Oxygen</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Oxygen" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return an object representing oxygen.</p>
 <p>The object returned by this method implements an accurate equation of
 state for oxygen that can be used in the liquid, vapor, saturated
@@ -872,8 +868,8 @@ equation of state is taken from</p>
 computational equations for forty substances</em> Stanford: Stanford
 University, 1979. Print.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></td>
 </tr>
@@ -883,7 +879,7 @@ University, 1979. Print.</p>
 
 <dl class="function">
 <dt id="Water">
-<code class="descname">Water</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Water" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Water</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#Water" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Return an object representing water.</p>
 <p>The object returned by this method implements an accurate equation of
 state for water that can be used in the liquid, vapor, saturated
@@ -895,8 +891,8 @@ University, 1979. Print.</p>
 <p>For more details, see classes Cantera::PureFluid and tpx::water in the
 Cantera C++ source code documentation.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></td>
 </tr>
@@ -929,8 +925,8 @@ Cantera C++ source code documentation.</p>
 <h3>Related Topics</h3>
 <ul>
   <li><a href="../index.html">Documentation overview</a><ul>
-  <li><a href="index.html">Matlab Interface User’s Guide</a><ul>
-      <li>Previous: <a href="index.html" title="previous chapter">Matlab Interface User’s Guide</a></li>
+  <li><a href="index.html">Matlab Interface User&#8217;s Guide</a><ul>
+      <li>Previous: <a href="index.html" title="previous chapter">Matlab Interface User&#8217;s Guide</a></li>
       <li>Next: <a href="thermodynamics.html" title="next chapter">Thermodynamic Properties</a></li>
   </ul></li>
   </ul></li>
@@ -939,25 +935,24 @@ Cantera C++ source code documentation.</p>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/matlab/importing.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/matlab/importing.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -966,15 +961,14 @@ Cantera C++ source code documentation.</p>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/matlab/importing.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/matlab/importing.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/matlab/importing.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/importing.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/matlab/index.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/index.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Matlab Interface User’s Guide | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+    <title>Matlab Interface User&#8217;s Guide | Cantera </title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,7 +77,7 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="matlab-interface-user-s-guide">
-<h1>Matlab Interface User’s Guide<a class="headerlink" href="#matlab-interface-user-s-guide" title="Permalink to this headline">¶</a></h1>
+<h1>Matlab Interface User&#8217;s Guide<a class="headerlink" href="#matlab-interface-user-s-guide" title="Permalink to this headline">&#182;</a></h1>
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="importing.html">Objects Representing Phases</a><ul>
@@ -147,25 +143,24 @@ lang="en">
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/matlab/index.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/matlab/index.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -174,15 +169,14 @@ lang="en">
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/matlab/index.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/matlab/index.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/matlab/index.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/index.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/matlab/kinetics.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/kinetics.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Chemical Kinetics | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,12 +77,12 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="chemical-kinetics">
-<h1>Chemical Kinetics<a class="headerlink" href="#chemical-kinetics" title="Permalink to this headline">¶</a></h1>
+<h1>Chemical Kinetics<a class="headerlink" href="#chemical-kinetics" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="kinetics">
-<h2>Kinetics<a class="headerlink" href="#kinetics" title="Permalink to this headline">¶</a></h2>
+<h2>Kinetics<a class="headerlink" href="#kinetics" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="Kinetics">
-<em class="property">class </em><code class="descname">Kinetics</code><span class="sig-paren">(</span><em>r</em>, <em>ph</em>, <em>neighbor1</em>, <em>neighbor2</em>, <em>neighbor3</em>, <em>neighbor4</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">Kinetics</code><span class="sig-paren">(</span><em>r</em>, <em>ph</em>, <em>neighbor1</em>, <em>neighbor2</em>, <em>neighbor3</em>, <em>neighbor4</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Kinetics class constructor.</p>
 <p>Class Kinetics represents kinetics managers, which are classes
 that manage reaction mechanisms.  The reaction mechanism
@@ -95,22 +91,22 @@ Instances of class <a class="reference internal" href="#Kinetics" title="Kinetic
 of progress, species production rates, and other quantities pertaining to
 a reaction mechanism.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>r</strong> – If <code class="docutils literal notranslate"><span class="pre">r</span></code> is an instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a>, a copy of the instance
+<li><strong>r</strong> &#8211; If <code class="docutils literal notranslate"><span class="pre">r</span></code> is an instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a>, a copy of the instance
 is returned. In this case, <code class="docutils literal notranslate"><span class="pre">r</span></code> should be the only argument. Otherwise, <code class="docutils literal notranslate"><span class="pre">r</span></code>
 must be an instance of class <a class="reference internal" href="utilities.html#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a>.</li>
-<li><strong>ph</strong> – If <code class="docutils literal notranslate"><span class="pre">r</span></code> is an instance of <a class="reference internal" href="utilities.html#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a>, <code class="docutils literal notranslate"><span class="pre">ph</span></code> is an instance of class
+<li><strong>ph</strong> &#8211; If <code class="docutils literal notranslate"><span class="pre">r</span></code> is an instance of <a class="reference internal" href="utilities.html#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a>, <code class="docutils literal notranslate"><span class="pre">ph</span></code> is an instance of class
 <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a>. Otherwise, optional.</li>
-<li><strong>neighbor1</strong> – Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> or <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> representing a
+<li><strong>neighbor1</strong> &#8211; Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> or <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> representing a
 neighboring phase.</li>
-<li><strong>neighbor2</strong> – Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> or <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> representing a
+<li><strong>neighbor2</strong> &#8211; Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> or <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> representing a
 neighboring phase.</li>
-<li><strong>neighbor3</strong> – Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> or <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> representing a
+<li><strong>neighbor3</strong> &#8211; Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> or <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> representing a
 neighboring phase.</li>
-<li><strong>neighbor4</strong> – Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> or <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> representing a
+<li><strong>neighbor4</strong> &#8211; Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> or <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> representing a
 neighboring phase.</li>
 </ul>
 </td>
@@ -122,17 +118,17 @@ neighboring phase.</li>
 </table>
 <dl class="function">
 <dt id="Kinetics.advanceCoverages">
-<code class="descname">advanceCoverages</code><span class="sig-paren">(</span><em>k</em>, <em>dt</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.advanceCoverages" title="Permalink to this definition">¶</a></dt>
+<code class="descname">advanceCoverages</code><span class="sig-paren">(</span><em>k</em>, <em>dt</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.advanceCoverages" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Advance the surface coverages forward in time.</p>
 <p>The bulk phase concentrations are held fixed during this operation.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>k</strong> – Instance of class <a class="reference internal" href="importing.html#Interface" title="Interface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Interface()</span></code></a> with an associated
+<li><strong>k</strong> &#8211; Instance of class <a class="reference internal" href="importing.html#Interface" title="Interface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Interface()</span></code></a> with an associated
 <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> object.</li>
-<li><strong>dt</strong> – Time interval by which the coverages should be advanced</li>
+<li><strong>dt</strong> &#8211; Time interval by which the coverages should be advanced</li>
 </ul>
 </td>
 </tr>
@@ -142,14 +138,14 @@ neighboring phase.</li>
 
 <dl class="function">
 <dt id="Kinetics.creationRates">
-<code class="descname">creationRates</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.creationRates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">creationRates</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.creationRates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the chemical creation rates.</p>
 <p>See also: <a class="reference internal" href="#Kinetics.destructionRates" title="Kinetics.destructionRates"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">destructionRates()</span></code></a>, <a class="reference internal" href="#Kinetics.netProdRates" title="Kinetics.netProdRates"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">netProdRates()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which creation rates are desired.</td>
 </tr>
@@ -163,14 +159,14 @@ bar graph is produced. Units: kmol/m**3-s</td>
 
 <dl class="function">
 <dt id="Kinetics.destructionRates">
-<code class="descname">destructionRates</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.destructionRates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">destructionRates</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.destructionRates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the chemical destruction rates.</p>
 <p>See also: <a class="reference internal" href="#Kinetics.creationRates" title="Kinetics.creationRates"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">creationRates()</span></code></a>, <a class="reference internal" href="#Kinetics.netProdRates" title="Kinetics.netProdRates"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">netProdRates()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which destruction rates are desired.</td>
 </tr>
@@ -184,14 +180,14 @@ bar graph is produced. Units: kmol/m**3-s</td>
 
 <dl class="function">
 <dt id="Kinetics.equil_Kc">
-<code class="descname">equil_Kc</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.equil_Kc" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equil_Kc</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.equil_Kc" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the equilibrium constants for all reactions</p>
 <p>See also: <a class="reference internal" href="#Kinetics.fwdRateConstants" title="Kinetics.fwdRateConstants"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">fwdRateConstants()</span></code></a>, <a class="reference internal" href="#Kinetics.revRateConstants" title="Kinetics.revRateConstants"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">revRateConstants()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which equilibrium constants are desired.</td>
 </tr>
@@ -207,17 +203,17 @@ not assigned to a variable, a bar graph is produced instead.</td>
 
 <dl class="function">
 <dt id="Kinetics.fwdRateConstants">
-<code class="descname">fwdRateConstants</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.fwdRateConstants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">fwdRateConstants</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.fwdRateConstants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the forward reaction rate constants.</p>
 <p>The computed values include all temperature-dependent, pressure-dependent, and
 third body contributions. Units are a combination of kmol, m^3 and s, that
 depend on the rate expression for the reaction.</p>
 <p>see also: <a class="reference internal" href="#Kinetics.revRateConstants" title="Kinetics.revRateConstants"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">revRateConstants()</span></code></a>, <a class="reference internal" href="#Kinetics.equil_Kc" title="Kinetics.equil_Kc"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">equil_Kc()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which forward rate constants are desired.</td>
 </tr>
@@ -230,7 +226,7 @@ all of the reactions.</td>
 
 <dl class="function">
 <dt id="Kinetics.isReversible">
-<code class="descname">isReversible</code><span class="sig-paren">(</span><em>a</em>, <em>i</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.isReversible" title="Permalink to this definition">¶</a></dt>
+<code class="descname">isReversible</code><span class="sig-paren">(</span><em>a</em>, <em>i</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.isReversible" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get an array of flags indicating reversibility of a reaction.</p>
 <p>A reversible reaction is one that runs in both the forward
 direction (reactants -&gt; products) and in the reverse direction
@@ -242,14 +238,14 @@ rate can also be specified directly by a rate expression. An
 irreversible reaction is one whose reverse reaction rate is
 zero.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<li><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which the reversible flags are desired.</li>
-<li><strong>i</strong> – Integer reaction number</li>
+<li><strong>i</strong> &#8211; Integer reaction number</li>
 </ul>
 </td>
 </tr>
@@ -263,7 +259,7 @@ reversible, and 0 if it is irreversible.</p>
 
 <dl class="function">
 <dt id="Kinetics.multiplier">
-<code class="descname">multiplier</code><span class="sig-paren">(</span><em>a</em>, <em>irxn</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.multiplier" title="Permalink to this definition">¶</a></dt>
+<code class="descname">multiplier</code><span class="sig-paren">(</span><em>a</em>, <em>irxn</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.multiplier" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the multiplier for reaction rate of progress.</p>
 <p>The multiplier multiplies the reaction rate of progress. It may
 be used to implement sensitivity analysis, or to selectively
@@ -272,14 +268,14 @@ the forward and reverse rates. By default, the multiplier value
 is 1.0, but it may be set to any other value by calling method
 <a class="reference internal" href="#Kinetics.setMultiplier" title="Kinetics.setMultiplier"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setMultiplier()</span></code></a>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<li><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which the multipliers are desired.</li>
-<li><strong>irxn</strong> – Integer reaction number for which the multiplier is desired.</li>
+<li><strong>irxn</strong> &#8211; Integer reaction number for which the multiplier is desired.</li>
 </ul>
 </td>
 </tr>
@@ -292,13 +288,13 @@ for which the multipliers are desired.</li>
 
 <dl class="function">
 <dt id="Kinetics.nReactions">
-<code class="descname">nReactions</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.nReactions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nReactions</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.nReactions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the number of reactions.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which the number of reactions is desired.</td>
 </tr>
@@ -310,15 +306,15 @@ for which the number of reactions is desired.</td>
 
 <dl class="function">
 <dt id="Kinetics.nTotalSpecies">
-<code class="descname">nTotalSpecies</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.nTotalSpecies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nTotalSpecies</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.nTotalSpecies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total number of species.</p>
 <p>The total number of species, summed over all
 participating phases.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which the number of species is desired.</td>
 </tr>
@@ -330,14 +326,14 @@ for which the number of species is desired.</td>
 
 <dl class="function">
 <dt id="Kinetics.netProdRates">
-<code class="descname">netProdRates</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.netProdRates" title="Permalink to this definition">¶</a></dt>
+<code class="descname">netProdRates</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.netProdRates" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the net chemical production rates for all species.</p>
 <p>See also: <a class="reference internal" href="#Kinetics.creationRates" title="Kinetics.creationRates"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">creationRates()</span></code></a>, <a class="reference internal" href="#Kinetics.destructionRates" title="Kinetics.destructionRates"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">destructionRates()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which net production rates are desired.</td>
 </tr>
@@ -351,21 +347,21 @@ assigned to a variable, a bar plot is produced.</td>
 
 <dl class="function">
 <dt id="Kinetics.reactionEqn">
-<code class="descname">reactionEqn</code><span class="sig-paren">(</span><em>a</em>, <em>irxn</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.reactionEqn" title="Permalink to this definition">¶</a></dt>
+<code class="descname">reactionEqn</code><span class="sig-paren">(</span><em>a</em>, <em>irxn</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.reactionEqn" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the reaction equation of a reaction.</p>
 <p>If only the first argument
 is given, the reaction equations of all of the reactions are
 returned in a cell array. Otherwise, <code class="docutils literal notranslate"><span class="pre">irxn</span></code> must be an integer
 or vector of integers.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<li><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which the reaction equations are desired.</li>
-<li><strong>irxn</strong> – Optional. Integer or vector of integer reaction numbers.</li>
+<li><strong>irxn</strong> &#8211; Optional. Integer or vector of integer reaction numbers.</li>
 </ul>
 </td>
 </tr>
@@ -378,17 +374,17 @@ for which the reaction equations are desired.</li>
 
 <dl class="function">
 <dt id="Kinetics.revRateConstants">
-<code class="descname">revRateConstants</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.revRateConstants" title="Permalink to this definition">¶</a></dt>
+<code class="descname">revRateConstants</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.revRateConstants" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the reverse reaction rate constants.</p>
 <p>The computed values include all temperature-dependent, pressure-dependent, and
 third body contributions. Units are a combination of kmol, m^3 and s, that
 depend on the rate expression for the reaction.</p>
 <p>See also: <a class="reference internal" href="#Kinetics.fwdRateConstants" title="Kinetics.fwdRateConstants"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">fwdRateConstants()</span></code></a>, <code class="xref mat mat-func docutils literal notranslate"><span class="pre">equil_KC()</span></code></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which reverse rate constants are desired.</td>
 </tr>
@@ -401,14 +397,14 @@ all of the reactions.</td>
 
 <dl class="function">
 <dt id="Kinetics.rop">
-<code class="descname">rop</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.rop" title="Permalink to this definition">¶</a></dt>
+<code class="descname">rop</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.rop" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the forward and reverse rates of progress.</p>
 <p>See also: <a class="reference internal" href="#Kinetics.rop_f" title="Kinetics.rop_f"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop_f()</span></code></a>, <a class="reference internal" href="#Kinetics.rop_r" title="Kinetics.rop_r"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop_r()</span></code></a>, <a class="reference internal" href="#Kinetics.rop_net" title="Kinetics.rop_net"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop_net()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which forward and reverse rates of progress are desired.</td>
 </tr>
@@ -424,15 +420,15 @@ is called with no output argument, a bar graph is produced.</td>
 
 <dl class="function">
 <dt id="Kinetics.rop_f">
-<code class="descname">rop_f</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.rop_f" title="Permalink to this definition">¶</a></dt>
+<code class="descname">rop_f</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.rop_f" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Forward rates of progress for all reactions.</p>
 <blockquote>
 <div>See also: <a class="reference internal" href="#Kinetics.rop_r" title="Kinetics.rop_r"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop_r()</span></code></a>, <a class="reference internal" href="#Kinetics.rop_net" title="Kinetics.rop_net"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop_net()</span></code></a>, <a class="reference internal" href="#Kinetics.rop" title="Kinetics.rop"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop()</span></code></a></div></blockquote>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which forward rates of progress are desired.</td>
 </tr>
@@ -446,14 +442,14 @@ is called with no output argument, a bar graph is produced.</td>
 
 <dl class="function">
 <dt id="Kinetics.rop_net">
-<code class="descname">rop_net</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.rop_net" title="Permalink to this definition">¶</a></dt>
+<code class="descname">rop_net</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.rop_net" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Net rates of progress for all reactions.</p>
 <p>See also: <a class="reference internal" href="#Kinetics.rop_f" title="Kinetics.rop_f"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop_f()</span></code></a>, <a class="reference internal" href="#Kinetics.rop_r" title="Kinetics.rop_r"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop_r()</span></code></a>, <a class="reference internal" href="#Kinetics.rop" title="Kinetics.rop"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which the net rates of progress are desired.</td>
 </tr>
@@ -467,15 +463,15 @@ is called with no output argument, a bar graph is produced.</td>
 
 <dl class="function">
 <dt id="Kinetics.rop_r">
-<code class="descname">rop_r</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.rop_r" title="Permalink to this definition">¶</a></dt>
+<code class="descname">rop_r</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.rop_r" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the reverse rates of progress for all reactions.</p>
 <blockquote>
 <div>See also: <a class="reference internal" href="#Kinetics.rop_f" title="Kinetics.rop_f"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop_f()</span></code></a>, <a class="reference internal" href="#Kinetics.rop_net" title="Kinetics.rop_net"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop_net()</span></code></a>, <a class="reference internal" href="#Kinetics.rop" title="Kinetics.rop"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rop()</span></code></a></div></blockquote>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which reverse rates of progress are desired.</td>
 </tr>
@@ -489,7 +485,7 @@ is called with no output argument, a bar graph is produced.</td>
 
 <dl class="function">
 <dt id="Kinetics.setMultiplier">
-<code class="descname">setMultiplier</code><span class="sig-paren">(</span><em>a</em>, <em>irxn</em>, <em>v</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.setMultiplier" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setMultiplier</code><span class="sig-paren">(</span><em>a</em>, <em>irxn</em>, <em>v</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.setMultiplier" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the multiplier for the reaction rate of progress.</p>
 <p>The multiplier multiplies the reaction rate of progress. It may
 be used to implement sensitivity analysis, or to selectively
@@ -500,16 +496,16 @@ is 1.0, but the current value may be checked by calling method
 <p>If only two arguments are given, it is assumed that the second is
 the desired multiplication factor for all of the reactions.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<li><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which the multipliers should be set.</li>
-<li><strong>irxn</strong> – Integer or vector of integers. Reaction number(s) for which
+<li><strong>irxn</strong> &#8211; Integer or vector of integers. Reaction number(s) for which
 the multiplier should be set. Optional.</li>
-<li><strong>v</strong> – Value by which the reaction rate of progress should be multiplied</li>
+<li><strong>v</strong> &#8211; Value by which the reaction rate of progress should be multiplied</li>
 </ul>
 </td>
 </tr>
@@ -519,21 +515,21 @@ the multiplier should be set. Optional.</li>
 
 <dl class="function">
 <dt id="Kinetics.stoich_net">
-<code class="descname">stoich_net</code><span class="sig-paren">(</span><em>a</em>, <em>species</em>, <em>rxns</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.stoich_net" title="Permalink to this definition">¶</a></dt>
+<code class="descname">stoich_net</code><span class="sig-paren">(</span><em>a</em>, <em>species</em>, <em>rxns</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.stoich_net" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the net stoichiometric coefficients.</p>
 <p>See also: <a class="reference internal" href="#Kinetics.stoich_r" title="Kinetics.stoich_r"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">stoich_r()</span></code></a>, <a class="reference internal" href="#Kinetics.stoich_p" title="Kinetics.stoich_p"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">stoich_p()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<li><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which the net stoichiometric coefficients are desired.</li>
-<li><strong>species</strong> – Species indices for which net stoichiometric coefficients
+<li><strong>species</strong> &#8211; Species indices for which net stoichiometric coefficients
 should be retrieved. Optional argument; if specified, <code class="docutils literal notranslate"><span class="pre">rxns</span></code>
 must be specified as well.</li>
-<li><strong>rxns</strong> – Reaction indices for which net stoichiometric coefficients
+<li><strong>rxns</strong> &#8211; Reaction indices for which net stoichiometric coefficients
 should be retrieved. Optional argument; if specified, <code class="docutils literal notranslate"><span class="pre">species</span></code>
 must be specified as well.</li>
 </ul>
@@ -555,21 +551,21 @@ in reactions 1, 3, 5, and 7.</p>
 
 <dl class="function">
 <dt id="Kinetics.stoich_p">
-<code class="descname">stoich_p</code><span class="sig-paren">(</span><em>a</em>, <em>species</em>, <em>rxns</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.stoich_p" title="Permalink to this definition">¶</a></dt>
+<code class="descname">stoich_p</code><span class="sig-paren">(</span><em>a</em>, <em>species</em>, <em>rxns</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.stoich_p" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the product stoichiometric coefficients.</p>
 <p>See also: <a class="reference internal" href="#Kinetics.stoich_r" title="Kinetics.stoich_r"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">stoich_r()</span></code></a>, <a class="reference internal" href="#Kinetics.stoich_net" title="Kinetics.stoich_net"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">stoich_net()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<li><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which the product stoichiometric coefficients are desired.</li>
-<li><strong>species</strong> – Species indices for which product stoichiometric coefficients
+<li><strong>species</strong> &#8211; Species indices for which product stoichiometric coefficients
 should be retrieved. Optional argument; if specified, <code class="docutils literal notranslate"><span class="pre">rxns</span></code>
 must be specified as well.</li>
-<li><strong>rxns</strong> – Reaction indices for which product stoichiometric coefficients
+<li><strong>rxns</strong> &#8211; Reaction indices for which product stoichiometric coefficients
 should be retrieved. Optional argument; if specified, <code class="docutils literal notranslate"><span class="pre">species</span></code>
 must be specified as well.</li>
 </ul>
@@ -591,21 +587,21 @@ in reactions 1, 3, 5, and 7.</p>
 
 <dl class="function">
 <dt id="Kinetics.stoich_r">
-<code class="descname">stoich_r</code><span class="sig-paren">(</span><em>a</em>, <em>species</em>, <em>rxns</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.stoich_r" title="Permalink to this definition">¶</a></dt>
+<code class="descname">stoich_r</code><span class="sig-paren">(</span><em>a</em>, <em>species</em>, <em>rxns</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.stoich_r" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the reactant stoichiometric coefficients.</p>
 <p>See also: <a class="reference internal" href="#Kinetics.stoich_p" title="Kinetics.stoich_p"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">stoich_p()</span></code></a>, <a class="reference internal" href="#Kinetics.stoich_net" title="Kinetics.stoich_net"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">stoich_net()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<li><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which the reactant stoichiometric coefficients are desired.</li>
-<li><strong>species</strong> – Species indices for which reactant stoichiometric coefficients
+<li><strong>species</strong> &#8211; Species indices for which reactant stoichiometric coefficients
 should be retrieved. Optional argument; if specified, <code class="docutils literal notranslate"><span class="pre">rxns</span></code>
 must be specified as well.</li>
-<li><strong>rxns</strong> – Reaction indices for which reactant stoichiometric coefficients
+<li><strong>rxns</strong> &#8211; Reaction indices for which reactant stoichiometric coefficients
 should be retrieved. Optional argument; if specified, <code class="docutils literal notranslate"><span class="pre">species</span></code>
 must be specified as well.</li>
 </ul>
@@ -627,14 +623,14 @@ in reactions 1, 3, 5, and 7.</p>
 
 <dl class="function">
 <dt id="Kinetics.ydot">
-<code class="descname">ydot</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.ydot" title="Permalink to this definition">¶</a></dt>
+<code class="descname">ydot</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Kinetics.ydot" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass production rates of the species.</p>
 <p>Evaluates the source term <span class="math">\(\dot{\omega}_k M_k /\rho\)</span></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a> (or another
 object deriving from Kinetics)
 for which the ydots are desired.</td>
 </tr>
@@ -667,7 +663,7 @@ for which the ydots are desired.</td>
 <h3>Related Topics</h3>
 <ul>
   <li><a href="../index.html">Documentation overview</a><ul>
-  <li><a href="index.html">Matlab Interface User’s Guide</a><ul>
+  <li><a href="index.html">Matlab Interface User&#8217;s Guide</a><ul>
       <li>Previous: <a href="thermodynamics.html" title="previous chapter">Thermodynamic Properties</a></li>
       <li>Next: <a href="transport.html" title="next chapter">Transport Properties</a></li>
   </ul></li>
@@ -677,25 +673,24 @@ for which the ydots are desired.</td>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/matlab/kinetics.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/matlab/kinetics.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -704,15 +699,14 @@ for which the ydots are desired.</td>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/matlab/kinetics.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/matlab/kinetics.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/matlab/kinetics.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/kinetics.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/matlab/one-dim.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/one-dim.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>One-Dimensional Reacting Flows | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,19 +77,19 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="one-dimensional-reacting-flows">
-<h1>One-Dimensional Reacting Flows<a class="headerlink" href="#one-dimensional-reacting-flows" title="Permalink to this headline">¶</a></h1>
+<h1>One-Dimensional Reacting Flows<a class="headerlink" href="#one-dimensional-reacting-flows" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="domain1d">
-<h2>Domain1D<a class="headerlink" href="#domain1d" title="Permalink to this headline">¶</a></h2>
+<h2>Domain1D<a class="headerlink" href="#domain1d" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="Domain1D">
-<em class="property">class </em><code class="descname">Domain1D</code><span class="sig-paren">(</span><em>a</em>, <em>b</em>, <em>c</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">Domain1D</code><span class="sig-paren">(</span><em>a</em>, <em>b</em>, <em>c</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Domain1D class constructor.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>a</strong> – <p>Integer type of domain. Possible values are</p>
+<li><strong>a</strong> &#8211; <p>Integer type of domain. Possible values are</p>
 <ul>
 <li>1 - Stagnation Flow</li>
 <li>2 - Inlet1D</li>
@@ -105,10 +101,10 @@ lang="en">
 <li>-2 - OutletRes</li>
 </ul>
 </li>
-<li><strong>b</strong> – Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> (for <code class="docutils literal notranslate"><span class="pre">a</span> <span class="pre">==</span> <span class="pre">1</span></code>)
+<li><strong>b</strong> &#8211; Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> (for <code class="docutils literal notranslate"><span class="pre">a</span> <span class="pre">==</span> <span class="pre">1</span></code>)
 or <a class="reference internal" href="importing.html#Interface" title="Interface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Interface()</span></code></a> (for <code class="docutils literal notranslate"><span class="pre">a</span> <span class="pre">==</span> <span class="pre">6</span></code>). Not used for
 all other valid values of <code class="docutils literal notranslate"><span class="pre">a</span></code>.</li>
-<li><strong>c</strong> – Integer, either 1 or 2, indicating whether an axisymmetric
+<li><strong>c</strong> &#8211; Integer, either 1 or 2, indicating whether an axisymmetric
 stagnation flow or a free flame should be created. If not
 specified, defaults to 1. Ignored if <code class="docutils literal notranslate"><span class="pre">a</span> <span class="pre">!=</span> <span class="pre">1</span></code>.</li>
 </ul>
@@ -118,13 +114,13 @@ specified, defaults to 1. Ignored if <code class="docutils literal notranslate">
 </table>
 <dl class="function">
 <dt id="Domain1D.AxiStagnFlow">
-<code class="descname">AxiStagnFlow</code><span class="sig-paren">(</span><em>gas</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.AxiStagnFlow" title="Permalink to this definition">¶</a></dt>
+<code class="descname">AxiStagnFlow</code><span class="sig-paren">(</span><em>gas</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.AxiStagnFlow" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get an axisymmetric stagnation flow domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>gas</strong> – Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>gas</strong> &#8211; Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Domain1D instance representing an axisymmetric
 stagnation flow.</td>
@@ -135,15 +131,15 @@ stagnation flow.</td>
 
 <dl class="function">
 <dt id="Domain1D.AxisymmetricFlow">
-<code class="descname">AxisymmetricFlow</code><span class="sig-paren">(</span><em>gas</em>, <em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.AxisymmetricFlow" title="Permalink to this definition">¶</a></dt>
+<code class="descname">AxisymmetricFlow</code><span class="sig-paren">(</span><em>gas</em>, <em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.AxisymmetricFlow" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create an axisymmetric flow domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>gas</strong> – Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></li>
-<li><strong>id</strong> – String, ID of the flow</li>
+<li><strong>gas</strong> &#8211; Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></li>
+<li><strong>id</strong> &#8211; String, ID of the flow</li>
 </ul>
 </td>
 </tr>
@@ -156,15 +152,15 @@ stagnation flow.</td>
 
 <dl class="function">
 <dt id="Domain1D.Inlet">
-<code class="descname">Inlet</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.Inlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Inlet</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.Inlet" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create an inlet domain.</p>
 <p>Note that an inlet can only be a terminal domain - it must be
 either the leftmost or rightmost domain in a stack.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>id</strong> – String name of the inlet.</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>id</strong> &#8211; String name of the inlet.</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a> representing an inlet.</td>
 </tr>
@@ -174,13 +170,13 @@ either the leftmost or rightmost domain in a stack.</p>
 
 <dl class="function">
 <dt id="Domain1D.Outlet">
-<code class="descname">Outlet</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.Outlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Outlet</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.Outlet" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create an outlet domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>id</strong> – String ID of the outlet.</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>id</strong> &#8211; String ID of the outlet.</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a> representing an outlet.</td>
 </tr>
@@ -190,11 +186,11 @@ either the leftmost or rightmost domain in a stack.</p>
 
 <dl class="function">
 <dt id="Domain1D.OutletRes">
-<code class="descname">OutletRes</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.OutletRes" title="Permalink to this definition">¶</a></dt>
+<code class="descname">OutletRes</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.OutletRes" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create an outlet reservoir domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Instance of <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a> representing an outlet
 reservoir.</td>
@@ -205,15 +201,15 @@ reservoir.</td>
 
 <dl class="function">
 <dt id="Domain1D.Surface">
-<code class="descname">Surface</code><span class="sig-paren">(</span><em>id</em>, <em>surface_mech</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.Surface" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Surface</code><span class="sig-paren">(</span><em>id</em>, <em>surface_mech</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.Surface" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a surface domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>id</strong> – String ID of surface</li>
-<li><strong>surface_mech</strong> – Instance of class <a class="reference internal" href="importing.html#Interface" title="Interface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Interface()</span></code></a> defining
+<li><strong>id</strong> &#8211; String ID of surface</li>
+<li><strong>surface_mech</strong> &#8211; Instance of class <a class="reference internal" href="importing.html#Interface" title="Interface"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Interface()</span></code></a> defining
 the surface reaction mechanism to be used. Optional.</li>
 </ul>
 </td>
@@ -228,13 +224,13 @@ non-reacting or reacting surface.</p>
 
 <dl class="function">
 <dt id="Domain1D.SymmPlane">
-<code class="descname">SymmPlane</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.SymmPlane" title="Permalink to this definition">¶</a></dt>
+<code class="descname">SymmPlane</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.SymmPlane" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a symmetry plane domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>id</strong> – String ID of the symmetry plane.</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>id</strong> &#8211; String ID of the symmetry plane.</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a> representing a symmetry
 plane.</td>
@@ -245,15 +241,15 @@ plane.</td>
 
 <dl class="function">
 <dt id="Domain1D.componentIndex">
-<code class="descname">componentIndex</code><span class="sig-paren">(</span><em>d</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.componentIndex" title="Permalink to this definition">¶</a></dt>
+<code class="descname">componentIndex</code><span class="sig-paren">(</span><em>d</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.componentIndex" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the index of a component given its name.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>name</strong> – String name of the component to look up. If a numeric value
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>name</strong> &#8211; String name of the component to look up. If a numeric value
 is passed, it will be returned.</li>
 </ul>
 </td>
@@ -267,15 +263,15 @@ is passed, it will be returned.</li>
 
 <dl class="function">
 <dt id="Domain1D.componentName">
-<code class="descname">componentName</code><span class="sig-paren">(</span><em>d</em>, <em>n</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.componentName" title="Permalink to this definition">¶</a></dt>
+<code class="descname">componentName</code><span class="sig-paren">(</span><em>d</em>, <em>n</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.componentName" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the name of a component given its index.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>n</strong> – Integer or vector of integers of components’ names
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>n</strong> &#8211; Integer or vector of integers of components&#8217; names
 to get.</li>
 </ul>
 </td>
@@ -289,13 +285,13 @@ to get.</li>
 
 <dl class="function">
 <dt id="Domain1D.disableEnergy">
-<code class="descname">disableEnergy</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.disableEnergy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">disableEnergy</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.disableEnergy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Disable the energy equation.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
 </tr>
 </tbody>
 </table>
@@ -303,13 +299,13 @@ to get.</li>
 
 <dl class="function">
 <dt id="Domain1D.domainIndex">
-<code class="descname">domainIndex</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.domainIndex" title="Permalink to this definition">¶</a></dt>
+<code class="descname">domainIndex</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.domainIndex" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the domain index.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">This function returns an integer flag denoting the location
 of the domain, beginning with 1 at the left.</td>
@@ -320,13 +316,13 @@ of the domain, beginning with 1 at the left.</td>
 
 <dl class="function">
 <dt id="Domain1D.domainType">
-<code class="descname">domainType</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.domainType" title="Permalink to this definition">¶</a></dt>
+<code class="descname">domainType</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.domainType" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the type of domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">This function returns an integer flag denoting the domain
 type.</td>
@@ -337,13 +333,13 @@ type.</td>
 
 <dl class="function">
 <dt id="Domain1D.enableEnergy">
-<code class="descname">enableEnergy</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.enableEnergy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enableEnergy</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.enableEnergy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Enable the energy equation.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
 </tr>
 </tbody>
 </table>
@@ -351,15 +347,15 @@ type.</td>
 
 <dl class="function">
 <dt id="Domain1D.gridPoints">
-<code class="descname">gridPoints</code><span class="sig-paren">(</span><em>d</em>, <em>n</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.gridPoints" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gridPoints</code><span class="sig-paren">(</span><em>d</em>, <em>n</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.gridPoints" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get grid points from a domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>n</strong> – Optional, vector of grid points to be retrieved.</li>
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>n</strong> &#8211; Optional, vector of grid points to be retrieved.</li>
 </ul>
 </td>
 </tr>
@@ -372,13 +368,13 @@ type.</td>
 
 <dl class="function">
 <dt id="Domain1D.isFlow">
-<code class="descname">isFlow</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.isFlow" title="Permalink to this definition">¶</a></dt>
+<code class="descname">isFlow</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.isFlow" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Determine whether a domain is a flow.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">1 if the domain is a flow domain, and 0 otherwise.</td>
 </tr>
@@ -388,13 +384,13 @@ type.</td>
 
 <dl class="function">
 <dt id="Domain1D.isInlet">
-<code class="descname">isInlet</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.isInlet" title="Permalink to this definition">¶</a></dt>
+<code class="descname">isInlet</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.isInlet" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Determine whether a domain is an inlet.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">1 if the domain is an inlet, and 0 otherwise.</td>
 </tr>
@@ -404,13 +400,13 @@ type.</td>
 
 <dl class="function">
 <dt id="Domain1D.isSurface">
-<code class="descname">isSurface</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.isSurface" title="Permalink to this definition">¶</a></dt>
+<code class="descname">isSurface</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.isSurface" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Determine if a domain is a surface.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">1 if the domain is a surface, and 0 otherwise.</td>
 </tr>
@@ -420,13 +416,13 @@ type.</td>
 
 <dl class="function">
 <dt id="Domain1D.massFlux">
-<code class="descname">massFlux</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.massFlux" title="Permalink to this definition">¶</a></dt>
+<code class="descname">massFlux</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.massFlux" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass flux.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">The mass flux in the domain.</td>
 </tr>
@@ -436,18 +432,18 @@ type.</td>
 
 <dl class="function">
 <dt id="Domain1D.massFraction">
-<code class="descname">massFraction</code><span class="sig-paren">(</span><em>d</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.massFraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">massFraction</code><span class="sig-paren">(</span><em>d</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.massFraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass fraction of a species given its integer index.</p>
 <p>This method returns the mass fraction of species <code class="docutils literal notranslate"><span class="pre">k</span></code>, where
 k is the integer index of the species in the flow domain
 to which the boundary domain is attached.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>k</strong> – Integer species index</li>
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>k</strong> &#8211; Integer species index</li>
 </ul>
 </td>
 </tr>
@@ -460,13 +456,13 @@ to which the boundary domain is attached.</p>
 
 <dl class="function">
 <dt id="Domain1D.nComponents">
-<code class="descname">nComponents</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.nComponents" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nComponents</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.nComponents" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the number of components.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Number of variables at each grid point</td>
 </tr>
@@ -476,13 +472,13 @@ to which the boundary domain is attached.</p>
 
 <dl class="function">
 <dt id="Domain1D.nPoints">
-<code class="descname">nPoints</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.nPoints" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nPoints</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.nPoints" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the number of grid points.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Integer number of grid points.</td>
 </tr>
@@ -492,7 +488,7 @@ to which the boundary domain is attached.</p>
 
 <dl class="function">
 <dt id="Domain1D.set">
-<code class="descname">set</code><span class="sig-paren">(</span><em>a</em>, <em>varargin</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.set" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set</code><span class="sig-paren">(</span><em>a</em>, <em>varargin</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.set" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set properties of a Domain1D.</p>
 <p>The properties that may be set are</p>
 <ul class="simple">
@@ -512,10 +508,10 @@ specified. Mole and mass
 fractions must be input as vectors (either row or column) with
 length equal to the number of species.</p>
 <p>Examples:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">&#39;Temperature&#39;</span><span class="p">,</span><span class="mf">600.0</span><span class="p">);</span>
-<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">&#39;T&#39;</span><span class="p">,</span><span class="mf">600.0</span><span class="p">);</span>
-<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">&#39;T&#39;</span><span class="p">,</span><span class="mf">600.0</span><span class="p">,</span><span class="s1">&#39;P&#39;</span><span class="p">,</span><span class="mi">2</span><span class="o">*</span><span class="n">oneatm</span><span class="p">,</span><span class="s1">&#39;Y&#39;</span><span class="p">,</span><span class="n">massfracs</span><span class="p">);</span>
-<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">&#39;X&#39;</span><span class="p">,</span><span class="n">ones</span><span class="p">(</span><span class="n">nSpecies</span><span class="p">(</span><span class="n">gas</span><span class="p">),</span><span class="mi">1</span><span class="p">));</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">'Temperature'</span><span class="p">,</span><span class="mf">600.0</span><span class="p">);</span>
+<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">'T'</span><span class="p">,</span><span class="mf">600.0</span><span class="p">);</span>
+<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">'T'</span><span class="p">,</span><span class="mf">600.0</span><span class="p">,</span><span class="s1">'P'</span><span class="p">,</span><span class="mi">2</span><span class="o">*</span><span class="n">oneatm</span><span class="p">,</span><span class="s1">'Y'</span><span class="p">,</span><span class="n">massfracs</span><span class="p">);</span>
+<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">'X'</span><span class="p">,</span><span class="n">ones</span><span class="p">(</span><span class="n">nSpecies</span><span class="p">(</span><span class="n">gas</span><span class="p">),</span><span class="mi">1</span><span class="p">));</span>
 </pre></div>
 </div>
 <p>Alternatively, individual methods to set properties may be
@@ -525,12 +521,12 @@ called (setTemperature, setMoleFractions, etc.)</p>
 <a class="reference internal" href="#Domain1D.setProfile" title="Domain1D.setProfile"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setProfile()</span></code></a>, <a class="reference internal" href="#Domain1D.setSteadyTolerances" title="Domain1D.setSteadyTolerances"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setSteadyTolerances()</span></code></a>, <a class="reference internal" href="#Domain1D.setTemperature" title="Domain1D.setTemperature"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setTemperature()</span></code></a>,
 <a class="reference internal" href="#Domain1D.setTransientTolerances" title="Domain1D.setTransientTolerances"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setTransientTolerances()</span></code></a>, <a class="reference internal" href="#Domain1D.setupGrid" title="Domain1D.setupGrid"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setupGrid()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>a</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>varargin</strong> – Comma separated list of <code class="docutils literal notranslate"><span class="pre">property,</span> <span class="pre">value</span></code> pairs to be set</li>
+<li><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>varargin</strong> &#8211; Comma separated list of <code class="docutils literal notranslate"><span class="pre">property,</span> <span class="pre">value</span></code> pairs to be set</li>
 </ul>
 </td>
 </tr>
@@ -540,17 +536,17 @@ called (setTemperature, setMoleFractions, etc.)</p>
 
 <dl class="function">
 <dt id="Domain1D.setBounds">
-<code class="descname">setBounds</code><span class="sig-paren">(</span><em>d</em>, <em>component</em>, <em>lower</em>, <em>upper</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setBounds" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setBounds</code><span class="sig-paren">(</span><em>d</em>, <em>component</em>, <em>lower</em>, <em>upper</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setBounds" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set bounds on the solution components.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>component</strong> – String, component to set the bounds on</li>
-<li><strong>lower</strong> – Lower bound</li>
-<li><strong>upper</strong> – Upper bound</li>
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>component</strong> &#8211; String, component to set the bounds on</li>
+<li><strong>lower</strong> &#8211; Lower bound</li>
+<li><strong>upper</strong> &#8211; Upper bound</li>
 </ul>
 </td>
 </tr>
@@ -560,15 +556,15 @@ called (setTemperature, setMoleFractions, etc.)</p>
 
 <dl class="function">
 <dt id="Domain1D.setCoverageEqs">
-<code class="descname">setCoverageEqs</code><span class="sig-paren">(</span><em>d</em>, <em>onoff</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setCoverageEqs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setCoverageEqs</code><span class="sig-paren">(</span><em>d</em>, <em>onoff</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setCoverageEqs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Enable or disable solving the coverage equations.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>onoff</strong> – String, one of <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'yes'</span></code> to turn solving
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>onoff</strong> &#8211; String, one of <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'yes'</span></code> to turn solving
 the coverage equations on. One of <code class="docutils literal notranslate"><span class="pre">'off'</span></code> or <code class="docutils literal notranslate"><span class="pre">'no'</span></code>
 to turn off the coverage equations.</li>
 </ul>
@@ -580,19 +576,19 @@ to turn off the coverage equations.</li>
 
 <dl class="function">
 <dt id="Domain1D.setFixedTempProfile">
-<code class="descname">setFixedTempProfile</code><span class="sig-paren">(</span><em>d</em>, <em>profile</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setFixedTempProfile" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setFixedTempProfile</code><span class="sig-paren">(</span><em>d</em>, <em>profile</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setFixedTempProfile" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set a fixed temperature profile.</p>
 <p>Set the temperature profile to use when the
 energy equation is not being solved. The profile must be entered
 as an array of positions / temperatures, which may be in rows or
 columns.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>profile</strong> – n x 2 or 2 x n array of <code class="docutils literal notranslate"><span class="pre">n</span></code> points at which the temperature
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>profile</strong> &#8211; n x 2 or 2 x n array of <code class="docutils literal notranslate"><span class="pre">n</span></code> points at which the temperature
 is specified.</li>
 </ul>
 </td>
@@ -603,15 +599,15 @@ is specified.</li>
 
 <dl class="function">
 <dt id="Domain1D.setID">
-<code class="descname">setID</code><span class="sig-paren">(</span><em>d</em>, <em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setID" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setID</code><span class="sig-paren">(</span><em>d</em>, <em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setID" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the ID tag for a domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>id</strong> – String ID to assign</li>
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>id</strong> &#8211; String ID to assign</li>
 </ul>
 </td>
 </tr>
@@ -621,15 +617,15 @@ is specified.</li>
 
 <dl class="function">
 <dt id="Domain1D.setMdot">
-<code class="descname">setMdot</code><span class="sig-paren">(</span><em>d</em>, <em>mdot</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setMdot" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setMdot</code><span class="sig-paren">(</span><em>d</em>, <em>mdot</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setMdot" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mass flow rate.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>mdot</strong> – Mass flow rate</li>
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>mdot</strong> &#8211; Mass flow rate</li>
 </ul>
 </td>
 </tr>
@@ -639,15 +635,15 @@ is specified.</li>
 
 <dl class="function">
 <dt id="Domain1D.setMoleFractions">
-<code class="descname">setMoleFractions</code><span class="sig-paren">(</span><em>d</em>, <em>x</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setMoleFractions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setMoleFractions</code><span class="sig-paren">(</span><em>d</em>, <em>x</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setMoleFractions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mole fractions.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>x</strong> – String specifying the species and mole fractions in
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>x</strong> &#8211; String specifying the species and mole fractions in
 the format <code class="docutils literal notranslate"><span class="pre">'SPEC:X,SPEC2:X2'</span></code>.</li>
 </ul>
 </td>
@@ -658,15 +654,15 @@ the format <code class="docutils literal notranslate"><span class="pre">'SPEC:X,
 
 <dl class="function">
 <dt id="Domain1D.setPressure">
-<code class="descname">setPressure</code><span class="sig-paren">(</span><em>d</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setPressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setPressure</code><span class="sig-paren">(</span><em>d</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setPressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>p</strong> – Pressure to be set. Units: Pa</li>
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>p</strong> &#8211; Pressure to be set. Units: Pa</li>
 </ul>
 </td>
 </tr>
@@ -676,19 +672,19 @@ the format <code class="docutils literal notranslate"><span class="pre">'SPEC:X,
 
 <dl class="function">
 <dt id="Domain1D.setProfile">
-<code class="descname">setProfile</code><span class="sig-paren">(</span><em>d</em>, <em>n</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setProfile" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setProfile</code><span class="sig-paren">(</span><em>d</em>, <em>n</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setProfile" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the profile of a component.</p>
 <p>Convenience function to allow an instance of <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a> to
 have a profile of its components set when it is part of a <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>n</strong> – Integer index of component, vector of component indices, string
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>n</strong> &#8211; Integer index of component, vector of component indices, string
 of component name, or cell array of strings of component names.</li>
-<li><strong>p</strong> – n x 2 array, whose columns are the relative (normalized) positions
+<li><strong>p</strong> &#8211; n x 2 array, whose columns are the relative (normalized) positions
 and the component values at those points. The number of positions
 <code class="docutils literal notranslate"><span class="pre">n</span></code> is arbitrary.</li>
 </ul>
@@ -700,19 +696,19 @@ and the component values at those points. The number of positions
 
 <dl class="function">
 <dt id="Domain1D.setSteadyTolerances">
-<code class="descname">setSteadyTolerances</code><span class="sig-paren">(</span><em>d</em>, <em>component</em>, <em>rtol</em>, <em>atol</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setSteadyTolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setSteadyTolerances</code><span class="sig-paren">(</span><em>d</em>, <em>component</em>, <em>rtol</em>, <em>atol</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setSteadyTolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the steady-state tolerances.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>component</strong> – String or cell array of strings of component values
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>component</strong> &#8211; String or cell array of strings of component values
 whose tolerances should be set. If <code class="docutils literal notranslate"><span class="pre">'default'</span></code> is
 specified, the tolerance of all components will be set.</li>
-<li><strong>rtol</strong> – Relative tolerance</li>
-<li><strong>atol</strong> – Absolute tolerance</li>
+<li><strong>rtol</strong> &#8211; Relative tolerance</li>
+<li><strong>atol</strong> &#8211; Absolute tolerance</li>
 </ul>
 </td>
 </tr>
@@ -722,15 +718,15 @@ specified, the tolerance of all components will be set.</li>
 
 <dl class="function">
 <dt id="Domain1D.setTemperature">
-<code class="descname">setTemperature</code><span class="sig-paren">(</span><em>d</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setTemperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setTemperature</code><span class="sig-paren">(</span><em>d</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setTemperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the temperature.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>t</strong> – Temperature to be set. Units: K</li>
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>t</strong> &#8211; Temperature to be set. Units: K</li>
 </ul>
 </td>
 </tr>
@@ -740,19 +736,19 @@ specified, the tolerance of all components will be set.</li>
 
 <dl class="function">
 <dt id="Domain1D.setTransientTolerances">
-<code class="descname">setTransientTolerances</code><span class="sig-paren">(</span><em>d</em>, <em>component</em>, <em>rtol</em>, <em>atol</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setTransientTolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setTransientTolerances</code><span class="sig-paren">(</span><em>d</em>, <em>component</em>, <em>rtol</em>, <em>atol</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setTransientTolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the transient tolerances.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>component</strong> – String or cell array of strings of component values
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>component</strong> &#8211; String or cell array of strings of component values
 whose tolerances should be set. If <code class="docutils literal notranslate"><span class="pre">'default'</span></code> is
 specified, the tolerance of all components will be set.</li>
-<li><strong>rtol</strong> – Relative tolerance</li>
-<li><strong>atol</strong> – Absolute tolerance</li>
+<li><strong>rtol</strong> &#8211; Relative tolerance</li>
+<li><strong>atol</strong> &#8211; Absolute tolerance</li>
 </ul>
 </td>
 </tr>
@@ -762,15 +758,15 @@ specified, the tolerance of all components will be set.</li>
 
 <dl class="function">
 <dt id="Domain1D.setupGrid">
-<code class="descname">setupGrid</code><span class="sig-paren">(</span><em>d</em>, <em>grid</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setupGrid" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setupGrid</code><span class="sig-paren">(</span><em>d</em>, <em>grid</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.setupGrid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set up the solution grid.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
-<li><strong>grid</strong> – </li>
+<li><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></li>
+<li><strong>grid</strong> &#8211; </li>
 </ul>
 </td>
 </tr>
@@ -780,13 +776,13 @@ specified, the tolerance of all components will be set.</li>
 
 <dl class="function">
 <dt id="Domain1D.temperature">
-<code class="descname">temperature</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.temperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">temperature</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#Domain1D.temperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the boundary temperature.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Instance of class <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Temperature. Units: K</td>
 </tr>
@@ -798,20 +794,20 @@ specified, the tolerance of all components will be set.</li>
 
 </div>
 <div class="section" id="stack">
-<h2>Stack<a class="headerlink" href="#stack" title="Permalink to this headline">¶</a></h2>
+<h2>Stack<a class="headerlink" href="#stack" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="Stack">
-<em class="property">class </em><code class="descname">Stack</code><span class="sig-paren">(</span><em>domains</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">Stack</code><span class="sig-paren">(</span><em>domains</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Stack class constructor.</p>
 <p>A stack object is a container for one-dimensional domains,
 which are instances of class Domain1D. The domains are of two
 types - extended domains, and connector domains.</p>
 <p>See also: <a class="reference internal" href="#Domain1D" title="Domain1D"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Domain1D()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>domains</strong> – Vector of domain instances</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>domains</strong> &#8211; Vector of domain instances</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></td>
 </tr>
@@ -819,24 +815,24 @@ types - extended domains, and connector domains.</p>
 </table>
 <dl class="function">
 <dt id="Stack.CounterFlowDiffusionFlame">
-<code class="descname">CounterFlowDiffusionFlame</code><span class="sig-paren">(</span><em>left</em>, <em>flow</em>, <em>right</em>, <em>tp_f</em>, <em>tp_o</em>, <em>oxidizer</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.CounterFlowDiffusionFlame" title="Permalink to this definition">¶</a></dt>
+<code class="descname">CounterFlowDiffusionFlame</code><span class="sig-paren">(</span><em>left</em>, <em>flow</em>, <em>right</em>, <em>tp_f</em>, <em>tp_o</em>, <em>oxidizer</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.CounterFlowDiffusionFlame" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a counter flow diffusion flame stack.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>left</strong> – Object representing the left inlet, which must be
+<li><strong>left</strong> &#8211; Object representing the left inlet, which must be
 created using function <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Inlet()</span></code>.</li>
-<li><strong>flow</strong> – Object representing the flow, created with
+<li><strong>flow</strong> &#8211; Object representing the flow, created with
 function <code class="xref mat mat-func docutils literal notranslate"><span class="pre">AxisymmetricFlow()</span></code>.</li>
-<li><strong>right</strong> – Object representing the right inlet, which must be
+<li><strong>right</strong> &#8211; Object representing the right inlet, which must be
 created using function <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Inlet()</span></code>.</li>
-<li><strong>tp_f</strong> – Object representing the fuel inlet gas, instance of class
+<li><strong>tp_f</strong> &#8211; Object representing the fuel inlet gas, instance of class
 <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a>, and an ideal gas.</li>
-<li><strong>tp_o</strong> – Object representing the oxidizer inlet gas, instance of class
+<li><strong>tp_o</strong> &#8211; Object representing the oxidizer inlet gas, instance of class
 <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a>, and an ideal gas.</li>
-<li><strong>oxidizer</strong> – String representing the oxidizer species. Most commonly O2.</li>
+<li><strong>oxidizer</strong> &#8211; String representing the oxidizer species. Most commonly O2.</li>
 </ul>
 </td>
 </tr>
@@ -850,15 +846,15 @@ inlet, flow, and right inlet.</p>
 
 <dl class="function">
 <dt id="Stack.FreeFlame">
-<code class="descname">FreeFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.FreeFlame" title="Permalink to this definition">¶</a></dt>
+<code class="descname">FreeFlame</code><span class="sig-paren">(</span><em>gas</em>, <em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.FreeFlame" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a freely-propagating flat flame.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>gas</strong> – Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></li>
-<li><strong>id</strong> – String, ID of the flow</li>
+<li><strong>gas</strong> &#8211; Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a></li>
+<li><strong>id</strong> &#8211; String, ID of the flow</li>
 </ul>
 </td>
 </tr>
@@ -872,30 +868,30 @@ adiabatic flame</p>
 
 <dl class="function">
 <dt id="Stack.npflame_init">
-<code class="descname">npflame_init</code><span class="sig-paren">(</span><em>gas</em>, <em>left</em>, <em>flow</em>, <em>right</em>, <em>fuel</em>, <em>oxidizer</em>, <em>nuox</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.npflame_init" title="Permalink to this definition">¶</a></dt>
+<code class="descname">npflame_init</code><span class="sig-paren">(</span><em>gas</em>, <em>left</em>, <em>flow</em>, <em>right</em>, <em>fuel</em>, <em>oxidizer</em>, <em>nuox</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.npflame_init" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a non-premixed flame stack.</p>
 <p>This function is deprecated in favor of <a class="reference internal" href="#Stack.CounterFlowDiffusionFlame" title="Stack.CounterFlowDiffusionFlame"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">CounterFlowDiffusionFlame()</span></code></a>
 and will be removed after Cantera 2.4.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>gas</strong> – Object representing the gas, instance of class
+<li><strong>gas</strong> &#8211; Object representing the gas, instance of class
 <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a>, and an ideal gas. This object will be used
 to compute all required thermodynamic, kinetic, and transport
 properties. The state of this object should be set
 to an estimate of the gas state emerging from the
 burner before calling StagnationFlame.</li>
-<li><strong>left</strong> – Object representing the left inlet, which must be
+<li><strong>left</strong> &#8211; Object representing the left inlet, which must be
 created using function <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Inlet()</span></code>.</li>
-<li><strong>flow</strong> – Object representing the flow, created with
+<li><strong>flow</strong> &#8211; Object representing the flow, created with
 function <code class="xref mat mat-func docutils literal notranslate"><span class="pre">AxisymmetricFlow()</span></code>.</li>
-<li><strong>right</strong> – Object representing the right inlet, which must be
+<li><strong>right</strong> &#8211; Object representing the right inlet, which must be
 created using function <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Inlet()</span></code>.</li>
-<li><strong>fuel</strong> – String representing the fuel species</li>
-<li><strong>ox</strong> – String representing the oxidizer species</li>
-<li><strong>nuox</strong> – Number of oxidizer molecules required to completely combust
+<li><strong>fuel</strong> &#8211; String representing the fuel species</li>
+<li><strong>ox</strong> &#8211; String representing the oxidizer species</li>
+<li><strong>nuox</strong> &#8211; Number of oxidizer molecules required to completely combust
 one fuel molecule.</li>
 </ul>
 </td>
@@ -910,15 +906,15 @@ inlet, flow, and right inlet.</p>
 
 <dl class="function">
 <dt id="Stack.domainIndex">
-<code class="descname">domainIndex</code><span class="sig-paren">(</span><em>s</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.domainIndex" title="Permalink to this definition">¶</a></dt>
+<code class="descname">domainIndex</code><span class="sig-paren">(</span><em>s</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.domainIndex" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the index of a domain in a stack given its name.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>name</strong> – If double, the value is returned. Otherwise,
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>name</strong> &#8211; If double, the value is returned. Otherwise,
 the name is looked up and its index is returned.</li>
 </ul>
 </td>
@@ -932,15 +928,15 @@ the name is looked up and its index is returned.</li>
 
 <dl class="function">
 <dt id="Stack.grid">
-<code class="descname">grid</code><span class="sig-paren">(</span><em>s</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.grid" title="Permalink to this definition">¶</a></dt>
+<code class="descname">grid</code><span class="sig-paren">(</span><em>s</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.grid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the grid in one domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>name</strong> – Name of the domain for which the grid
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>name</strong> &#8211; Name of the domain for which the grid
 should be retrieved.</li>
 </ul>
 </td>
@@ -954,17 +950,17 @@ should be retrieved.</li>
 
 <dl class="function">
 <dt id="Stack.plotSolution">
-<code class="descname">plotSolution</code><span class="sig-paren">(</span><em>s</em>, <em>domain</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.plotSolution" title="Permalink to this definition">¶</a></dt>
+<code class="descname">plotSolution</code><span class="sig-paren">(</span><em>s</em>, <em>domain</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.plotSolution" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Plot a specified solution component.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>domain</strong> – Name of domain from which the component should be
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>domain</strong> &#8211; Name of domain from which the component should be
 retrieved</li>
-<li><strong>component</strong> – Name of the component to be plotted</li>
+<li><strong>component</strong> &#8211; Name of the component to be plotted</li>
 </ul>
 </td>
 </tr>
@@ -974,17 +970,17 @@ retrieved</li>
 
 <dl class="function">
 <dt id="Stack.resid">
-<code class="descname">resid</code><span class="sig-paren">(</span><em>s</em>, <em>domain</em>, <em>rdt</em>, <em>count</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.resid" title="Permalink to this definition">¶</a></dt>
+<code class="descname">resid</code><span class="sig-paren">(</span><em>s</em>, <em>domain</em>, <em>rdt</em>, <em>count</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.resid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the residuals.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>domain</strong> – Name of the domain</li>
-<li><strong>rdt</strong> – </li>
-<li><strong>count</strong> – </li>
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>domain</strong> &#8211; Name of the domain</li>
+<li><strong>rdt</strong> &#8211; </li>
+<li><strong>count</strong> &#8211; </li>
 </ul>
 </td>
 </tr>
@@ -997,18 +993,18 @@ retrieved</li>
 
 <dl class="function">
 <dt id="Stack.restore">
-<code class="descname">restore</code><span class="sig-paren">(</span><em>s</em>, <em>fname</em>, <em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.restore" title="Permalink to this definition">¶</a></dt>
+<code class="descname">restore</code><span class="sig-paren">(</span><em>s</em>, <em>fname</em>, <em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.restore" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Restore a previously-saved solution.</p>
 <p>This method can be used to provide an initial guess for the solution.</p>
 <p>See also: <a class="reference internal" href="#Stack.save" title="Stack.save"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">save()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>fname</strong> – File name of an XML file containing solution information</li>
-<li><strong>id</strong> – ID of the element that should be restored</li>
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>fname</strong> &#8211; File name of an XML file containing solution information</li>
+<li><strong>id</strong> &#8211; ID of the element that should be restored</li>
 </ul>
 </td>
 </tr>
@@ -1018,20 +1014,20 @@ retrieved</li>
 
 <dl class="function">
 <dt id="Stack.save">
-<code class="descname">save</code><span class="sig-paren">(</span><em>s</em>, <em>fname</em>, <em>id</em>, <em>desc</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.save" title="Permalink to this definition">¶</a></dt>
+<code class="descname">save</code><span class="sig-paren">(</span><em>s</em>, <em>fname</em>, <em>id</em>, <em>desc</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.save" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Save a solution to a file.</p>
 <p>The output file is in a format that
 can be used by <a class="reference internal" href="#Stack.restore" title="Stack.restore"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">restore()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>fname</strong> – File name where XML file should be written</li>
-<li><strong>id</strong> – ID to be assigned to the XML element when it is
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>fname</strong> &#8211; File name where XML file should be written</li>
+<li><strong>id</strong> &#8211; ID to be assigned to the XML element when it is
 written</li>
-<li><strong>desc</strong> – Description to be written to the output file</li>
+<li><strong>desc</strong> &#8211; Description to be written to the output file</li>
 </ul>
 </td>
 </tr>
@@ -1041,20 +1037,20 @@ written</li>
 
 <dl class="function">
 <dt id="Stack.saveSoln">
-<code class="descname">saveSoln</code><span class="sig-paren">(</span><em>s</em>, <em>fname</em>, <em>id</em>, <em>desc</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.saveSoln" title="Permalink to this definition">¶</a></dt>
+<code class="descname">saveSoln</code><span class="sig-paren">(</span><em>s</em>, <em>fname</em>, <em>id</em>, <em>desc</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.saveSoln" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Save a solution to a file.</p>
 <p>The output file is in a format that
 can be used by <a class="reference internal" href="#Stack.restore" title="Stack.restore"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">restore()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>fname</strong> – File name where XML file should be written</li>
-<li><strong>id</strong> – ID to be assigned to the XML element when it is
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>fname</strong> &#8211; File name where XML file should be written</li>
+<li><strong>id</strong> &#8211; ID to be assigned to the XML element when it is
 written</li>
-<li><strong>desc</strong> – Description to be written to the output file</li>
+<li><strong>desc</strong> &#8211; Description to be written to the output file</li>
 </ul>
 </td>
 </tr>
@@ -1064,17 +1060,17 @@ written</li>
 
 <dl class="function">
 <dt id="Stack.setFlatProfile">
-<code class="descname">setFlatProfile</code><span class="sig-paren">(</span><em>s</em>, <em>domain</em>, <em>comp</em>, <em>v</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setFlatProfile" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setFlatProfile</code><span class="sig-paren">(</span><em>s</em>, <em>domain</em>, <em>comp</em>, <em>v</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setFlatProfile" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set a component to a value across the entire domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>domain</strong> – Integer ID of the domain</li>
-<li><strong>comp</strong> – Component to be set</li>
-<li><strong>v</strong> – Double, value to be set</li>
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>domain</strong> &#8211; Integer ID of the domain</li>
+<li><strong>comp</strong> &#8211; Component to be set</li>
+<li><strong>v</strong> &#8211; Double, value to be set</li>
 </ul>
 </td>
 </tr>
@@ -1084,16 +1080,16 @@ written</li>
 
 <dl class="function">
 <dt id="Stack.setMaxJacAge">
-<code class="descname">setMaxJacAge</code><span class="sig-paren">(</span><em>s</em>, <em>ss_age</em>, <em>ts_age</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setMaxJacAge" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setMaxJacAge</code><span class="sig-paren">(</span><em>s</em>, <em>ss_age</em>, <em>ts_age</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setMaxJacAge" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the number of times the Jacobian will be used before it is recomputed.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>ss_age</strong> – Maximum age of the Jacobian for steady state analysis</li>
-<li><strong>ts_age</strong> – Maximum age of the Jacobian for transient analysis. If
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>ss_age</strong> &#8211; Maximum age of the Jacobian for steady state analysis</li>
+<li><strong>ts_age</strong> &#8211; Maximum age of the Jacobian for transient analysis. If
 not specified, defaults to <code class="docutils literal notranslate"><span class="pre">ss_age</span></code>.</li>
 </ul>
 </td>
@@ -1104,7 +1100,7 @@ not specified, defaults to <code class="docutils literal notranslate"><span clas
 
 <dl class="function">
 <dt id="Stack.setProfile">
-<code class="descname">setProfile</code><span class="sig-paren">(</span><em>s</em>, <em>name</em>, <em>comp</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setProfile" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setProfile</code><span class="sig-paren">(</span><em>s</em>, <em>name</em>, <em>comp</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setProfile" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specify a profile for one component.</p>
 <p>The solution vector values for this component will be linearly
 interpolated from the discrete function defined by p(:,1) vs. p(:,2).
@@ -1119,14 +1115,14 @@ usually used to set the initial guess for the solution.</p>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>name</strong> – Domain name</li>
-<li><strong>comp</strong> – component number</li>
-<li><strong>p</strong> – n x 2 array, whose columns are the relative (normalized) positions
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>name</strong> &#8211; Domain name</li>
+<li><strong>comp</strong> &#8211; component number</li>
+<li><strong>p</strong> &#8211; n x 2 array, whose columns are the relative (normalized) positions
 and the component values at those points. The number of positions
 <code class="docutils literal notranslate"><span class="pre">n</span></code> is arbitrary.</li>
 </ul>
@@ -1138,21 +1134,21 @@ and the component values at those points. The number of positions
 
 <dl class="function">
 <dt id="Stack.setRefineCriteria">
-<code class="descname">setRefineCriteria</code><span class="sig-paren">(</span><em>s</em>, <em>n</em>, <em>ratio</em>, <em>slope</em>, <em>curve</em>, <em>prune</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setRefineCriteria" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setRefineCriteria</code><span class="sig-paren">(</span><em>s</em>, <em>n</em>, <em>ratio</em>, <em>slope</em>, <em>curve</em>, <em>prune</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setRefineCriteria" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the criteria used to refine the grid.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>n</strong> – Domain number</li>
-<li><strong>ratio</strong> – Maximum size ratio between adjacent cells</li>
-<li><strong>slope</strong> – Maximum relative difference in value between
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>n</strong> &#8211; Domain number</li>
+<li><strong>ratio</strong> &#8211; Maximum size ratio between adjacent cells</li>
+<li><strong>slope</strong> &#8211; Maximum relative difference in value between
 adjacent points</li>
-<li><strong>curve</strong> – Maximum relative difference in slope between
+<li><strong>curve</strong> &#8211; Maximum relative difference in slope between
 adjacent cells</li>
-<li><strong>prune</strong> – Minimum value for slope or curve for which points
+<li><strong>prune</strong> &#8211; Minimum value for slope or curve for which points
 will be retained in the grid. If the computed
 slope or curve value is below prune for all
 components, it will be deleted, unless either
@@ -1166,15 +1162,15 @@ neighboring point is already marked for deletion.</li>
 
 <dl class="function">
 <dt id="Stack.setTimeStep">
-<code class="descname">setTimeStep</code><span class="sig-paren">(</span><em>s</em>, <em>stepsize</em>, <em>steps</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setTimeStep" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setTimeStep</code><span class="sig-paren">(</span><em>s</em>, <em>stepsize</em>, <em>steps</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setTimeStep" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Specify a sequence of time steps.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>stepsize</strong> – Initial step size (s)</li>
-<li><strong>steps</strong> – Vector of number of steps to take before
+<li><strong>stepsize</strong> &#8211; Initial step size (s)</li>
+<li><strong>steps</strong> &#8211; Vector of number of steps to take before
 re-attempting solution of steady-state problem. For
 example, steps = [1, 2, 5, 10] would cause one time
 step to be taken first the the steady-state
@@ -1189,7 +1185,7 @@ would be taken, etc.</li>
 
 <dl class="function">
 <dt id="Stack.setValue">
-<code class="descname">setValue</code><span class="sig-paren">(</span><em>s</em>, <em>n</em>, <em>comp</em>, <em>localPoint</em>, <em>v</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setValue" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setValue</code><span class="sig-paren">(</span><em>s</em>, <em>n</em>, <em>comp</em>, <em>localPoint</em>, <em>v</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.setValue" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the value of a single entry in the solution vector.</p>
 <p>Example (assuming <code class="docutils literal notranslate"><span class="pre">s</span></code> is an instance of <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a>):</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">setValue</span><span class="p">(</span><span class="n">s</span><span class="p">,</span> <span class="mi">3</span><span class="p">,</span> <span class="mi">5</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mf">5.6</span><span class="p">)</span>
@@ -1201,15 +1197,15 @@ at the left of each domain, independent of the global index of
 the point, which depends on the location of this domain in the
 stack.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>n</strong> – Domain number</li>
-<li><strong>comp</strong> – Component number</li>
-<li><strong>localPoint</strong> – Local index of the grid point in the domain</li>
-<li><strong>v</strong> – Value</li>
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>n</strong> &#8211; Domain number</li>
+<li><strong>comp</strong> &#8211; Component number</li>
+<li><strong>localPoint</strong> &#8211; Local index of the grid point in the domain</li>
+<li><strong>v</strong> &#8211; Value</li>
 </ul>
 </td>
 </tr>
@@ -1219,16 +1215,16 @@ stack.</p>
 
 <dl class="function">
 <dt id="Stack.solution">
-<code class="descname">solution</code><span class="sig-paren">(</span><em>s</em>, <em>domain</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.solution" title="Permalink to this definition">¶</a></dt>
+<code class="descname">solution</code><span class="sig-paren">(</span><em>s</em>, <em>domain</em>, <em>component</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.solution" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get a solution component in one domain.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>domain</strong> – String, name of the domain from which the solution is desired</li>
-<li><strong>component</strong> – String, component for which the solution is desired. If omitted,
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>domain</strong> &#8211; String, name of the domain from which the solution is desired</li>
+<li><strong>component</strong> &#8211; String, component for which the solution is desired. If omitted,
 solutions for all of the components will be returned in an
 <code class="xref mat mat-func docutils literal notranslate"><span class="pre">nPoints()</span></code> x <code class="xref mat mat-func docutils literal notranslate"><span class="pre">nComponents()</span></code> array.</li>
 </ul>
@@ -1244,18 +1240,18 @@ solutions for all of the components will be returned in an
 
 <dl class="function">
 <dt id="Stack.solve">
-<code class="descname">solve</code><span class="sig-paren">(</span><em>s</em>, <em>loglevel</em>, <em>refine_grid</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.solve" title="Permalink to this definition">¶</a></dt>
+<code class="descname">solve</code><span class="sig-paren">(</span><em>s</em>, <em>loglevel</em>, <em>refine_grid</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.solve" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Solve the problem.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
-<li><strong>loglevel</strong> – Integer flag controlling the amount of diagnostic
+<li><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></li>
+<li><strong>loglevel</strong> &#8211; Integer flag controlling the amount of diagnostic
 output. Zero supresses all output, and 5 produces
 very verbose output.</li>
-<li><strong>refine_grid</strong> – Integer, 1 to allow grid refinement, 0 to disallow.</li>
+<li><strong>refine_grid</strong> &#8211; Integer, 1 to allow grid refinement, 0 to disallow.</li>
 </ul>
 </td>
 </tr>
@@ -1265,16 +1261,16 @@ very verbose output.</li>
 
 <dl class="function">
 <dt id="Stack.writeStats">
-<code class="descname">writeStats</code><span class="sig-paren">(</span><em>s</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.writeStats" title="Permalink to this definition">¶</a></dt>
+<code class="descname">writeStats</code><span class="sig-paren">(</span><em>s</em><span class="sig-paren">)</span><a class="headerlink" href="#Stack.writeStats" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Print statistics for the current solution.</p>
 <p>Prints a summary of the number of function and
 Jacobian evaluations for each grid, and the CPU time spent on
 each one.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>s</strong> – Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>s</strong> &#8211; Instance of class <a class="reference internal" href="#Stack" title="Stack"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Stack()</span></code></a></td>
 </tr>
 </tbody>
 </table>
@@ -1304,7 +1300,7 @@ each one.</p>
 <h3>Related Topics</h3>
 <ul>
   <li><a href="../index.html">Documentation overview</a><ul>
-  <li><a href="index.html">Matlab Interface User’s Guide</a><ul>
+  <li><a href="index.html">Matlab Interface User&#8217;s Guide</a><ul>
       <li>Previous: <a href="zero-dim.html" title="previous chapter">Zero-Dimensional Reactor Networks</a></li>
       <li>Next: <a href="data.html" title="next chapter">Physical Constants</a></li>
   </ul></li>
@@ -1314,25 +1310,24 @@ each one.</p>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/matlab/one-dim.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/matlab/one-dim.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -1341,15 +1336,14 @@ each one.</p>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/matlab/one-dim.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/matlab/one-dim.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/matlab/one-dim.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/one-dim.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/matlab/thermodynamics.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/thermodynamics.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Thermodynamic Properties | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,18 +77,18 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="thermodynamic-properties">
-<h1>Thermodynamic Properties<a class="headerlink" href="#thermodynamic-properties" title="Permalink to this headline">¶</a></h1>
+<h1>Thermodynamic Properties<a class="headerlink" href="#thermodynamic-properties" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="thermophase">
-<h2>ThermoPhase<a class="headerlink" href="#thermophase" title="Permalink to this headline">¶</a></h2>
+<h2>ThermoPhase<a class="headerlink" href="#thermophase" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="ThermoPhase">
-<em class="property">class </em><code class="descname">ThermoPhase</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">ThermoPhase</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>ThermoPhase class constructor.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – If <code class="docutils literal notranslate"><span class="pre">r</span></code> is an instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a>,
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; If <code class="docutils literal notranslate"><span class="pre">r</span></code> is an instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a>,
 a copy of the instance is returned. Otherwise, <code class="docutils literal notranslate"><span class="pre">r</span></code> must
 be an instance of class <a class="reference internal" href="utilities.html#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a>.</td>
 </tr>
@@ -102,13 +98,13 @@ be an instance of class <a class="reference internal" href="utilities.html#XML_N
 </table>
 <dl class="function">
 <dt id="ThermoPhase.atomicMasses">
-<code class="descname">atomicMasses</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.atomicMasses" title="Permalink to this definition">¶</a></dt>
+<code class="descname">atomicMasses</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.atomicMasses" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the atomic masses of the elements.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase).</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of element atomic masses. Units: kg/kmol</td>
@@ -119,23 +115,23 @@ object that derives from ThermoPhase).</td>
 
 <dl class="function">
 <dt id="ThermoPhase.chemPotentials">
-<code class="descname">chemPotentials</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.chemPotentials" title="Permalink to this definition">¶</a></dt>
+<code class="descname">chemPotentials</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.chemPotentials" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the chemical potentials of the species.</p>
 <p>The expressions used to compute the chemical potential
 depend on the model implemented by the underlying kernel
 thermo manager.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase).</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of species chemical potentials. Units: J/kmol<blockquote>
 <div>This method returns an array containing the species
 chemical potentials [J/kmol]. The expressions used to
 compute these depend on the model implemented by the
-underlying kernel thermo manager.”“”</div></blockquote>
+underlying kernel thermo manager.&#8221;&#8220;&#8221;</div></blockquote>
 </td>
 </tr>
 </tbody>
@@ -144,13 +140,13 @@ underlying kernel thermo manager.”“”</div></blockquote>
 
 <dl class="function">
 <dt id="ThermoPhase.cp_R">
-<code class="descname">cp_R</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.cp_R" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp_R</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.cp_R" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the non-dimensional specific heats at constant pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of specific heats of the species at
@@ -162,13 +158,13 @@ constant pressure, non-dimensional basis</td>
 
 <dl class="function">
 <dt id="ThermoPhase.cp_mass">
-<code class="descname">cp_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.cp_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.cp_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass-basis specific heat at constant pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Molar basis specific heat of the mixture at
@@ -180,13 +176,13 @@ constant pressure. Units: J/kg-K</td>
 
 <dl class="function">
 <dt id="ThermoPhase.cp_mole">
-<code class="descname">cp_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.cp_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cp_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.cp_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the molar-basis specific heat at constant pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Molar basis specific heat of the mixture at
@@ -198,13 +194,13 @@ constant pressure. Units: J/kmol-K</td>
 
 <dl class="function">
 <dt id="ThermoPhase.critDensity">
-<code class="descname">critDensity</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.critDensity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critDensity</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.critDensity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the critical density.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Critical density. Units: kg/m**3</td>
@@ -215,13 +211,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.critPressure">
-<code class="descname">critPressure</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.critPressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critPressure</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.critPressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the critical pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Critical pressure. Units: Pa</td>
@@ -232,13 +228,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.critTemperature">
-<code class="descname">critTemperature</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.critTemperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">critTemperature</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.critTemperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the critical temperature.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Critical temperature. Units: K</td>
@@ -249,13 +245,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.cv_mass">
-<code class="descname">cv_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.cv_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.cv_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass-basis specific heat at constant volume.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Mass basis specific heat of the mixture at
@@ -267,13 +263,13 @@ constant volume. Units: J/kg-K</td>
 
 <dl class="function">
 <dt id="ThermoPhase.cv_mole">
-<code class="descname">cv_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.cv_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cv_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.cv_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the molar-basis specific heat at constant volume.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Molar basis specific heat of the mixture at
@@ -285,13 +281,13 @@ constant volume. Units: J/kmol-K</td>
 
 <dl class="function">
 <dt id="ThermoPhase.density">
-<code class="descname">density</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.density" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.density" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the density.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Mass density. Units: kg/m**3</td>
@@ -302,13 +298,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.electricPotential">
-<code class="descname">electricPotential</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.electricPotential" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electricPotential</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.electricPotential" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the electric potential.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">The electric potential of the phase. Units: V</td>
@@ -319,7 +315,7 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.elementIndex">
-<code class="descname">elementIndex</code><span class="sig-paren">(</span><em>tp</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.elementIndex" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elementIndex</code><span class="sig-paren">(</span><em>tp</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.elementIndex" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the index of an element given its name.</p>
 <p>The index is an integer assigned to each element in sequence as it
 is read in from the input file.</p>
@@ -331,18 +327,18 @@ containing the indices.</p>
 returns 1 for the first element. In contrast, the corresponding
 method elementIndex in the Cantera C++ and Python interfaces
 returns 0 for the first element, 1 for the second one, etc.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">ic</span> <span class="o">=</span> <span class="n">elementIndex</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span> <span class="s1">&#39;C&#39;</span><span class="p">);</span>
-<span class="o">&gt;&gt;</span> <span class="n">ih</span> <span class="o">=</span> <span class="n">elementIndex</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span> <span class="s1">&#39;H&#39;</span><span class="p">);</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">ic</span> <span class="o">=</span> <span class="n">elementIndex</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span> <span class="s1">'C'</span><span class="p">);</span>
+<span class="o">&gt;&gt;</span> <span class="n">ih</span> <span class="o">=</span> <span class="n">elementIndex</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span> <span class="s1">'H'</span><span class="p">);</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</li>
-<li><strong>name</strong> – String or cell array of strings of elements to look up</li>
+<li><strong>name</strong> &#8211; String or cell array of strings of elements to look up</li>
 </ul>
 </td>
 </tr>
@@ -355,16 +351,16 @@ object that derives from ThermoPhase)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.elementName">
-<code class="descname">elementName</code><span class="sig-paren">(</span><em>tp</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.elementName" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elementName</code><span class="sig-paren">(</span><em>tp</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.elementName" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the name of an element given its index.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</li>
-<li><strong>m</strong> – Scalar or vector of integers of element indices</li>
+<li><strong>m</strong> &#8211; Scalar or vector of integers of element indices</li>
 </ul>
 </td>
 </tr>
@@ -380,17 +376,17 @@ the same shape containing the name strings.</p>
 
 <dl class="function">
 <dt id="ThermoPhase.elementalMassFraction">
-<code class="descname">elementalMassFraction</code><span class="sig-paren">(</span><em>tp</em>, <em>element</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.elementalMassFraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">elementalMassFraction</code><span class="sig-paren">(</span><em>tp</em>, <em>element</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.elementalMassFraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Determine the elemental mass fraction in gas object.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>tp</strong> – Object representing the gas, instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a>,
+<li><strong>tp</strong> &#8211; Object representing the gas, instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a>,
 and an ideal gas. The state of this object should be set to an
 estimate of the gas state before calling elementalMassFraction.</li>
-<li><strong>element</strong> – String representing the element name.</li>
+<li><strong>element</strong> &#8211; String representing the element name.</li>
 </ul>
 </td>
 </tr>
@@ -403,13 +399,13 @@ estimate of the gas state before calling elementalMassFraction.</li>
 
 <dl class="function">
 <dt id="ThermoPhase.enthalpies_RT">
-<code class="descname">enthalpies_RT</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.enthalpies_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpies_RT</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.enthalpies_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the non-dimensional enthalpies.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of standard-state species enthalpies
@@ -423,13 +419,13 @@ values are ideal gas enthalpies.</td>
 
 <dl class="function">
 <dt id="ThermoPhase.enthalpy_mass">
-<code class="descname">enthalpy_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.enthalpy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.enthalpy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass specific enthalpy.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Mass specific enthalpy of the mixture. Units: J/kg</td>
@@ -440,13 +436,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.enthalpy_mole">
-<code class="descname">enthalpy_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.enthalpy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.enthalpy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mole specific enthalpy.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Molar specific enthalpy of the mixture. Units: J/kmol</td>
@@ -457,13 +453,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.entropies_R">
-<code class="descname">entropies_R</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.entropies_R" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropies_R</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.entropies_R" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the non-dimensional entropy.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of species non-dimensional entropies.</td>
@@ -474,13 +470,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.entropy_mass">
-<code class="descname">entropy_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.entropy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropy_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.entropy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass specific entropy.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Mass specific entropy of the mixture. Units: J/kg-K</td>
@@ -491,13 +487,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.entropy_mole">
-<code class="descname">entropy_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.entropy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">entropy_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.entropy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mole specific entropy.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Molar specific entropy of the mixture. Units: J/kg</td>
@@ -508,13 +504,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.eosType">
-<code class="descname">eosType</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.eosType" title="Permalink to this definition">¶</a></dt>
+<code class="descname">eosType</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.eosType" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the type of the equation of state.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">An string identifying the equation of state.</td>
@@ -525,32 +521,32 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.equilibrate">
-<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>tp</em>, <em>xy</em>, <em>solver</em>, <em>rtol</em>, <em>maxsteps</em>, <em>maxiter</em>, <em>loglevel</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.equilibrate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">equilibrate</code><span class="sig-paren">(</span><em>tp</em>, <em>xy</em>, <em>solver</em>, <em>rtol</em>, <em>maxsteps</em>, <em>maxiter</em>, <em>loglevel</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.equilibrate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the phase to a state of chemical equilibrium.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>XY</strong> – A two-letter string, which must be one of the set
+<li><strong>XY</strong> &#8211; A two-letter string, which must be one of the set
 <code class="docutils literal notranslate"><span class="pre">['TP','TV','HP','SP','SV','UV','UP']</span></code>,
 indicating which pair of properties should be held constant.
 Not all of the properties to be held constant are available with
 all of the solvers.</li>
-<li><strong>solver</strong> – Specifies the equilibrium solver to use. If solver = 0, a fast
+<li><strong>solver</strong> &#8211; Specifies the equilibrium solver to use. If solver = 0, a fast
 solver using the element potential method will be used. If
 solver = 1, a slower but more robust Gibbs minimization solver
 will be used. If solver &gt;= 2, a version of the VCS algorithm will
 be used. If solver &lt; 0 or is unspecified, the fast solver
 will be tried first, then if it fails the Gibbs minimization solver
 will be tried.</li>
-<li><strong>rtol</strong> – The relative error tolerance.</li>
-<li><strong>maxsteps</strong> – Maximum number of steps in composition to take to find a
+<li><strong>rtol</strong> &#8211; The relative error tolerance.</li>
+<li><strong>maxsteps</strong> &#8211; Maximum number of steps in composition to take to find a
 converged solution.</li>
-<li><strong>maxiter</strong> – For the Gibbs minimization solver only, this specifies the number
-of ‘outer’ iterations on T or P when some property pair other than
+<li><strong>maxiter</strong> &#8211; For the Gibbs minimization solver only, this specifies the number
+of &#8216;outer&#8217; iterations on T or P when some property pair other than
 TP is specified.</li>
-<li><strong>loglevel</strong> – Set to a value &gt; 0 to write diagnostic output. Larger values
+<li><strong>loglevel</strong> &#8211; Set to a value &gt; 0 to write diagnostic output. Larger values
 generate more detailed information.</li>
 </ul>
 </td>
@@ -561,13 +557,13 @@ generate more detailed information.</li>
 
 <dl class="function">
 <dt id="ThermoPhase.gibbs_RT">
-<code class="descname">gibbs_RT</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.gibbs_RT" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs_RT</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.gibbs_RT" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the non-dimensional Gibbs function.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of non-dimensional Gibbs functions of the species.</td>
@@ -578,13 +574,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.gibbs_mass">
-<code class="descname">gibbs_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.gibbs_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.gibbs_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass specific Gibbs function.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Mass specific Gibbs function of the mixture. Units: J/kg</td>
@@ -595,13 +591,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.gibbs_mole">
-<code class="descname">gibbs_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.gibbs_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gibbs_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.gibbs_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mole specific Gibbs function.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Molar specific Gibbs function of the mixture. Units: J/kmol</td>
@@ -612,13 +608,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.intEnergy_mass">
-<code class="descname">intEnergy_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.intEnergy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">intEnergy_mass</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.intEnergy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass specific internal energy.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Mass specific internal energy of the mixture. Units: J/kg</td>
@@ -629,13 +625,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.intEnergy_mole">
-<code class="descname">intEnergy_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.intEnergy_mole" title="Permalink to this definition">¶</a></dt>
+<code class="descname">intEnergy_mole</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.intEnergy_mole" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mole specific internal energy.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Molar specific internal energy of the mixture. Units: J/kmol</td>
@@ -646,13 +642,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.isIdealGas">
-<code class="descname">isIdealGas</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.isIdealGas" title="Permalink to this definition">¶</a></dt>
+<code class="descname">isIdealGas</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.isIdealGas" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get a flag indicating whether the phase is an ideal gas.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">True (1) if the phase is an ideal gas or ideal gas
@@ -664,13 +660,13 @@ mixture, and false (0) otherwise.</td>
 
 <dl class="function">
 <dt id="ThermoPhase.isothermalCompressibility">
-<code class="descname">isothermalCompressibility</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.isothermalCompressibility" title="Permalink to this definition">¶</a></dt>
+<code class="descname">isothermalCompressibility</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.isothermalCompressibility" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the isothermal compressibility.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Isothermal Compressibility. Units: 1/Pa</td>
@@ -681,16 +677,16 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.massFraction">
-<code class="descname">massFraction</code><span class="sig-paren">(</span><em>tp</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.massFraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">massFraction</code><span class="sig-paren">(</span><em>tp</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.massFraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass fraction of a species.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</li>
-<li><strong>species</strong> – String or cell array of strings of species whose mass
+<li><strong>species</strong> &#8211; String or cell array of strings of species whose mass
 fraction is desired</li>
 </ul>
 </td>
@@ -704,13 +700,13 @@ fraction is desired</li>
 
 <dl class="function">
 <dt id="ThermoPhase.massFractions">
-<code class="descname">massFractions</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.massFractions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">massFractions</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.massFractions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass fractions of all species.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of species mass fractions for input phase. If
@@ -722,7 +718,7 @@ no output argument is specified, a bar plot is produced.</td>
 
 <dl class="function">
 <dt id="ThermoPhase.maxTemp">
-<code class="descname">maxTemp</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.maxTemp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">maxTemp</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.maxTemp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the maximum temperature of the parameter fits.</p>
 <p>The parameterizations used to represent the temperature-dependent
 species thermodynamic properties are generally only valid in some
@@ -730,10 +726,10 @@ finite temperature range, which may be different for each species
 in the phase.</p>
 <p>See also: <a class="reference internal" href="#ThermoPhase.minTemp" title="ThermoPhase.minTemp"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">minTemp()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of maximum temperatures of all species</td>
@@ -744,15 +740,15 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.meanMolecularWeight">
-<code class="descname">meanMolecularWeight</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.meanMolecularWeight" title="Permalink to this definition">¶</a></dt>
+<code class="descname">meanMolecularWeight</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.meanMolecularWeight" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mean molecular weight.</p>
 <p>The mean molecular weight is the mole-fraction-weighted sum of the
 molar masses of the individual species in the phase.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Scalar double mean molecular weight. Units: kg/kmol</td>
@@ -763,7 +759,7 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.minTemp">
-<code class="descname">minTemp</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.minTemp" title="Permalink to this definition">¶</a></dt>
+<code class="descname">minTemp</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.minTemp" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the minimum temperature of the parameter fits.</p>
 <p>The parameterizations used to represent the temperature-dependent
 species thermodynamic properties are generally only valid in some
@@ -771,10 +767,10 @@ finite temperature range, which may be different for each species
 in the phase.</p>
 <p>See also: <a class="reference internal" href="#ThermoPhase.maxTemp" title="ThermoPhase.maxTemp"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">maxTemp()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of minimum temperatures of all species</td>
@@ -785,13 +781,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.molarDensity">
-<code class="descname">molarDensity</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.molarDensity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">molarDensity</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.molarDensity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the molar density.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Molar density. Units: kmol/m^3</td>
@@ -802,16 +798,16 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.moleFraction">
-<code class="descname">moleFraction</code><span class="sig-paren">(</span><em>tp</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.moleFraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">moleFraction</code><span class="sig-paren">(</span><em>tp</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.moleFraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mole fraction of a species.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</li>
-<li><strong>species</strong> – String or cell array of strings of species whose mole
+<li><strong>species</strong> &#8211; String or cell array of strings of species whose mole
 fraction is desired</li>
 </ul>
 </td>
@@ -825,13 +821,13 @@ fraction is desired</li>
 
 <dl class="function">
 <dt id="ThermoPhase.moleFractions">
-<code class="descname">moleFractions</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.moleFractions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">moleFractions</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.moleFractions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mole fractions of all species.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of species mole fractions for input phase. If
@@ -843,13 +839,13 @@ no output argument is specified, a bar plot is produced.</td>
 
 <dl class="function">
 <dt id="ThermoPhase.molecularWeights">
-<code class="descname">molecularWeights</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.molecularWeights" title="Permalink to this definition">¶</a></dt>
+<code class="descname">molecularWeights</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.molecularWeights" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the molecular weights of the species.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vector of species molecular weights. Units: kg/kmol</td>
@@ -860,17 +856,17 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.nAtoms">
-<code class="descname">nAtoms</code><span class="sig-paren">(</span><em>tp</em>, <em>k</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.nAtoms" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nAtoms</code><span class="sig-paren">(</span><em>tp</em>, <em>k</em>, <em>m</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.nAtoms" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the number of atoms of an element in a species.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</li>
-<li><strong>k</strong> – String species name or integer species number</li>
-<li><strong>m</strong> – String element name or integer element number</li>
+<li><strong>k</strong> &#8211; String species name or integer species number</li>
+<li><strong>m</strong> &#8211; String element name or integer element number</li>
 </ul>
 </td>
 </tr>
@@ -883,13 +879,13 @@ object that derives from ThermoPhase)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.nElements">
-<code class="descname">nElements</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.nElements" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nElements</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.nElements" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the number of elements.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Number of elements in the phase.</td>
@@ -900,13 +896,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.nSpecies">
-<code class="descname">nSpecies</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.nSpecies" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nSpecies</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.nSpecies" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the number of species.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Number of species in the phase.</td>
@@ -917,13 +913,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.name">
-<code class="descname">name</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.name" title="Permalink to this definition">¶</a></dt>
+<code class="descname">name</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.name" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the name of the phase.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">String name of the input phase</td>
@@ -934,13 +930,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.pressure">
-<code class="descname">pressure</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.pressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">pressure</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.pressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Pressure. Units: Pa</td>
@@ -951,13 +947,13 @@ object that derives from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.refPressure">
-<code class="descname">refPressure</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.refPressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">refPressure</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.refPressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the reference pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Reference pressure in Pa. All standard-state
@@ -969,16 +965,16 @@ thermodynamic properties are for this pressure.</td>
 
 <dl class="function">
 <dt id="ThermoPhase.satPressure">
-<code class="descname">satPressure</code><span class="sig-paren">(</span><em>tp</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.satPressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">satPressure</code><span class="sig-paren">(</span><em>tp</em>, <em>T</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.satPressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the saturation pressure for a given temperature.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</li>
-<li><strong>T</strong> – Temperature Units: K</li>
+<li><strong>T</strong> &#8211; Temperature Units: K</li>
 </ul>
 </td>
 </tr>
@@ -991,16 +987,16 @@ object that derives from ThermoPhase)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.satTemperature">
-<code class="descname">satTemperature</code><span class="sig-paren">(</span><em>tp</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.satTemperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">satTemperature</code><span class="sig-paren">(</span><em>tp</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.satTemperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the saturation temperature for a given pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</li>
-<li><strong>p</strong> – Pressure. Units: Pa</li>
+<li><strong>p</strong> &#8211; Pressure. Units: Pa</li>
 </ul>
 </td>
 </tr>
@@ -1013,7 +1009,7 @@ object that derives from ThermoPhase)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.set">
-<code class="descname">set</code><span class="sig-paren">(</span><em>tp</em>, <em>varargin</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.set" title="Permalink to this definition">¶</a></dt>
+<code class="descname">set</code><span class="sig-paren">(</span><em>tp</em>, <em>varargin</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.set" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set properties of a phase.</p>
 <p>The properties that may be set are</p>
 <ul class="simple">
@@ -1038,13 +1034,13 @@ length equal to the number of species. Two properties may be
 specified in a single call to <a class="reference internal" href="#ThermoPhase.set" title="ThermoPhase.set"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">set()</span></code></a>, plus one of
 mass fractions or mole fractions.</p>
 <p>Examples:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">&#39;Temperature&#39;</span><span class="p">,</span><span class="mf">600.0</span><span class="p">);</span>
-<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">&#39;T&#39;</span><span class="p">,</span><span class="mf">600.0</span><span class="p">);</span>
-<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">&#39;T&#39;</span><span class="p">,</span><span class="mf">600.0</span><span class="p">,</span><span class="s1">&#39;P&#39;</span><span class="p">,</span><span class="mi">2</span><span class="o">*</span><span class="n">oneatm</span><span class="p">,</span><span class="s1">&#39;Y&#39;</span><span class="p">,</span><span class="n">massfracs</span><span class="p">);</span>
-<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">&#39;H&#39;</span><span class="p">,</span><span class="mf">0.5</span><span class="o">*</span><span class="n">enthalpy_mass</span><span class="p">(</span><span class="n">gas</span><span class="p">),</span><span class="s1">&#39;P&#39;</span><span class="p">,</span><span class="n">pressure</span><span class="p">(</span><span class="n">gas</span><span class="p">));</span>
-<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">&#39;S&#39;</span><span class="p">,</span><span class="n">entropy_mass</span><span class="p">(</span><span class="n">gas</span><span class="p">),</span><span class="s1">&#39;P&#39;</span><span class="p">,</span><span class="mf">0.5</span><span class="o">*</span><span class="n">pressure</span><span class="p">(</span><span class="n">gas</span><span class="p">));</span>
-<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">&#39;X&#39;</span><span class="p">,</span><span class="n">ones</span><span class="p">(</span><span class="n">nSpecies</span><span class="p">(</span><span class="n">gas</span><span class="p">),</span><span class="mi">1</span><span class="p">));</span>
-<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">&#39;T&#39;</span><span class="p">,</span><span class="mf">500.0</span><span class="p">,</span><span class="s1">&#39;Vapor&#39;</span><span class="p">,</span><span class="mf">0.8</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">'Temperature'</span><span class="p">,</span><span class="mf">600.0</span><span class="p">);</span>
+<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">'T'</span><span class="p">,</span><span class="mf">600.0</span><span class="p">);</span>
+<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">'T'</span><span class="p">,</span><span class="mf">600.0</span><span class="p">,</span><span class="s1">'P'</span><span class="p">,</span><span class="mi">2</span><span class="o">*</span><span class="n">oneatm</span><span class="p">,</span><span class="s1">'Y'</span><span class="p">,</span><span class="n">massfracs</span><span class="p">);</span>
+<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">'H'</span><span class="p">,</span><span class="mf">0.5</span><span class="o">*</span><span class="n">enthalpy_mass</span><span class="p">(</span><span class="n">gas</span><span class="p">),</span><span class="s1">'P'</span><span class="p">,</span><span class="n">pressure</span><span class="p">(</span><span class="n">gas</span><span class="p">));</span>
+<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">'S'</span><span class="p">,</span><span class="n">entropy_mass</span><span class="p">(</span><span class="n">gas</span><span class="p">),</span><span class="s1">'P'</span><span class="p">,</span><span class="mf">0.5</span><span class="o">*</span><span class="n">pressure</span><span class="p">(</span><span class="n">gas</span><span class="p">));</span>
+<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">'X'</span><span class="p">,</span><span class="n">ones</span><span class="p">(</span><span class="n">nSpecies</span><span class="p">(</span><span class="n">gas</span><span class="p">),</span><span class="mi">1</span><span class="p">));</span>
+<span class="o">&gt;&gt;</span> <span class="nb">set</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span><span class="s1">'T'</span><span class="p">,</span><span class="mf">500.0</span><span class="p">,</span><span class="s1">'Vapor'</span><span class="p">,</span><span class="mf">0.8</span><span class="p">)</span>
 </pre></div>
 </div>
 <p>Alternatively, individual methods to set properties may be
@@ -1054,13 +1050,13 @@ called (setTemperature, setMoleFractions, etc.)</p>
 <a class="reference internal" href="#ThermoPhase.setState_Psat" title="ThermoPhase.setState_Psat"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setState_Psat()</span></code></a>, <a class="reference internal" href="#ThermoPhase.setState_SP" title="ThermoPhase.setState_SP"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setState_SP()</span></code></a>, <a class="reference internal" href="#ThermoPhase.setState_SV" title="ThermoPhase.setState_SV"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setState_SV()</span></code></a>,
 <a class="reference internal" href="#ThermoPhase.setState_Tsat" title="ThermoPhase.setState_Tsat"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setState_Tsat()</span></code></a>, <a class="reference internal" href="#ThermoPhase.setState_UV" title="ThermoPhase.setState_UV"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setState_UV()</span></code></a>, <a class="reference internal" href="#ThermoPhase.setTemperature" title="ThermoPhase.setTemperature"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setTemperature()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 object that derives from ThermoPhase)</li>
-<li><strong>varargin</strong> – Comma separated list of <code class="docutils literal notranslate"><span class="pre">property,</span> <span class="pre">value</span></code> pairs to be set</li>
+<li><strong>varargin</strong> &#8211; Comma separated list of <code class="docutils literal notranslate"><span class="pre">property,</span> <span class="pre">value</span></code> pairs to be set</li>
 </ul>
 </td>
 </tr>
@@ -1070,16 +1066,16 @@ object that derives from ThermoPhase)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setDensity">
-<code class="descname">setDensity</code><span class="sig-paren">(</span><em>tp</em>, <em>rho</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setDensity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setDensity</code><span class="sig-paren">(</span><em>tp</em>, <em>rho</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setDensity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the density.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>rho</strong> – Density. Units: kg/m**3</li>
+<li><strong>rho</strong> &#8211; Density. Units: kg/m**3</li>
 </ul>
 </td>
 </tr>
@@ -1089,16 +1085,16 @@ class derived from ThermoPhase)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setElectricPotential">
-<code class="descname">setElectricPotential</code><span class="sig-paren">(</span><em>tp</em>, <em>phi</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setElectricPotential" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setElectricPotential</code><span class="sig-paren">(</span><em>tp</em>, <em>phi</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setElectricPotential" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the electric potential.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>phi</strong> – Electric potential. Units: V</li>
+<li><strong>phi</strong> &#8211; Electric potential. Units: V</li>
 </ul>
 </td>
 </tr>
@@ -1108,7 +1104,7 @@ class derived from ThermoPhase)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setMassFractions">
-<code class="descname">setMassFractions</code><span class="sig-paren">(</span><em>tp</em>, <em>y</em>, <em>norm</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setMassFractions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setMassFractions</code><span class="sig-paren">(</span><em>tp</em>, <em>y</em>, <em>norm</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setMassFractions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the species mass fractions.</p>
 <p>Note that calling <a class="reference internal" href="#ThermoPhase.setMassFractions" title="ThermoPhase.setMassFractions"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setMassFractions()</span></code></a> leaves the temperature and
 density unchanged, and therefore the pressure changes if the new
@@ -1118,17 +1114,17 @@ the pressure fixed, use method <a class="reference internal" href="#ThermoPhase.
 fractions and the pressure, or call <a class="reference internal" href="#ThermoPhase.setPressure" title="ThermoPhase.setPressure"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setPressure()</span></code></a>
 after calling <a class="reference internal" href="#ThermoPhase.setMassFractions" title="ThermoPhase.setMassFractions"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setMassFractions()</span></code></a>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>y</strong> – Vector of mass fractions whose length must be the same as
+<li><strong>y</strong> &#8211; Vector of mass fractions whose length must be the same as
 the number of species. Alternatively, a string in the format
 <code class="docutils literal notranslate"><span class="pre">'SPEC:Y,SPEC2:Y2'</span></code> that specifies the mass fraction of
 specific species.</li>
-<li><strong>norm</strong> – If <code class="docutils literal notranslate"><span class="pre">'nonorm'</span></code> is specified, <code class="docutils literal notranslate"><span class="pre">y</span></code> will be normalized. This only
+<li><strong>norm</strong> &#8211; If <code class="docutils literal notranslate"><span class="pre">'nonorm'</span></code> is specified, <code class="docutils literal notranslate"><span class="pre">y</span></code> will be normalized. This only
 works if <code class="docutils literal notranslate"><span class="pre">y</span></code> is a vector, not a string. Since unnormalized mass
 fractions can lead to unphysical results, <code class="docutils literal notranslate"><span class="pre">'nonorm'</span></code> should be
 used only in rare cases, such as computing partial
@@ -1142,7 +1138,7 @@ derivatives with respect to a species mass fraction.</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setMoleFractions">
-<code class="descname">setMoleFractions</code><span class="sig-paren">(</span><em>tp</em>, <em>x</em>, <em>norm</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setMoleFractions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setMoleFractions</code><span class="sig-paren">(</span><em>tp</em>, <em>x</em>, <em>norm</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setMoleFractions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the species mole fractions.</p>
 <p>Note that calling <a class="reference internal" href="#ThermoPhase.setMoleFractions" title="ThermoPhase.setMoleFractions"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setMoleFractions()</span></code></a> leaves the temperature and
 density unchanged, and therefore the pressure changes if the new
@@ -1152,17 +1148,17 @@ the pressure fixed, use method <a class="reference internal" href="#ThermoPhase.
 fractions and the pressure, or call <a class="reference internal" href="#ThermoPhase.setPressure" title="ThermoPhase.setPressure"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setPressure()</span></code></a>
 after calling <code class="xref mat mat-func docutils literal notranslate"><span class="pre">setmoleFractions()</span></code>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>y</strong> – Vector of mole fractions whose length must be the same as
+<li><strong>y</strong> &#8211; Vector of mole fractions whose length must be the same as
 the number of species. Alternatively, a string in the format
 <code class="docutils literal notranslate"><span class="pre">'SPEC:Y,SPEC2:Y2'</span></code> that specifies the mole fraction of
 specific species.</li>
-<li><strong>norm</strong> – If <code class="docutils literal notranslate"><span class="pre">'nonorm'</span></code> is specified, <code class="docutils literal notranslate"><span class="pre">y</span></code> will be normalized. This only
+<li><strong>norm</strong> &#8211; If <code class="docutils literal notranslate"><span class="pre">'nonorm'</span></code> is specified, <code class="docutils literal notranslate"><span class="pre">y</span></code> will be normalized. This only
 works if <code class="docutils literal notranslate"><span class="pre">y</span></code> is a vector, not a string. Since unnormalized mole
 fractions can lead to unphysical results, <code class="docutils literal notranslate"><span class="pre">'nonorm'</span></code> should be
 used only in rare cases, such as computing partial
@@ -1176,16 +1172,16 @@ derivatives with respect to a species mole fraction.</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setName">
-<code class="descname">setName</code><span class="sig-paren">(</span><em>tp</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setName" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setName</code><span class="sig-paren">(</span><em>tp</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setName" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the name of the phase.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>name</strong> – String, name of the phase</li>
+<li><strong>name</strong> &#8211; String, name of the phase</li>
 </ul>
 </td>
 </tr>
@@ -1195,18 +1191,18 @@ class derived from ThermoPhase)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setPressure">
-<code class="descname">setPressure</code><span class="sig-paren">(</span><em>tp</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setPressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setPressure</code><span class="sig-paren">(</span><em>tp</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setPressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the pressure.</p>
 <p>The pressure is set by changing the density holding the
 temperature and chemical composition fixed.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>p</strong> – Pressure. Units: Pa</li>
+<li><strong>p</strong> &#8211; Pressure. Units: Pa</li>
 </ul>
 </td>
 </tr>
@@ -1216,16 +1212,16 @@ class derived from ThermoPhase)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_HP">
-<code class="descname">setState_HP</code><span class="sig-paren">(</span><em>tp</em>, <em>hp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_HP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_HP</code><span class="sig-paren">(</span><em>tp</em>, <em>hp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_HP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the specific enthalpy and pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>hp</strong> – Vector of length 2 containing the desired values for the specific
+<li><strong>hp</strong> &#8211; Vector of length 2 containing the desired values for the specific
 enthalpy (J/kg) and pressure (Pa).</li>
 </ul>
 </td>
@@ -1236,16 +1232,16 @@ enthalpy (J/kg) and pressure (Pa).</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_PV">
-<code class="descname">setState_PV</code><span class="sig-paren">(</span><em>tp</em>, <em>pv</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_PV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_PV</code><span class="sig-paren">(</span><em>tp</em>, <em>pv</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_PV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the pressure and specific volume.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>pv</strong> – Vector of length 2 containing the desired values for the
+<li><strong>pv</strong> &#8211; Vector of length 2 containing the desired values for the
 pressure (Pa) and specific volume (m^3/kg).</li>
 </ul>
 </td>
@@ -1256,19 +1252,19 @@ pressure (Pa) and specific volume (m^3/kg).</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_Psat">
-<code class="descname">setState_Psat</code><span class="sig-paren">(</span><em>tp</em>, <em>px</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_Psat" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_Psat</code><span class="sig-paren">(</span><em>tp</em>, <em>px</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_Psat" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the fluid state using the given pressure and quality.</p>
 <p>The fluid state will be set to a saturated liquid-vapor state using the
 input pressure and vapor fraction (quality) as the independent,
 intensive variables.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>px</strong> – Vector of length 2 containing the desired values for the pressure (Pa)
+<li><strong>px</strong> &#8211; Vector of length 2 containing the desired values for the pressure (Pa)
 and the vapor fraction</li>
 </ul>
 </td>
@@ -1279,19 +1275,19 @@ and the vapor fraction</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_RP">
-<code class="descname">setState_RP</code><span class="sig-paren">(</span><em>tp</em>, <em>rp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_RP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_RP</code><span class="sig-paren">(</span><em>tp</em>, <em>rp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_RP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the density and pressure.</p>
 <p>The density is set first, then the pressure is set by
 changing the temperature holding the density and
 chemical composition fixed.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>rp</strong> – Vector of length 2 containing the desired values for the density (kg/m^3)
+<li><strong>rp</strong> &#8211; Vector of length 2 containing the desired values for the density (kg/m^3)
 and pressure (Pa)</li>
 </ul>
 </td>
@@ -1302,16 +1298,16 @@ and pressure (Pa)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_SH">
-<code class="descname">setState_SH</code><span class="sig-paren">(</span><em>tp</em>, <em>sh</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_SH" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_SH</code><span class="sig-paren">(</span><em>tp</em>, <em>sh</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_SH" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the specific entropy and specific enthalpy.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>sh</strong> – Vector of length 2 containing the desired values for the specific
+<li><strong>sh</strong> &#8211; Vector of length 2 containing the desired values for the specific
 entropy (J/kg/K) and specific enthalpy (J/kg).</li>
 </ul>
 </td>
@@ -1322,16 +1318,16 @@ entropy (J/kg/K) and specific enthalpy (J/kg).</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_SP">
-<code class="descname">setState_SP</code><span class="sig-paren">(</span><em>tp</em>, <em>sp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_SP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_SP</code><span class="sig-paren">(</span><em>tp</em>, <em>sp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_SP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the specific entropy and pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>sp</strong> – Vector of length 2 containing the desired values for the specific
+<li><strong>sp</strong> &#8211; Vector of length 2 containing the desired values for the specific
 entropy (J/kg-K) and pressure (Pa).</li>
 </ul>
 </td>
@@ -1342,16 +1338,16 @@ entropy (J/kg-K) and pressure (Pa).</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_ST">
-<code class="descname">setState_ST</code><span class="sig-paren">(</span><em>tp</em>, <em>st</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_ST" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_ST</code><span class="sig-paren">(</span><em>tp</em>, <em>st</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_ST" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the specific entropy and temperature.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>st</strong> – Vector of length 2 containing the desired values for the specific
+<li><strong>st</strong> &#8211; Vector of length 2 containing the desired values for the specific
 entropy (J/kg-K) and temperature (K).</li>
 </ul>
 </td>
@@ -1362,16 +1358,16 @@ entropy (J/kg-K) and temperature (K).</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_SV">
-<code class="descname">setState_SV</code><span class="sig-paren">(</span><em>tp</em>, <em>sv</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_SV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_SV</code><span class="sig-paren">(</span><em>tp</em>, <em>sv</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_SV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the specific entropy and specific volume.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>sv</strong> – Vector of length 2 containing the desired values for the specific
+<li><strong>sv</strong> &#8211; Vector of length 2 containing the desired values for the specific
 entropy (J/kg-K) and specific volume (m**3/kg).</li>
 </ul>
 </td>
@@ -1382,16 +1378,16 @@ entropy (J/kg-K) and specific volume (m**3/kg).</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_TH">
-<code class="descname">setState_TH</code><span class="sig-paren">(</span><em>tp</em>, <em>th</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_TH" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_TH</code><span class="sig-paren">(</span><em>tp</em>, <em>th</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_TH" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the temperature and specific enthalpy.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>th</strong> – Vector of length 2 containing the desired values for the
+<li><strong>th</strong> &#8211; Vector of length 2 containing the desired values for the
 temperature (K) and specific enthalpy (J/kg).</li>
 </ul>
 </td>
@@ -1402,16 +1398,16 @@ temperature (K) and specific enthalpy (J/kg).</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_TV">
-<code class="descname">setState_TV</code><span class="sig-paren">(</span><em>tp</em>, <em>tv</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_TV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_TV</code><span class="sig-paren">(</span><em>tp</em>, <em>tv</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_TV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the temperature and specific volume.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>tv</strong> – Vector of length 2 containing the desired values for the
+<li><strong>tv</strong> &#8211; Vector of length 2 containing the desired values for the
 temperature (K) and specific volume (m^3/kg).</li>
 </ul>
 </td>
@@ -1422,19 +1418,19 @@ temperature (K) and specific volume (m^3/kg).</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_Tsat">
-<code class="descname">setState_Tsat</code><span class="sig-paren">(</span><em>tp</em>, <em>tx</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_Tsat" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_Tsat</code><span class="sig-paren">(</span><em>tp</em>, <em>tx</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_Tsat" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the fluid state using the given temperature and quality.</p>
 <p>The fluid state will be set to a saturated liquid-vapor state using the
 input temperature and vapor fraction (quality) as the independent,
 intensive variables.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>tx</strong> – Vector of length 2 containing the desired values for the temperature (K)
+<li><strong>tx</strong> &#8211; Vector of length 2 containing the desired values for the temperature (K)
 and the vapor fraction (quality)</li>
 </ul>
 </td>
@@ -1445,16 +1441,16 @@ and the vapor fraction (quality)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_UP">
-<code class="descname">setState_UP</code><span class="sig-paren">(</span><em>tp</em>, <em>up</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_UP" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_UP</code><span class="sig-paren">(</span><em>tp</em>, <em>up</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_UP" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the specific internal energy and pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>up</strong> – Vector of length 2 containing the desired values for the specific
+<li><strong>up</strong> &#8211; Vector of length 2 containing the desired values for the specific
 internal energy (J/kg) and pressure (Pa).</li>
 </ul>
 </td>
@@ -1465,16 +1461,16 @@ internal energy (J/kg) and pressure (Pa).</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_UV">
-<code class="descname">setState_UV</code><span class="sig-paren">(</span><em>tp</em>, <em>uv</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_UV" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_UV</code><span class="sig-paren">(</span><em>tp</em>, <em>uv</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_UV" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the specific internal energy and specific volume.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>uv</strong> – Vector of length 2 containing
+<li><strong>uv</strong> &#8211; Vector of length 2 containing
 the desired values for the specific internal energy (J/kg) and
 specific volume (m**3/kg).</li>
 </ul>
@@ -1486,16 +1482,16 @@ specific volume (m**3/kg).</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_VH">
-<code class="descname">setState_VH</code><span class="sig-paren">(</span><em>tp</em>, <em>vh</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_VH" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_VH</code><span class="sig-paren">(</span><em>tp</em>, <em>vh</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_VH" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the specific volume and specific enthalpy.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>vh</strong> – Vector of length 2 containing the desired values for the specific
+<li><strong>vh</strong> &#8211; Vector of length 2 containing the desired values for the specific
 volume (m^3/kg) and specific enthalpy (J/kg).</li>
 </ul>
 </td>
@@ -1506,13 +1502,13 @@ volume (m^3/kg) and specific enthalpy (J/kg).</li>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_satLiquid">
-<code class="descname">setState_satLiquid</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_satLiquid" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_satLiquid</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_satLiquid" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the fluid to the saturated liquid state at the current temperature.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</td>
 </tr>
 </tbody>
@@ -1521,13 +1517,13 @@ class derived from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.setState_satVapor">
-<code class="descname">setState_satVapor</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_satVapor" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setState_satVapor</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setState_satVapor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the fluid to the saturated vapor state at the current temperature.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</td>
 </tr>
 </tbody>
@@ -1536,16 +1532,16 @@ class derived from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.setTemperature">
-<code class="descname">setTemperature</code><span class="sig-paren">(</span><em>tp</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setTemperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setTemperature</code><span class="sig-paren">(</span><em>tp</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.setTemperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the temperature.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>t</strong> – Temperature. Units: K</li>
+<li><strong>t</strong> &#8211; Temperature. Units: K</li>
 </ul>
 </td>
 </tr>
@@ -1555,7 +1551,7 @@ class derived from ThermoPhase)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.soundspeed">
-<code class="descname">soundspeed</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.soundspeed" title="Permalink to this definition">¶</a></dt>
+<code class="descname">soundspeed</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.soundspeed" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the speed of sound.</p>
 <p>If the phase is an ideal gas, the speed of sound
 is calculated by:</p>
@@ -1579,10 +1575,10 @@ and computing the change in pressure.</p>
 
 \]</div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">The speed of sound. Units: m/s</td>
@@ -1593,7 +1589,7 @@ class derived from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.speciesIndex">
-<code class="descname">speciesIndex</code><span class="sig-paren">(</span><em>tp</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.speciesIndex" title="Permalink to this definition">¶</a></dt>
+<code class="descname">speciesIndex</code><span class="sig-paren">(</span><em>tp</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.speciesIndex" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the index of a species given the name.</p>
 <p>The index is an integer assigned to each species in sequence as it
 is read in from the input file.</p>
@@ -1602,18 +1598,18 @@ returns 1 for the first species, 2 for the second, etc. In
 contrast, the corresponding method speciesIndex in the Cantera C++
 and Python interfaces returns 0 for the first species, 1 for the
 second one, etc.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">ich4</span> <span class="o">=</span> <span class="n">speciesIndex</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span> <span class="s1">&#39;CH4&#39;</span><span class="p">);</span>
-<span class="o">&gt;&gt;</span> <span class="n">iho2</span> <span class="o">=</span> <span class="n">speciesIndex</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span> <span class="s1">&#39;HO2&#39;</span><span class="p">);</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">ich4</span> <span class="o">=</span> <span class="n">speciesIndex</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span> <span class="s1">'CH4'</span><span class="p">);</span>
+<span class="o">&gt;&gt;</span> <span class="n">iho2</span> <span class="o">=</span> <span class="n">speciesIndex</span><span class="p">(</span><span class="n">gas</span><span class="p">,</span> <span class="s1">'HO2'</span><span class="p">);</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>name</strong> – If name is a single string, the return value will be a integer
+<li><strong>name</strong> &#8211; If name is a single string, the return value will be a integer
 containing the corresponding index. If it is an cell array of
 strings, the output will be an array of the same shape
 containing the indices.</li>
@@ -1629,16 +1625,16 @@ containing the indices.</li>
 
 <dl class="function">
 <dt id="ThermoPhase.speciesName">
-<code class="descname">speciesName</code><span class="sig-paren">(</span><em>tp</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.speciesName" title="Permalink to this definition">¶</a></dt>
+<code class="descname">speciesName</code><span class="sig-paren">(</span><em>tp</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.speciesName" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the name of a species given the index.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<li><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</li>
-<li><strong>k</strong> – Scalar or array of integer species numbers</li>
+<li><strong>k</strong> &#8211; Scalar or array of integer species numbers</li>
 </ul>
 </td>
 </tr>
@@ -1651,13 +1647,13 @@ class derived from ThermoPhase)</li>
 
 <dl class="function">
 <dt id="ThermoPhase.speciesNames">
-<code class="descname">speciesNames</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.speciesNames" title="Permalink to this definition">¶</a></dt>
+<code class="descname">speciesNames</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.speciesNames" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the species names.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Cell array of strings of all of the species names</td>
@@ -1668,13 +1664,13 @@ class derived from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.temperature">
-<code class="descname">temperature</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.temperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">temperature</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.temperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the temperature.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Temperature. Units: K</td>
@@ -1685,13 +1681,13 @@ class derived from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.thermalExpansionCoeff">
-<code class="descname">thermalExpansionCoeff</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.thermalExpansionCoeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermalExpansionCoeff</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.thermalExpansionCoeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the thermal expansion coefficient.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Thermal Expansion Coefficient. Units: 1/K</td>
@@ -1702,13 +1698,13 @@ class derived from ThermoPhase)</td>
 
 <dl class="function">
 <dt id="ThermoPhase.vaporFraction">
-<code class="descname">vaporFraction</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.vaporFraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">vaporFraction</code><span class="sig-paren">(</span><em>tp</em><span class="sig-paren">)</span><a class="headerlink" href="#ThermoPhase.vaporFraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the vapor fraction.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> – Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tp</strong> &#8211; Instance of class <a class="reference internal" href="#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a> (or another
 class derived from ThermoPhase)</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vapor fraction.</td>
@@ -1740,7 +1736,7 @@ class derived from ThermoPhase)</td>
 <h3>Related Topics</h3>
 <ul>
   <li><a href="../index.html">Documentation overview</a><ul>
-  <li><a href="index.html">Matlab Interface User’s Guide</a><ul>
+  <li><a href="index.html">Matlab Interface User&#8217;s Guide</a><ul>
       <li>Previous: <a href="importing.html" title="previous chapter">Objects Representing Phases</a></li>
       <li>Next: <a href="kinetics.html" title="next chapter">Chemical Kinetics</a></li>
   </ul></li>
@@ -1750,25 +1746,24 @@ class derived from ThermoPhase)</td>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/matlab/thermodynamics.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/matlab/thermodynamics.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -1777,15 +1772,14 @@ class derived from ThermoPhase)</td>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/matlab/thermodynamics.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/matlab/thermodynamics.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/matlab/thermodynamics.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/thermodynamics.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/matlab/transport.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/transport.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Transport Properties | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,12 +77,12 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="transport-properties">
-<h1>Transport Properties<a class="headerlink" href="#transport-properties" title="Permalink to this headline">¶</a></h1>
+<h1>Transport Properties<a class="headerlink" href="#transport-properties" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="transport">
-<h2>Transport<a class="headerlink" href="#transport" title="Permalink to this headline">¶</a></h2>
+<h2>Transport<a class="headerlink" href="#transport" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="Transport">
-<em class="property">class </em><code class="descname">Transport</code><span class="sig-paren">(</span><em>r</em>, <em>th</em>, <em>model</em>, <em>loglevel</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">Transport</code><span class="sig-paren">(</span><em>r</em>, <em>th</em>, <em>model</em>, <em>loglevel</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Transport class constructor.</p>
 <p>Create a new instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a>. One, three,
 or four arguments may be supplied. If one argument is given,
@@ -100,16 +96,16 @@ by the string <code class="docutils literal notranslate"><span class="pre">'defa
 <a class="reference internal" href="utilities.html#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a>. The fourth argument is
 the logging level desired.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>r</strong> – Either an instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> or an
+<li><strong>r</strong> &#8211; Either an instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> or an
 instance of class <a class="reference internal" href="utilities.html#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
-<li><strong>th</strong> – Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a></li>
-<li><strong>model</strong> – String indicating the transport model to use. Possible values
+<li><strong>th</strong> &#8211; Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a></li>
+<li><strong>model</strong> &#8211; String indicating the transport model to use. Possible values
 are <code class="docutils literal notranslate"><span class="pre">'default'</span></code>, <code class="docutils literal notranslate"><span class="pre">'Mix'</span></code>, and <code class="docutils literal notranslate"><span class="pre">'Multi'</span></code></li>
-<li><strong>loglevel</strong> – Level of diagnostic logging. Default if not specified is 4.</li>
+<li><strong>loglevel</strong> &#8211; Level of diagnostic logging. Default if not specified is 4.</li>
 </ul>
 </td>
 </tr>
@@ -120,13 +116,13 @@ are <code class="docutils literal notranslate"><span class="pre">'default'</span
 </table>
 <dl class="function">
 <dt id="Transport.binDiffCoeffs">
-<code class="descname">binDiffCoeffs</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.binDiffCoeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">binDiffCoeffs</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.binDiffCoeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the binary diffusion coefficents.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
 object derived from Transport)
 for which binary diffusion coefficients are desired.</td>
 </tr>
@@ -139,13 +135,13 @@ The matrix is symmetric: d(i,j) = d(j,i). Units: m**2/s</td>
 
 <dl class="function">
 <dt id="Transport.electricalConductivity">
-<code class="descname">electricalConductivity</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.electricalConductivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">electricalConductivity</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.electricalConductivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the electrical conductivity.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
 object derived from Transport)
 for which the electrical conductivity is desired.</td>
 </tr>
@@ -157,7 +153,7 @@ for which the electrical conductivity is desired.</td>
 
 <dl class="function">
 <dt id="Transport.mixDiffCoeffs">
-<code class="descname">mixDiffCoeffs</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.mixDiffCoeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mixDiffCoeffs</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.mixDiffCoeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mixture-averaged diffusion coefficients.</p>
 <p>Object <code class="docutils literal notranslate"><span class="pre">a</span></code> must belong to a class derived from
 Transport, and that was constructed by specifying the <code class="docutils literal notranslate"><span class="pre">'Mix'</span></code>
@@ -168,15 +164,15 @@ option. If <code class="docutils literal notranslate"><span class="pre">'Mix'</s
 <p>In this case, try method <a class="reference internal" href="#Transport.multiDiffCoeffs" title="Transport.multiDiffCoeffs"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">multiDiffCoeffs()</span></code></a>, or create a
 new gas mixture model that uses a mixture-averaged transport manager,
 for example:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">gas</span> <span class="o">=</span> <span class="n">GRI30</span><span class="p">(</span><span class="s1">&#39;Mix&#39;</span><span class="p">);</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">gas</span> <span class="o">=</span> <span class="n">GRI30</span><span class="p">(</span><span class="s1">'Mix'</span><span class="p">);</span>
 </pre></div>
 </div>
 <p>See also: <code class="xref mat mat-func docutils literal notranslate"><span class="pre">MultiDiffCoeffs()</span></code></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
 object derived from Transport)
 for which mixture-averaged diffusion coefficients are desired.</td>
 </tr>
@@ -189,7 +185,7 @@ coefficients. Units: m**2/s</td>
 
 <dl class="function">
 <dt id="Transport.multiDiffCoeffs">
-<code class="descname">multiDiffCoeffs</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.multiDiffCoeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">multiDiffCoeffs</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.multiDiffCoeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the multicomponent diffusion coefficients.</p>
 <p>Object <code class="docutils literal notranslate"><span class="pre">a</span></code> must belong to a class derived from
 Transport, and that was constructed by specifying the <code class="docutils literal notranslate"><span class="pre">'Multi'</span></code>
@@ -201,14 +197,14 @@ error message</p>
 <p>In this case, try method <a class="reference internal" href="#Transport.mixDiffCoeffs" title="Transport.mixDiffCoeffs"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">mixDiffCoeffs()</span></code></a>, or create a
 new gas mixture model that uses a mixture-averaged transport manager,
 for example:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">gas</span> <span class="o">=</span> <span class="n">GRI30</span><span class="p">(</span><span class="s1">&#39;Multi&#39;</span><span class="p">);</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">gas</span> <span class="o">=</span> <span class="n">GRI30</span><span class="p">(</span><span class="s1">'Multi'</span><span class="p">);</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
 object derived from Transport)
 for which multicomponent diffusion coefficients are desired.</td>
 </tr>
@@ -221,20 +217,20 @@ coefficients. Units: m**2/s</td>
 
 <dl class="function">
 <dt id="Transport.setParameters">
-<code class="descname">setParameters</code><span class="sig-paren">(</span><em>tr</em>, <em>type</em>, <em>k</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.setParameters" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setParameters</code><span class="sig-paren">(</span><em>tr</em>, <em>type</em>, <em>k</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.setParameters" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the parameters.</p>
 <p>Set parameters of the <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> instance.
 Not defined for all transport types.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tr</strong> – Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
+<li><strong>tr</strong> &#8211; Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
 object derived from Transport)</li>
-<li><strong>type</strong> – </li>
-<li><strong>k</strong> – </li>
-<li><strong>p</strong> – </li>
+<li><strong>type</strong> &#8211; </li>
+<li><strong>k</strong> &#8211; </li>
+<li><strong>p</strong> &#8211; </li>
 </ul>
 </td>
 </tr>
@@ -244,19 +240,19 @@ object derived from Transport)</li>
 
 <dl class="function">
 <dt id="Transport.setThermalConductivity">
-<code class="descname">setThermalConductivity</code><span class="sig-paren">(</span><em>tr</em>, <em>lam</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.setThermalConductivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setThermalConductivity</code><span class="sig-paren">(</span><em>tr</em>, <em>lam</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.setThermalConductivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the thermal conductivity.</p>
 <p>This method can only be used with transport models that
 support directly setting the value of the thermal
 conductivity.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>tr</strong> – Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
+<li><strong>tr</strong> &#8211; Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
 object derived from Transport)</li>
-<li><strong>lam</strong> – Thermal conductivity in W/(m-K)</li>
+<li><strong>lam</strong> &#8211; Thermal conductivity in W/(m-K)</li>
 </ul>
 </td>
 </tr>
@@ -266,13 +262,13 @@ object derived from Transport)</li>
 
 <dl class="function">
 <dt id="Transport.thermalConductivity">
-<code class="descname">thermalConductivity</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.thermalConductivity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermalConductivity</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.thermalConductivity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the thermal conductivity.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
 object derived from Transport)
 for which the thermal conductivity is desired.</td>
 </tr>
@@ -284,17 +280,17 @@ for which the thermal conductivity is desired.</td>
 
 <dl class="function">
 <dt id="Transport.thermalDiffCoeffs">
-<code class="descname">thermalDiffCoeffs</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.thermalDiffCoeffs" title="Permalink to this definition">¶</a></dt>
+<code class="descname">thermalDiffCoeffs</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.thermalDiffCoeffs" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the thermal diffusion coefficients.</p>
 <p>Object <code class="docutils literal notranslate"><span class="pre">a</span></code> must belong to a class derived from
 Transport, and that was constructed by specifying the <code class="docutils literal notranslate"><span class="pre">'Multi'</span></code>
 option. If <code class="docutils literal notranslate"><span class="pre">'Multi'</span></code> was not specified, the returned values will
 all be zero.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
 object derived from Transport)
 for which the thermal diffusion coefficients are desired.</td>
 </tr>
@@ -306,13 +302,13 @@ for which the thermal diffusion coefficients are desired.</td>
 
 <dl class="function">
 <dt id="Transport.viscosity">
-<code class="descname">viscosity</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.viscosity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">viscosity</code><span class="sig-paren">(</span><em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Transport.viscosity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the dynamic viscosity.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> – Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Transport" title="Transport"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Transport()</span></code></a> (or another
 object derived from Transport)
 for which the viscosity is desired.</td>
 </tr>
@@ -345,7 +341,7 @@ for which the viscosity is desired.</td>
 <h3>Related Topics</h3>
 <ul>
   <li><a href="../index.html">Documentation overview</a><ul>
-  <li><a href="index.html">Matlab Interface User’s Guide</a><ul>
+  <li><a href="index.html">Matlab Interface User&#8217;s Guide</a><ul>
       <li>Previous: <a href="kinetics.html" title="previous chapter">Chemical Kinetics</a></li>
       <li>Next: <a href="zero-dim.html" title="next chapter">Zero-Dimensional Reactor Networks</a></li>
   </ul></li>
@@ -355,25 +351,24 @@ for which the viscosity is desired.</td>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/matlab/transport.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/matlab/transport.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -382,15 +377,14 @@ for which the viscosity is desired.</td>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/matlab/transport.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/matlab/transport.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/matlab/transport.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/transport.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/matlab/utilities.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/utilities.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Utility Functions | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,21 +77,21 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="utility-functions">
-<h1>Utility Functions<a class="headerlink" href="#utility-functions" title="Permalink to this headline">¶</a></h1>
+<h1>Utility Functions<a class="headerlink" href="#utility-functions" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="utilities">
-<h2>Utilities<a class="headerlink" href="#utilities" title="Permalink to this headline">¶</a></h2>
+<h2>Utilities<a class="headerlink" href="#utilities" title="Permalink to this headline">&#182;</a></h2>
 <blockquote>
 <div><dl class="function">
 <dt id="adddir">
-<code class="descname">adddir</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#adddir" title="Permalink to this definition">¶</a></dt>
+<code class="descname">adddir</code><span class="sig-paren">(</span><em>d</em><span class="sig-paren">)</span><a class="headerlink" href="#adddir" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Add a directory to the search path.</p>
 <p>Adds directory <code class="docutils literal notranslate"><span class="pre">d</span></code> to the set of directories where Cantera looks for
 input and data files.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> – Path to add to the MATLAB search path.</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>d</strong> &#8211; Path to add to the MATLAB search path.</td>
 </tr>
 </tbody>
 </table>
@@ -103,30 +99,30 @@ input and data files.</p>
 
 <dl class="function">
 <dt id="ck2cti">
-<code class="descname">ck2cti</code><span class="sig-paren">(</span><em>infile</em>, <em>thermo</em>, <em>transport</em><span class="sig-paren">)</span><a class="headerlink" href="#ck2cti" title="Permalink to this definition">¶</a></dt>
+<code class="descname">ck2cti</code><span class="sig-paren">(</span><em>infile</em>, <em>thermo</em>, <em>transport</em><span class="sig-paren">)</span><a class="headerlink" href="#ck2cti" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Convert a CHEMKIN input file to Cantera format.</p>
 <p>Examples:</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">f</span> <span class="o">=</span> <span class="n">ck2cti</span><span class="p">(</span><span class="s1">&#39;chem.inp&#39;</span><span class="p">)</span>
-<span class="n">f</span> <span class="o">=</span> <span class="n">ck2cti</span><span class="p">(</span><span class="s1">&#39;chem.inp&#39;</span><span class="p">,</span> <span class="s1">&#39;therm.dat&#39;</span><span class="p">)</span>
-<span class="n">f</span> <span class="o">=</span> <span class="n">ck2cti</span><span class="p">(</span><span class="s1">&#39;chem.inp&#39;</span><span class="p">,</span> <span class="s1">&#39;therm.dat&#39;</span><span class="p">,</span> <span class="s1">&#39;tran.dat&#39;</span><span class="p">)</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">f</span> <span class="o">=</span> <span class="n">ck2cti</span><span class="p">(</span><span class="s1">'chem.inp'</span><span class="p">)</span>
+<span class="n">f</span> <span class="o">=</span> <span class="n">ck2cti</span><span class="p">(</span><span class="s1">'chem.inp'</span><span class="p">,</span> <span class="s1">'therm.dat'</span><span class="p">)</span>
+<span class="n">f</span> <span class="o">=</span> <span class="n">ck2cti</span><span class="p">(</span><span class="s1">'chem.inp'</span><span class="p">,</span> <span class="s1">'therm.dat'</span><span class="p">,</span> <span class="s1">'tran.dat'</span><span class="p">)</span>
 </pre></div>
 </div>
-<p>These 3 statements all create a Cantera input file ‘chem.cti.’ In
+<p>These 3 statements all create a Cantera input file &#8216;chem.cti.&#8217; In
 the first case, the CK-format file contains all required species
 thermo data, while in the second case some or all thermo data is
-read from file ‘therm.dat.’ In the third form, the input file
+read from file &#8216;therm.dat.&#8217; In the third form, the input file
 created will also contain transport property parameters. The
 function return value is a string containing the output file
 name.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>infile</strong> – Chemistry input file in CHEMKIN format. Required.</li>
-<li><strong>thermo</strong> – Thermodynamic input file in CHEMKIN format. Optional if
+<li><strong>infile</strong> &#8211; Chemistry input file in CHEMKIN format. Required.</li>
+<li><strong>thermo</strong> &#8211; Thermodynamic input file in CHEMKIN format. Optional if
 thermodynamic data is specified in the chemistry input file.</li>
-<li><strong>transport</strong> – Transport input file in CHEMKIN format. Optional.</li>
+<li><strong>transport</strong> &#8211; Transport input file in CHEMKIN format. Optional.</li>
 </ul>
 </td>
 </tr>
@@ -139,24 +135,24 @@ thermodynamic data is specified in the chemistry input file.</li>
 
 <dl class="function">
 <dt id="cleanup">
-<code class="descname">cleanup</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cleanup" title="Permalink to this definition">¶</a></dt>
+<code class="descname">cleanup</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#cleanup" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Delete all stored Cantera objects and reclaim memory.</p>
 </dd></dl>
 
 <dl class="function">
 <dt id="geterr">
-<code class="descname">geterr</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#geterr" title="Permalink to this definition">¶</a></dt>
+<code class="descname">geterr</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#geterr" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the error message from a Cantera error.</p>
 </dd></dl>
 
 <dl class="function">
 <dt id="getDataDirectories">
-<code class="descname">getDataDirectories</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#getDataDirectories" title="Permalink to this definition">¶</a></dt>
+<code class="descname">getDataDirectories</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#getDataDirectories" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get a cell array of the directories searched for data files.</p>
 <p>Get a cell array of the directories Cantera searches for data files</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Cell array with strings representing the data file search directories</td>
 </tr>
@@ -166,11 +162,11 @@ thermodynamic data is specified in the chemistry input file.</li>
 
 <dl class="function">
 <dt id="canteraVersion">
-<code class="descname">canteraVersion</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#canteraVersion" title="Permalink to this definition">¶</a></dt>
+<code class="descname">canteraVersion</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#canteraVersion" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get Cantera version information</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">A string containing the Cantera version</td>
 </tr>
@@ -180,11 +176,11 @@ thermodynamic data is specified in the chemistry input file.</li>
 
 <dl class="function">
 <dt id="canteraGitCommit">
-<code class="descname">canteraGitCommit</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#canteraGitCommit" title="Permalink to this definition">¶</a></dt>
+<code class="descname">canteraGitCommit</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#canteraGitCommit" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get Cantera Git commit hash</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">A string containing the Git commit hash for the current version of Cantera</td>
 </tr>
@@ -195,20 +191,20 @@ thermodynamic data is specified in the chemistry input file.</li>
 </div></blockquote>
 </div>
 <div class="section" id="xml-node">
-<h2>XML_Node<a class="headerlink" href="#xml-node" title="Permalink to this headline">¶</a></h2>
+<h2>XML_Node<a class="headerlink" href="#xml-node" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="XML_Node">
-<em class="property">class </em><code class="descname">XML_Node</code><span class="sig-paren">(</span><em>name</em>, <em>src</em>, <em>wrap</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">XML_Node</code><span class="sig-paren">(</span><em>name</em>, <em>src</em>, <em>wrap</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>XML_Node class constructor</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>name</strong> – String name of the XML_Node that should be created.</li>
-<li><strong>src</strong> – String XML file name from which an instance of XML_Node
+<li><strong>name</strong> &#8211; String name of the XML_Node that should be created.</li>
+<li><strong>src</strong> &#8211; String XML file name from which an instance of XML_Node
 should be created. Reads the XML tree from the input file.</li>
-<li><strong>wrap</strong> – Specify the ID of the XML_Node.</li>
+<li><strong>wrap</strong> &#8211; Specify the ID of the XML_Node.</li>
 </ul>
 </td>
 </tr>
@@ -219,16 +215,16 @@ should be created. Reads the XML tree from the input file.</li>
 </table>
 <dl class="function">
 <dt id="XML_Node.addChild">
-<code class="descname">addChild</code><span class="sig-paren">(</span><em>root</em>, <em>name</em>, <em>val</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.addChild" title="Permalink to this definition">¶</a></dt>
+<code class="descname">addChild</code><span class="sig-paren">(</span><em>root</em>, <em>name</em>, <em>val</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.addChild" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Add a child to the root.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>root</strong> – Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
-<li><strong>name</strong> – String ID of the child to be added.</li>
-<li><strong>val</strong> – String value to be added to the child.</li>
+<li><strong>root</strong> &#8211; Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
+<li><strong>name</strong> &#8211; String ID of the child to be added.</li>
+<li><strong>val</strong> &#8211; String value to be added to the child.</li>
 </ul>
 </td>
 </tr>
@@ -241,15 +237,15 @@ should be created. Reads the XML tree from the input file.</li>
 
 <dl class="function">
 <dt id="XML_Node.attrib">
-<code class="descname">attrib</code><span class="sig-paren">(</span><em>x</em>, <em>key</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.attrib" title="Permalink to this definition">¶</a></dt>
+<code class="descname">attrib</code><span class="sig-paren">(</span><em>x</em>, <em>key</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.attrib" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the XML_Node attribute with a given key.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>x</strong> – Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
-<li><strong>key</strong> – String key to look up.</li>
+<li><strong>x</strong> &#8211; Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
+<li><strong>key</strong> &#8211; String key to look up.</li>
 </ul>
 </td>
 </tr>
@@ -262,16 +258,16 @@ should be created. Reads the XML tree from the input file.</li>
 
 <dl class="function">
 <dt id="XML_Node.build">
-<code class="descname">build</code><span class="sig-paren">(</span><em>x</em>, <em>file</em>, <em>pre</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.build" title="Permalink to this definition">¶</a></dt>
+<code class="descname">build</code><span class="sig-paren">(</span><em>x</em>, <em>file</em>, <em>pre</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.build" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Build an XML_Node in memory from an input file.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>x</strong> – Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
-<li><strong>file</strong> – String input file name.</li>
-<li><strong>pre</strong> – Determine the method of building. If not specified or
+<li><strong>x</strong> &#8211; Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
+<li><strong>file</strong> &#8211; String input file name.</li>
+<li><strong>pre</strong> &#8211; Determine the method of building. If not specified or
 less than zero, use XML_Node::build. Otherwise, use
 XML_Node::get_XML_File.</li>
 </ul>
@@ -286,15 +282,15 @@ XML_Node::get_XML_File.</li>
 
 <dl class="function">
 <dt id="XML_Node.child">
-<code class="descname">child</code><span class="sig-paren">(</span><em>x</em>, <em>loc</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.child" title="Permalink to this definition">¶</a></dt>
+<code class="descname">child</code><span class="sig-paren">(</span><em>x</em>, <em>loc</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.child" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the child of an XML_Node instance.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>x</strong> – Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
-<li><strong>loc</strong> – String loc to search for.</li>
+<li><strong>x</strong> &#8211; Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
+<li><strong>loc</strong> &#8211; String loc to search for.</li>
 </ul>
 </td>
 </tr>
@@ -307,15 +303,15 @@ XML_Node::get_XML_File.</li>
 
 <dl class="function">
 <dt id="XML_Node.findByID">
-<code class="descname">findByID</code><span class="sig-paren">(</span><em>root</em>, <em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.findByID" title="Permalink to this definition">¶</a></dt>
+<code class="descname">findByID</code><span class="sig-paren">(</span><em>root</em>, <em>id</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.findByID" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get an XML element given its ID.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>root</strong> – Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
-<li><strong>id</strong> – String ID of the element to search for.</li>
+<li><strong>root</strong> &#8211; Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
+<li><strong>id</strong> &#8211; String ID of the element to search for.</li>
 </ul>
 </td>
 </tr>
@@ -328,15 +324,15 @@ XML_Node::get_XML_File.</li>
 
 <dl class="function">
 <dt id="XML_Node.findByName">
-<code class="descname">findByName</code><span class="sig-paren">(</span><em>root</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.findByName" title="Permalink to this definition">¶</a></dt>
+<code class="descname">findByName</code><span class="sig-paren">(</span><em>root</em>, <em>name</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.findByName" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get an XML element given its name.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>root</strong> – Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
-<li><strong>name</strong> – String name of the element to search for.</li>
+<li><strong>root</strong> &#8211; Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
+<li><strong>name</strong> &#8211; String name of the element to search for.</li>
 </ul>
 </td>
 </tr>
@@ -349,13 +345,13 @@ XML_Node::get_XML_File.</li>
 
 <dl class="function">
 <dt id="XML_Node.nChildren">
-<code class="descname">nChildren</code><span class="sig-paren">(</span><em>root</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.nChildren" title="Permalink to this definition">¶</a></dt>
+<code class="descname">nChildren</code><span class="sig-paren">(</span><em>root</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.nChildren" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the number of children of an XML_Node.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>root</strong> – Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>root</strong> &#8211; Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Integer number of children of the input XML_Node</td>
 </tr>
@@ -365,17 +361,17 @@ XML_Node::get_XML_File.</li>
 
 <dl class="function">
 <dt id="XML_Node.value">
-<code class="descname">value</code><span class="sig-paren">(</span><em>x</em>, <em>loc</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.value" title="Permalink to this definition">¶</a></dt>
+<code class="descname">value</code><span class="sig-paren">(</span><em>x</em>, <em>loc</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.value" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the value at a location in an XML_Node</p>
 <p>value(x) returns the value of the XML element.
 value(x, loc) is shorthand for value(child(x,loc))</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>x</strong> – Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
-<li><strong>loc</strong> – </li>
+<li><strong>x</strong> &#8211; Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
+<li><strong>loc</strong> &#8211; </li>
 </ul>
 </td>
 </tr>
@@ -388,15 +384,15 @@ value(x, loc) is shorthand for value(child(x,loc))</p>
 
 <dl class="function">
 <dt id="XML_Node.write">
-<code class="descname">write</code><span class="sig-paren">(</span><em>x</em>, <em>file</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.write" title="Permalink to this definition">¶</a></dt>
+<code class="descname">write</code><span class="sig-paren">(</span><em>x</em>, <em>file</em><span class="sig-paren">)</span><a class="headerlink" href="#XML_Node.write" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Write XML_Node to file.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>x</strong> – Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
-<li><strong>file</strong> – Name of the output file to be written.</li>
+<li><strong>x</strong> &#8211; Instance of class <a class="reference internal" href="#XML_Node" title="XML_Node"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">XML_Node()</span></code></a></li>
+<li><strong>file</strong> &#8211; Name of the output file to be written.</li>
 </ul>
 </td>
 </tr>
@@ -431,7 +427,7 @@ value(x, loc) is shorthand for value(child(x,loc))</p>
 <h3>Related Topics</h3>
 <ul>
   <li><a href="../index.html">Documentation overview</a><ul>
-  <li><a href="index.html">Matlab Interface User’s Guide</a><ul>
+  <li><a href="index.html">Matlab Interface User&#8217;s Guide</a><ul>
       <li>Previous: <a href="data.html" title="previous chapter">Physical Constants</a></li>
   </ul></li>
   </ul></li>
@@ -440,25 +436,24 @@ value(x, loc) is shorthand for value(child(x,loc))</p>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/matlab/utilities.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/matlab/utilities.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -467,15 +462,14 @@ value(x, loc) is shorthand for value(child(x,loc))</p>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/matlab/utilities.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/matlab/utilities.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/matlab/utilities.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/utilities.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/matlab/zero-dim.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/zero-dim.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Zero-Dimensional Reactor Networks | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="../_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="../search.html" />
+    <link rel="search" title="Search" href="../search.html">
   </head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
@@ -81,12 +77,12 @@ lang="en">
                 <div class="body" role="main">
 
   <div class="section" id="zero-dimensional-reactor-networks">
-<h1>Zero-Dimensional Reactor Networks<a class="headerlink" href="#zero-dimensional-reactor-networks" title="Permalink to this headline">¶</a></h1>
+<h1>Zero-Dimensional Reactor Networks<a class="headerlink" href="#zero-dimensional-reactor-networks" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="func">
-<h2>Func<a class="headerlink" href="#func" title="Permalink to this headline">¶</a></h2>
+<h2>Func<a class="headerlink" href="#func" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="Func">
-<em class="property">class </em><code class="descname">Func</code><span class="sig-paren">(</span><em>typ</em>, <em>n</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Func" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">Func</code><span class="sig-paren">(</span><em>typ</em>, <em>n</em>, <em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Func" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Func class constructor.</p>
 <p>A class for functors.
 A functor is an object that behaves like a function. Cantera
@@ -110,15 +106,15 @@ return value would of course be 3.</p>
 <p>You can also create composite functors by adding, multiplying, or
 dividing these basic functors, or other composite functors.</p>
 <p>Note: this MATLAB class shadows the underlying C++ Cantera class
-“Func1”. See the Cantera C++ documentation for more details.</p>
+&#8220;Func1&#8221;. See the Cantera C++ documentation for more details.</p>
 <p>See also: <a class="reference internal" href="#Func.polynom" title="Func.polynom"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">polynom()</span></code></a>, <a class="reference internal" href="#Func.gaussian" title="Func.gaussian"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">gaussian()</span></code></a>, <a class="reference internal" href="#Func.plus" title="Func.plus"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">plus()</span></code></a>,
 <a class="reference internal" href="#Func.rdivide" title="Func.rdivide"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">rdivide()</span></code></a>, <a class="reference internal" href="#Func.times" title="Func.times"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">times()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>typ</strong> – <p>String indicating type of functor to create. Possible values are:</p>
+<li><strong>typ</strong> &#8211; <p>String indicating type of functor to create. Possible values are:</p>
 <ul>
 <li><code class="docutils literal notranslate"><span class="pre">'polynomial'</span></code></li>
 <li><code class="docutils literal notranslate"><span class="pre">'fourier'</span></code></li>
@@ -131,8 +127,8 @@ dividing these basic functors, or other composite functors.</p>
 <li><code class="docutils literal notranslate"><span class="pre">'periodic'</span></code></li>
 </ul>
 </li>
-<li><strong>n</strong> – Number of parameters required for the functor</li>
-<li><strong>p</strong> – Vector of parameters</li>
+<li><strong>n</strong> &#8211; Number of parameters required for the functor</li>
+<li><strong>p</strong> &#8211; Vector of parameters</li>
 </ul>
 </td>
 </tr>
@@ -143,13 +139,13 @@ dividing these basic functors, or other composite functors.</p>
 </table>
 <dl class="function">
 <dt id="Func.char">
-<code class="descname">char</code><span class="sig-paren">(</span><em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.char" title="Permalink to this definition">¶</a></dt>
+<code class="descname">char</code><span class="sig-paren">(</span><em>p</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.char" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the formatted string to display the function.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>p</strong> – Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>p</strong> &#8211; Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Formatted string displaying the function</td>
 </tr>
@@ -159,16 +155,16 @@ dividing these basic functors, or other composite functors.</p>
 
 <dl class="function">
 <dt id="Func.gaussian">
-<code class="descname">gaussian</code><span class="sig-paren">(</span><em>peak</em>, <em>center</em>, <em>width</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.gaussian" title="Permalink to this definition">¶</a></dt>
+<code class="descname">gaussian</code><span class="sig-paren">(</span><em>peak</em>, <em>center</em>, <em>width</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.gaussian" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a Gaussian <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a> instance.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>peak</strong> – The peak value</li>
-<li><strong>center</strong> – Value of x at which the peak is located</li>
-<li><strong>width</strong> – Full width at half-maximum. The value of the
+<li><strong>peak</strong> &#8211; The peak value</li>
+<li><strong>center</strong> &#8211; Value of x at which the peak is located</li>
+<li><strong>width</strong> &#8211; Full width at half-maximum. The value of the
 function at center +/- (width)/2 is one-half
 the peak value.</li>
 </ul>
@@ -180,15 +176,15 @@ the peak value.</li>
 
 <dl class="function">
 <dt id="Func.plus">
-<code class="descname">plus</code><span class="sig-paren">(</span><em>a</em>, <em>b</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.plus" title="Permalink to this definition">¶</a></dt>
+<code class="descname">plus</code><span class="sig-paren">(</span><em>a</em>, <em>b</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.plus" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get a functor representing the sum of two input functors.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>a</strong> – Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
-<li><strong>b</strong> – Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
+<li><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
+<li><strong>b</strong> &#8211; Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
 </ul>
 </td>
 </tr>
@@ -203,7 +199,7 @@ and b.</p>
 
 <dl class="function">
 <dt id="Func.polynom">
-<code class="descname">polynom</code><span class="sig-paren">(</span><em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.polynom" title="Permalink to this definition">¶</a></dt>
+<code class="descname">polynom</code><span class="sig-paren">(</span><em>coeffs</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.polynom" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a polynomial <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a> instance.</p>
 <p>The polynomial coefficients are specified by a vector
 <code class="docutils literal notranslate"><span class="pre">[a0</span> <span class="pre">a1</span> <span class="pre">....</span> <span class="pre">aN]</span></code>. Examples:</p>
@@ -212,10 +208,10 @@ and b.</p>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>coeffs</strong> – Vector of polynomial coefficients</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>coeffs</strong> &#8211; Vector of polynomial coefficients</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></td>
 </tr>
@@ -225,15 +221,15 @@ and b.</p>
 
 <dl class="function">
 <dt id="Func.rdivide">
-<code class="descname">rdivide</code><span class="sig-paren">(</span><em>a</em>, <em>b</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.rdivide" title="Permalink to this definition">¶</a></dt>
+<code class="descname">rdivide</code><span class="sig-paren">(</span><em>a</em>, <em>b</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.rdivide" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get a functor that is the ratio of the input functors.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>a</strong> – Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
-<li><strong>b</strong> – Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
+<li><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
+<li><strong>b</strong> &#8211; Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
 </ul>
 </td>
 </tr>
@@ -246,15 +242,15 @@ and b.</p>
 
 <dl class="function">
 <dt id="Func.times">
-<code class="descname">times</code><span class="sig-paren">(</span><em>a</em>, <em>b</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.times" title="Permalink to this definition">¶</a></dt>
+<code class="descname">times</code><span class="sig-paren">(</span><em>a</em>, <em>b</em><span class="sig-paren">)</span><a class="headerlink" href="#Func.times" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a functor that multiplies two other functors.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>a</strong> – Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
-<li><strong>b</strong> – Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
+<li><strong>a</strong> &#8211; Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
+<li><strong>b</strong> &#8211; Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
 </ul>
 </td>
 </tr>
@@ -269,10 +265,10 @@ and b.</p>
 
 </div>
 <div class="section" id="reactor">
-<h2>Reactor<a class="headerlink" href="#reactor" title="Permalink to this headline">¶</a></h2>
+<h2>Reactor<a class="headerlink" href="#reactor" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="Reactor">
-<em class="property">class </em><code class="descname">Reactor</code><span class="sig-paren">(</span><em>contents</em>, <em>typ</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">Reactor</code><span class="sig-paren">(</span><em>contents</em>, <em>typ</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Reactor class constructor.</p>
 <p>A <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> object simulates a perfectly-stirred reactor.
 It has a time-dependent state, and may be coupled to other reactors
@@ -285,13 +281,13 @@ contract and/or conduct heat.</p>
 <p>See also: <a class="reference internal" href="#Reactor.Reservoir" title="Reactor.Reservoir"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reservoir()</span></code></a>, <a class="reference internal" href="#Reactor.IdealGasReactor" title="Reactor.IdealGasReactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">IdealGasReactor()</span></code></a>,
 <a class="reference internal" href="#Reactor.IdealGasConstPressureReactor" title="Reactor.IdealGasConstPressureReactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">IdealGasConstPressureReactor()</span></code></a>, <a class="reference internal" href="#Reactor.ConstPressureReactor" title="Reactor.ConstPressureReactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ConstPressureReactor()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>contents</strong> – Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> representing the contents of the
+<li><strong>contents</strong> &#8211; Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> representing the contents of the
 reactor</li>
-<li><strong>typ</strong> – <p>Integer, reactor type. Options are:</p>
+<li><strong>typ</strong> &#8211; <p>Integer, reactor type. Options are:</p>
 <ol class="arabic">
 <li>Reservoir</li>
 <li>Reactor</li>
@@ -311,7 +307,7 @@ reactor</li>
 </table>
 <dl class="function">
 <dt id="Reactor.ConstPressureReactor">
-<code class="descname">ConstPressureReactor</code><span class="sig-paren">(</span><em>contents</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.ConstPressureReactor" title="Permalink to this definition">¶</a></dt>
+<code class="descname">ConstPressureReactor</code><span class="sig-paren">(</span><em>contents</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.ConstPressureReactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a constant pressure reactor object.</p>
 <p>A <a class="reference internal" href="#Reactor.ConstPressureReactor" title="Reactor.ConstPressureReactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ConstPressureReactor()</span></code></a> is an instance of class
 <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> where the pressure is held constant. The volume
@@ -323,10 +319,10 @@ consistent with holding the pressure constant. Examples:</p>
 </div>
 <p>See also: <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>contents</strong> – Cantera <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be set as the contents of the
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>contents</strong> &#8211; Cantera <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be set as the contents of the
 reactor</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
@@ -337,7 +333,7 @@ reactor</td>
 
 <dl class="function">
 <dt id="Reactor.FlowReactor">
-<code class="descname">FlowReactor</code><span class="sig-paren">(</span><em>contents</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.FlowReactor" title="Permalink to this definition">¶</a></dt>
+<code class="descname">FlowReactor</code><span class="sig-paren">(</span><em>contents</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.FlowReactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a flow reactor object.</p>
 <p>A reactor representing adiabatic plug flow in a constant-area
 duct. Examples:</p>
@@ -347,10 +343,10 @@ duct. Examples:</p>
 </div>
 <p>See also: <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>contents</strong> – Cantera <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be set as the contents of the
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>contents</strong> &#8211; Cantera <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be set as the contents of the
 reactor</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
@@ -361,7 +357,7 @@ reactor</td>
 
 <dl class="function">
 <dt id="Reactor.IdealGasConstPressureReactor">
-<code class="descname">IdealGasConstPressureReactor</code><span class="sig-paren">(</span><em>contents</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.IdealGasConstPressureReactor" title="Permalink to this definition">¶</a></dt>
+<code class="descname">IdealGasConstPressureReactor</code><span class="sig-paren">(</span><em>contents</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.IdealGasConstPressureReactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a constant pressure reactor with an ideal gas.</p>
 <p>An IdealGasConstPressureReactor is an instance of class Reactor where the
 pressure is held constant. The volume is not a state variable, but
@@ -376,10 +372,10 @@ thermodynamic models). Examples:</p>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>contents</strong> – Cantera <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be set as the contents of the
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>contents</strong> &#8211; Cantera <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be set as the contents of the
 reactor</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
@@ -390,7 +386,7 @@ reactor</td>
 
 <dl class="function">
 <dt id="Reactor.IdealGasReactor">
-<code class="descname">IdealGasReactor</code><span class="sig-paren">(</span><em>contents</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.IdealGasReactor" title="Permalink to this definition">¶</a></dt>
+<code class="descname">IdealGasReactor</code><span class="sig-paren">(</span><em>contents</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.IdealGasReactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a reactor with an ideal gas.</p>
 <p>An IdealGasReactor is an instance of class Reactor where the governing
 equations are specialized for the ideal gas equation of state (and do not
@@ -401,10 +397,10 @@ work correctly with other thermodynamic models). Examples:</p>
 </div>
 <p>See also: <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>contents</strong> – Cantera <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be set as the contents of the
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>contents</strong> &#8211; Cantera <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be set as the contents of the
 reactor</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
@@ -415,7 +411,7 @@ reactor</td>
 
 <dl class="function">
 <dt id="Reactor.Reservoir">
-<code class="descname">Reservoir</code><span class="sig-paren">(</span><em>contents</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.Reservoir" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Reservoir</code><span class="sig-paren">(</span><em>contents</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.Reservoir" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a Reservoir object.</p>
 <p>A <a class="reference internal" href="#Reactor.Reservoir" title="Reactor.Reservoir"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reservoir()</span></code></a> is an instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a>
 configured so that its intensive state is constant in time. A
@@ -431,10 +427,10 @@ reservoirs. Examples:</p>
 </div>
 <p>See also: <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>contents</strong> – Cantera <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be set as the contents of the
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>contents</strong> &#8211; Cantera <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be set as the contents of the
 reactor</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
@@ -445,13 +441,13 @@ reactor</td>
 
 <dl class="function">
 <dt id="Reactor.density">
-<code class="descname">density</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.density" title="Permalink to this definition">¶</a></dt>
+<code class="descname">density</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.density" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the density of the reactor.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Density of the phase in the input. Units: kg/m**3</td>
 </tr>
@@ -461,14 +457,14 @@ reactor</td>
 
 <dl class="function">
 <dt id="Reactor.enthalpy_mass">
-<code class="descname">enthalpy_mass</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.enthalpy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">enthalpy_mass</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.enthalpy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>The specific enthalpy of the reactor.</p>
 <p>See also: <a class="reference internal" href="#Reactor.intEnergy_mass" title="Reactor.intEnergy_mass"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">intEnergy_mass()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">The specific enthalpy of the reactor contents at the
 end of the last call to <code class="xref mat mat-func docutils literal notranslate"><span class="pre">advance()</span></code> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">step()</span></code>.
@@ -480,15 +476,15 @@ The enthalpy is retrieved from the solution vector. Units: J/kg</td>
 
 <dl class="function">
 <dt id="Reactor.insert">
-<code class="descname">insert</code><span class="sig-paren">(</span><em>r</em>, <em>gas</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.insert" title="Permalink to this definition">¶</a></dt>
+<code class="descname">insert</code><span class="sig-paren">(</span><em>r</em>, <em>gas</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.insert" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Insert a solution or mixture into a reactor.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
-<li><strong>gas</strong> – Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be inserted</li>
+<li><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
+<li><strong>gas</strong> &#8211; Instance of class <a class="reference internal" href="importing.html#Solution" title="Solution"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Solution()</span></code></a> to be inserted</li>
 </ul>
 </td>
 </tr>
@@ -498,14 +494,14 @@ The enthalpy is retrieved from the solution vector. Units: J/kg</td>
 
 <dl class="function">
 <dt id="Reactor.intEnergy_mass">
-<code class="descname">intEnergy_mass</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.intEnergy_mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">intEnergy_mass</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.intEnergy_mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the specific internal energy.</p>
 <p>See also: <a class="reference internal" href="#Reactor.enthalpy_mass" title="Reactor.enthalpy_mass"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">enthalpy_mass()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">The specific internal energy of the reactor contents at the
 end of the last call to <code class="xref mat mat-func docutils literal notranslate"><span class="pre">advance()</span></code> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">step()</span></code>.
@@ -518,13 +514,13 @@ Units: J/kg</td>
 
 <dl class="function">
 <dt id="Reactor.mass">
-<code class="descname">mass</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.mass" title="Permalink to this definition">¶</a></dt>
+<code class="descname">mass</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.mass" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass of the reactor.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">The mass of the reactor contents at the
 end of the last call to <code class="xref mat mat-func docutils literal notranslate"><span class="pre">advance()</span></code> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">step()</span></code>.
@@ -536,15 +532,15 @@ The mass is retrieved from the solution vector. Units: kg</td>
 
 <dl class="function">
 <dt id="Reactor.massFraction">
-<code class="descname">massFraction</code><span class="sig-paren">(</span><em>r</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.massFraction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">massFraction</code><span class="sig-paren">(</span><em>r</em>, <em>species</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.massFraction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass fraction of a species.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
-<li><strong>species</strong> – String or the one-based integer index of the species</li>
+<li><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
+<li><strong>species</strong> &#8211; String or the one-based integer index of the species</li>
 </ul>
 </td>
 </tr>
@@ -558,13 +554,13 @@ end of the last call to <code class="xref mat mat-func docutils literal notransl
 
 <dl class="function">
 <dt id="Reactor.massFractions">
-<code class="descname">massFractions</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.massFractions" title="Permalink to this definition">¶</a></dt>
+<code class="descname">massFractions</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.massFractions" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass fractions of the species.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">The mass fractions of the reactor contents at the
 end of the last call to <code class="xref mat mat-func docutils literal notranslate"><span class="pre">advance()</span></code> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">step()</span></code>.</td>
@@ -575,13 +571,13 @@ end of the last call to <code class="xref mat mat-func docutils literal notransl
 
 <dl class="function">
 <dt id="Reactor.pressure">
-<code class="descname">pressure</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.pressure" title="Permalink to this definition">¶</a></dt>
+<code class="descname">pressure</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.pressure" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the pressure of the reactor.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">The pressure of the reactor contents at the
 end of the last call to <code class="xref mat mat-func docutils literal notranslate"><span class="pre">advance()</span></code> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">step()</span></code>.
@@ -593,7 +589,7 @@ Units: Pa</td>
 
 <dl class="function">
 <dt id="Reactor.setChemistry">
-<code class="descname">setChemistry</code><span class="sig-paren">(</span><em>r</em>, <em>flag</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setChemistry" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setChemistry</code><span class="sig-paren">(</span><em>r</em>, <em>flag</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setChemistry" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Enable or disable changing reactor composition by reactions.</p>
 <p>If the chemistry is disabled, then the reactor composition is
 constant. The parameter should be the string <code class="docutils literal notranslate"><span class="pre">'on'</span></code> to enable the
@@ -601,17 +597,17 @@ species equations, or <code class="docutils literal notranslate"><span class="pr
 <p>By default, Reactor objects are created with the species equations
 enabled if there are reactions present in the mechanism file, and
 disabled otherwise.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">setChemistry</span><span class="p">(</span><span class="n">r</span><span class="p">,</span> <span class="s1">&#39;on&#39;</span><span class="p">);</span>
-<span class="o">&gt;&gt;</span> <span class="n">setChemistry</span><span class="p">(</span><span class="n">r</span><span class="p">,</span> <span class="s1">&#39;off&#39;</span><span class="p">);</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">setChemistry</span><span class="p">(</span><span class="n">r</span><span class="p">,</span> <span class="s1">'on'</span><span class="p">);</span>
+<span class="o">&gt;&gt;</span> <span class="n">setChemistry</span><span class="p">(</span><span class="n">r</span><span class="p">,</span> <span class="s1">'off'</span><span class="p">);</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
-<li><strong>flag</strong> – String, either <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code> to enable and disable
+<li><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
+<li><strong>flag</strong> &#8211; String, either <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code> to enable and disable
 solving the energy equation, respectively</li>
 </ul>
 </td>
@@ -622,7 +618,7 @@ solving the energy equation, respectively</li>
 
 <dl class="function">
 <dt id="Reactor.setEnergy">
-<code class="descname">setEnergy</code><span class="sig-paren">(</span><em>r</em>, <em>flag</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setEnergy" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setEnergy</code><span class="sig-paren">(</span><em>r</em>, <em>flag</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setEnergy" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Enable or disable solving the energy equation.</p>
 <p>If the energy equation is disabled, then the reactor temperature is
 constant. The parameter should be the string <code class="docutils literal notranslate"><span class="pre">'on'</span></code> to enable the
@@ -630,17 +626,17 @@ energy equation, or <code class="docutils literal notranslate"><span class="pre"
 <p>By default, Reactor objects are created with the energy equation
 enabled, so usually this method is only needed to disable the
 energy equation for isothermal simulations.</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">setEnergy</span><span class="p">(</span><span class="n">r</span><span class="p">,</span> <span class="s1">&#39;on&#39;</span><span class="p">);</span>
-<span class="o">&gt;&gt;</span> <span class="n">setEnergy</span><span class="p">(</span><span class="n">r</span><span class="p">,</span> <span class="s1">&#39;off&#39;</span><span class="p">);</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">&gt;&gt;</span> <span class="n">setEnergy</span><span class="p">(</span><span class="n">r</span><span class="p">,</span> <span class="s1">'on'</span><span class="p">);</span>
+<span class="o">&gt;&gt;</span> <span class="n">setEnergy</span><span class="p">(</span><span class="n">r</span><span class="p">,</span> <span class="s1">'off'</span><span class="p">);</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
-<li><strong>flag</strong> – String, either <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code> to enable and disable
+<li><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
+<li><strong>flag</strong> &#8211; String, either <code class="docutils literal notranslate"><span class="pre">'on'</span></code> or <code class="docutils literal notranslate"><span class="pre">'off'</span></code> to enable and disable
 solving the energy equation, respectively</li>
 </ul>
 </td>
@@ -651,15 +647,15 @@ solving the energy equation, respectively</li>
 
 <dl class="function">
 <dt id="Reactor.setInitialVolume">
-<code class="descname">setInitialVolume</code><span class="sig-paren">(</span><em>r</em>, <em>v0</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setInitialVolume" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setInitialVolume</code><span class="sig-paren">(</span><em>r</em>, <em>v0</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setInitialVolume" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the initial reactor volume.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
-<li><strong>v0</strong> – Initial volume. Units: m**3</li>
+<li><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
+<li><strong>v0</strong> &#8211; Initial volume. Units: m**3</li>
 </ul>
 </td>
 </tr>
@@ -669,17 +665,17 @@ solving the energy equation, respectively</li>
 
 <dl class="function">
 <dt id="Reactor.setKineticsMgr">
-<code class="descname">setKineticsMgr</code><span class="sig-paren">(</span><em>r</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setKineticsMgr" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setKineticsMgr</code><span class="sig-paren">(</span><em>r</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setKineticsMgr" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the kinetics manager.</p>
 <p>This method is used internally during Reactor initialization, but
 is usually not called by users.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
-<li><strong>k</strong> – Instance of class <a class="reference internal" href="kinetics.html#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a>, or another object
+<li><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
+<li><strong>k</strong> &#8211; Instance of class <a class="reference internal" href="kinetics.html#Kinetics" title="Kinetics"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Kinetics()</span></code></a>, or another object
 containing an instance of that class.</li>
 </ul>
 </td>
@@ -690,15 +686,15 @@ containing an instance of that class.</li>
 
 <dl class="function">
 <dt id="Reactor.setMassFlowRate">
-<code class="descname">setMassFlowRate</code><span class="sig-paren">(</span><em>r</em>, <em>mdot</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setMassFlowRate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setMassFlowRate</code><span class="sig-paren">(</span><em>r</em>, <em>mdot</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setMassFlowRate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mass flow rate.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
-<li><strong>mdot</strong> – Mass flow rate. Units: kg/s</li>
+<li><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
+<li><strong>mdot</strong> &#8211; Mass flow rate. Units: kg/s</li>
 </ul>
 </td>
 </tr>
@@ -708,17 +704,17 @@ containing an instance of that class.</li>
 
 <dl class="function">
 <dt id="Reactor.setThermoMgr">
-<code class="descname">setThermoMgr</code><span class="sig-paren">(</span><em>r</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setThermoMgr" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setThermoMgr</code><span class="sig-paren">(</span><em>r</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.setThermoMgr" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the thermodynamics manager.</p>
 <p>This method is used internally during Reactor initialization, but
 is usually not called by users.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
-<li><strong>t</strong> – Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a>, or another object
+<li><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
+<li><strong>t</strong> &#8211; Instance of class <a class="reference internal" href="thermodynamics.html#ThermoPhase" title="ThermoPhase"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ThermoPhase()</span></code></a>, or another object
 containing an instance of that class.</li>
 </ul>
 </td>
@@ -729,13 +725,13 @@ containing an instance of that class.</li>
 
 <dl class="function">
 <dt id="Reactor.temperature">
-<code class="descname">temperature</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.temperature" title="Permalink to this definition">¶</a></dt>
+<code class="descname">temperature</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.temperature" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the temperature of the reactor.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">The temperature of the reactor contents at the
 end of the last call to <code class="xref mat mat-func docutils literal notranslate"><span class="pre">advance()</span></code> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">step()</span></code>.
@@ -747,13 +743,13 @@ Units: K</td>
 
 <dl class="function">
 <dt id="Reactor.volume">
-<code class="descname">volume</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.volume" title="Permalink to this definition">¶</a></dt>
+<code class="descname">volume</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Reactor.volume" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the volume of the reactor.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">The volume of the reactor contents at the
 end of the last call to <code class="xref mat mat-func docutils literal notranslate"><span class="pre">advance()</span></code> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">step()</span></code>.
@@ -767,10 +763,10 @@ Units: m**3</td>
 
 </div>
 <div class="section" id="reactornet">
-<h2>ReactorNet<a class="headerlink" href="#reactornet" title="Permalink to this headline">¶</a></h2>
+<h2>ReactorNet<a class="headerlink" href="#reactornet" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="ReactorNet">
-<em class="property">class </em><code class="descname">ReactorNet</code><span class="sig-paren">(</span><em>reactors</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">ReactorNet</code><span class="sig-paren">(</span><em>reactors</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>ReactorNet class constructor.</p>
 <p>A <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a> object is a container that holds one
 or more <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> objects in a network. <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a>
@@ -787,10 +783,10 @@ more coupled reactors.</p>
 </div>
 <p>See also: <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>reactors</strong> – A single instance of <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or a cell array
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>reactors</strong> &#8211; A single instance of <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or a cell array
 of instances of <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></td>
@@ -799,15 +795,15 @@ of instances of <a class="reference internal" href="#Reactor" title="Reactor"><c
 </table>
 <dl class="function">
 <dt id="ReactorNet.addReactor">
-<code class="descname">addReactor</code><span class="sig-paren">(</span><em>net</em>, <em>reactor</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.addReactor" title="Permalink to this definition">¶</a></dt>
+<code class="descname">addReactor</code><span class="sig-paren">(</span><em>net</em>, <em>reactor</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.addReactor" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Add a reactor to a network.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>net</strong> – Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></li>
-<li><strong>reactor</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
+<li><strong>net</strong> &#8211; Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></li>
+<li><strong>reactor</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a></li>
 </ul>
 </td>
 </tr>
@@ -817,7 +813,7 @@ of instances of <a class="reference internal" href="#Reactor" title="Reactor"><c
 
 <dl class="function">
 <dt id="ReactorNet.advance">
-<code class="descname">advance</code><span class="sig-paren">(</span><em>n</em>, <em>tout</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.advance" title="Permalink to this definition">¶</a></dt>
+<code class="descname">advance</code><span class="sig-paren">(</span><em>n</em>, <em>tout</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.advance" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Advance the state of the reactor network in time.</p>
 <p>Method <a class="reference internal" href="#ReactorNet.advance" title="ReactorNet.advance"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">advance()</span></code></a> integrates the system of ordinary differential
 equations that determine the rate of change of the volume, the
@@ -837,12 +833,12 @@ tout.</p>
 </div>
 <p>See also: <a class="reference internal" href="#ReactorNet.step" title="ReactorNet.step"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">step()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>n</strong> – Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></li>
-<li><strong>tout</strong> – End time of the integration. The solver may take many internal
+<li><strong>n</strong> &#8211; Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></li>
+<li><strong>tout</strong> &#8211; End time of the integration. The solver may take many internal
 time steps to reach <code class="docutils literal notranslate"><span class="pre">tout</span></code>.</li>
 </ul>
 </td>
@@ -853,13 +849,13 @@ time steps to reach <code class="docutils literal notranslate"><span class="pre"
 
 <dl class="function">
 <dt id="ReactorNet.atol">
-<code class="descname">atol</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.atol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">atol</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.atol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the absolute error tolerance.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Absolute error tolerance.</td>
 </tr>
@@ -869,13 +865,13 @@ time steps to reach <code class="docutils literal notranslate"><span class="pre"
 
 <dl class="function">
 <dt id="ReactorNet.rtol">
-<code class="descname">rtol</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.rtol" title="Permalink to this definition">¶</a></dt>
+<code class="descname">rtol</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.rtol" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the relative error tolerance.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Relative error tolerance.</td>
 </tr>
@@ -885,18 +881,18 @@ time steps to reach <code class="docutils literal notranslate"><span class="pre"
 
 <dl class="function">
 <dt id="ReactorNet.setInitialTime">
-<code class="descname">setInitialTime</code><span class="sig-paren">(</span><em>r</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.setInitialTime" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setInitialTime</code><span class="sig-paren">(</span><em>r</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.setInitialTime" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the initial time of the integration.</p>
 <p>If the time integration has already begun, this restarts the
 integrator using the current solution as the initial condition,
 setting the time to <code class="docutils literal notranslate"><span class="pre">t</span></code>.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>r</strong> – Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></li>
-<li><strong>t</strong> – Time at which integration should be restarted, using the
+<li><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></li>
+<li><strong>t</strong> &#8211; Time at which integration should be restarted, using the
 current state as the initial condition. Units: s</li>
 </ul>
 </td>
@@ -907,7 +903,7 @@ current state as the initial condition. Units: s</li>
 
 <dl class="function">
 <dt id="ReactorNet.setMaxTimeStep">
-<code class="descname">setMaxTimeStep</code><span class="sig-paren">(</span><em>r</em>, <em>maxstep</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.setMaxTimeStep" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setMaxTimeStep</code><span class="sig-paren">(</span><em>r</em>, <em>maxstep</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.setMaxTimeStep" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the maximum time step.</p>
 <p>The integrator chooses a step size based on the desired error
 tolerances and the rate at which the solution is changing. In
@@ -917,12 +913,12 @@ choose a timestep that is too large, which leads to numerical
 problems later. Use this method to set an upper bound on the
 timestep.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>r</strong> – Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></li>
-<li><strong>maxstep</strong> – Maximum time step</li>
+<li><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></li>
+<li><strong>maxstep</strong> &#8211; Maximum time step</li>
 </ul>
 </td>
 </tr>
@@ -932,16 +928,16 @@ timestep.</p>
 
 <dl class="function">
 <dt id="ReactorNet.setTolerances">
-<code class="descname">setTolerances</code><span class="sig-paren">(</span><em>r</em>, <em>rtol</em>, <em>atol</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.setTolerances" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setTolerances</code><span class="sig-paren">(</span><em>r</em>, <em>rtol</em>, <em>atol</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.setTolerances" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the error tolerances.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>r</strong> – Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></li>
-<li><strong>rtol</strong> – Scalar relative error tolerance</li>
-<li><strong>atol</strong> – Scalar absolute error tolerance</li>
+<li><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></li>
+<li><strong>rtol</strong> &#8211; Scalar relative error tolerance</li>
+<li><strong>atol</strong> &#8211; Scalar absolute error tolerance</li>
 </ul>
 </td>
 </tr>
@@ -951,7 +947,7 @@ timestep.</p>
 
 <dl class="function">
 <dt id="ReactorNet.step">
-<code class="descname">step</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.step" title="Permalink to this definition">¶</a></dt>
+<code class="descname">step</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.step" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Take one internal time step.</p>
 <p>The integrator used to integrate the ODEs (CVODE) takes
 variable-size steps, chosen so that a specified error
@@ -975,10 +971,10 @@ solution.</p>
 </div>
 <p>See also: <a class="reference internal" href="#ReactorNet.advance" title="ReactorNet.advance"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">advance()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Network time after the internal time step. Units: s</td>
 </tr>
@@ -988,13 +984,13 @@ solution.</p>
 
 <dl class="function">
 <dt id="ReactorNet.time">
-<code class="descname">time</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.time" title="Permalink to this definition">¶</a></dt>
+<code class="descname">time</code><span class="sig-paren">(</span><em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#ReactorNet.time" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the current value of the time.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> – Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>r</strong> &#8211; Instance of class <a class="reference internal" href="#ReactorNet" title="ReactorNet"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">ReactorNet()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Current time in the input ReactorNet. Units: s</td>
 </tr>
@@ -1006,10 +1002,10 @@ solution.</p>
 
 </div>
 <div class="section" id="flowdevice">
-<h2>FlowDevice<a class="headerlink" href="#flowdevice" title="Permalink to this headline">¶</a></h2>
+<h2>FlowDevice<a class="headerlink" href="#flowdevice" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="FlowDevice">
-<em class="property">class </em><code class="descname">FlowDevice</code><span class="sig-paren">(</span><em>typ</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">FlowDevice</code><span class="sig-paren">(</span><em>typ</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>FlowDevice class constructor.</p>
 <p>Base class for devices that allow flow between reactors.
 <a class="reference internal" href="#FlowDevice" title="FlowDevice"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">FlowDevice()</span></code></a> objects are assumed to be adiabatic,
@@ -1021,10 +1017,10 @@ pressure difference equals the difference in pressure between the
 upstream and downstream reactors.</p>
 <p>See also: <a class="reference internal" href="#FlowDevice.MassFlowController" title="FlowDevice.MassFlowController"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">MassFlowController()</span></code></a>, <a class="reference internal" href="#FlowDevice.Valve" title="FlowDevice.Valve"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Valve()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>typ</strong> – Type of <a class="reference internal" href="#FlowDevice" title="FlowDevice"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">FlowDevice()</span></code></a> to be created. <code class="docutils literal notranslate"><span class="pre">typ=1</span></code> for
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>typ</strong> &#8211; Type of <a class="reference internal" href="#FlowDevice" title="FlowDevice"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">FlowDevice()</span></code></a> to be created. <code class="docutils literal notranslate"><span class="pre">typ=1</span></code> for
 <a class="reference internal" href="#FlowDevice.MassFlowController" title="FlowDevice.MassFlowController"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">MassFlowController()</span></code></a> and <code class="docutils literal notranslate"><span class="pre">typ=3</span></code> for
 <a class="reference internal" href="#FlowDevice.Valve" title="FlowDevice.Valve"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Valve()</span></code></a></td>
 </tr>
@@ -1034,7 +1030,7 @@ upstream and downstream reactors.</p>
 </table>
 <dl class="function">
 <dt id="FlowDevice.MassFlowController">
-<code class="descname">MassFlowController</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.MassFlowController" title="Permalink to this definition">¶</a></dt>
+<code class="descname">MassFlowController</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.MassFlowController" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a mass flow controller.</p>
 <p>Creates an instance of class <a class="reference internal" href="#FlowDevice" title="FlowDevice"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">FlowDevice()</span></code></a> configured to
 simulate a mass flow controller that maintains a constant mass flow
@@ -1045,12 +1041,12 @@ should be used to install the <a class="reference internal" href="#FlowDevice.Ma
 reactors.</p>
 <p>see also: <a class="reference internal" href="#FlowDevice" title="FlowDevice"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">FlowDevice()</span></code></a>, <a class="reference internal" href="#FlowDevice.Valve" title="FlowDevice.Valve"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Valve()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>upstream</strong> – Upstream <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reservoir()</span></code></li>
-<li><strong>downstream</strong> – Downstream <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reservoir()</span></code></li>
+<li><strong>upstream</strong> &#8211; Upstream <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reservoir()</span></code></li>
+<li><strong>downstream</strong> &#8211; Downstream <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reservoir()</span></code></li>
 </ul>
 </td>
 </tr>
@@ -1063,7 +1059,7 @@ reactors.</p>
 
 <dl class="function">
 <dt id="FlowDevice.Valve">
-<code class="descname">Valve</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.Valve" title="Permalink to this definition">¶</a></dt>
+<code class="descname">Valve</code><span class="sig-paren">(</span><em>upstream</em>, <em>downstream</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.Valve" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Create a valve.</p>
 <p>Create an instance of class <a class="reference internal" href="#FlowDevice" title="FlowDevice"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">FlowDevice()</span></code></a> configured to
 simulate a valve that produces a flow rate proportional to the
@@ -1084,12 +1080,12 @@ large the pressure difference. THIS MAY CHANGE IN A FUTURE
 RELEASE.</p>
 <p>see also: <a class="reference internal" href="#FlowDevice" title="FlowDevice"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">FlowDevice()</span></code></a>, <a class="reference internal" href="#FlowDevice.MassFlowController" title="FlowDevice.MassFlowController"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">MassFlowController()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>upstream</strong> – Upstream reactor or reservoir</li>
-<li><strong>downstream</strong> – Downstream Reactor or reservoir</li>
+<li><strong>upstream</strong> &#8211; Upstream reactor or reservoir</li>
+<li><strong>downstream</strong> &#8211; Downstream Reactor or reservoir</li>
 </ul>
 </td>
 </tr>
@@ -1102,16 +1098,16 @@ RELEASE.</p>
 
 <dl class="function">
 <dt id="FlowDevice.install">
-<code class="descname">install</code><span class="sig-paren">(</span><em>f</em>, <em>upstream</em>, <em>downstream</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.install" title="Permalink to this definition">¶</a></dt>
+<code class="descname">install</code><span class="sig-paren">(</span><em>f</em>, <em>upstream</em>, <em>downstream</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.install" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Install a flow device between reactors or reservoirs.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>f</strong> – Instance of class <a class="reference internal" href="#FlowDevice" title="FlowDevice"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">FlowDevice()</span></code></a> to install</li>
-<li><strong>upstream</strong> – Upstream <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reservoir()</span></code></li>
-<li><strong>downstream</strong> – Downstream <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reservoir()</span></code></li>
+<li><strong>f</strong> &#8211; Instance of class <a class="reference internal" href="#FlowDevice" title="FlowDevice"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">FlowDevice()</span></code></a> to install</li>
+<li><strong>upstream</strong> &#8211; Upstream <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reservoir()</span></code></li>
+<li><strong>downstream</strong> &#8211; Downstream <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reservoir()</span></code></li>
 </ul>
 </td>
 </tr>
@@ -1124,15 +1120,15 @@ RELEASE.</p>
 
 <dl class="function">
 <dt id="FlowDevice.massFlowRate">
-<code class="descname">massFlowRate</code><span class="sig-paren">(</span><em>f</em>, <em>time</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.massFlowRate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">massFlowRate</code><span class="sig-paren">(</span><em>f</em>, <em>time</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.massFlowRate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the mass flow rate at a given time.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>f</strong> – Instance of class <a class="reference internal" href="#FlowDevice.MassFlowController" title="FlowDevice.MassFlowController"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">MassFlowController()</span></code></a></li>
-<li><strong>time</strong> – Time at which the mass flow rate is desired</li>
+<li><strong>f</strong> &#8211; Instance of class <a class="reference internal" href="#FlowDevice.MassFlowController" title="FlowDevice.MassFlowController"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">MassFlowController()</span></code></a></li>
+<li><strong>time</strong> &#8211; Time at which the mass flow rate is desired</li>
 </ul>
 </td>
 </tr>
@@ -1145,16 +1141,16 @@ RELEASE.</p>
 
 <dl class="function">
 <dt id="FlowDevice.setFunction">
-<code class="descname">setFunction</code><span class="sig-paren">(</span><em>f</em>, <em>mf</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.setFunction" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setFunction</code><span class="sig-paren">(</span><em>f</em>, <em>mf</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.setFunction" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mass flow rate with class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>.</p>
 <p>See also: <a class="reference internal" href="#FlowDevice.MassFlowController" title="FlowDevice.MassFlowController"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">MassFlowController()</span></code></a>, <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>f</strong> – Instance of class <a class="reference internal" href="#FlowDevice.MassFlowController" title="FlowDevice.MassFlowController"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">MassFlowController()</span></code></a></li>
-<li><strong>mf</strong> – Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
+<li><strong>f</strong> &#8211; Instance of class <a class="reference internal" href="#FlowDevice.MassFlowController" title="FlowDevice.MassFlowController"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">MassFlowController()</span></code></a></li>
+<li><strong>mf</strong> &#8211; Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></li>
 </ul>
 </td>
 </tr>
@@ -1164,16 +1160,16 @@ RELEASE.</p>
 
 <dl class="function">
 <dt id="FlowDevice.setMassFlowRate">
-<code class="descname">setMassFlowRate</code><span class="sig-paren">(</span><em>f</em>, <em>mdot</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.setMassFlowRate" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setMassFlowRate</code><span class="sig-paren">(</span><em>f</em>, <em>mdot</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.setMassFlowRate" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the mass flow rate to a constant value.</p>
 <p>See also: <a class="reference internal" href="#FlowDevice.MassFlowController" title="FlowDevice.MassFlowController"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">MassFlowController()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>f</strong> – Instance of class <a class="reference internal" href="#FlowDevice.MassFlowController" title="FlowDevice.MassFlowController"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">MassFlowController()</span></code></a></li>
-<li><strong>mdot</strong> – Mass flow rate</li>
+<li><strong>f</strong> &#8211; Instance of class <a class="reference internal" href="#FlowDevice.MassFlowController" title="FlowDevice.MassFlowController"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">MassFlowController()</span></code></a></li>
+<li><strong>mdot</strong> &#8211; Mass flow rate</li>
 </ul>
 </td>
 </tr>
@@ -1183,7 +1179,7 @@ RELEASE.</p>
 
 <dl class="function">
 <dt id="FlowDevice.setValveCoeff">
-<code class="descname">setValveCoeff</code><span class="sig-paren">(</span><em>f</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.setValveCoeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setValveCoeff</code><span class="sig-paren">(</span><em>f</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#FlowDevice.setValveCoeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the valve coefficient <span class="math">\(K\)</span>.</p>
 <p>The mass flow rate [kg/s] is computed from the expression</p>
 <div class="math">
@@ -1194,12 +1190,12 @@ RELEASE.</p>
 negative, zero is returned.</p>
 <p>See also: <a class="reference internal" href="#FlowDevice.Valve" title="FlowDevice.Valve"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Valve()</span></code></a></p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>f</strong> – Instance of class <a class="reference internal" href="#FlowDevice.Valve" title="FlowDevice.Valve"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Valve()</span></code></a></li>
-<li><strong>k</strong> – Value of the valve coefficient. Units: kg/Pa-s</li>
+<li><strong>f</strong> &#8211; Instance of class <a class="reference internal" href="#FlowDevice.Valve" title="FlowDevice.Valve"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Valve()</span></code></a></li>
+<li><strong>k</strong> &#8211; Value of the valve coefficient. Units: kg/Pa-s</li>
 </ul>
 </td>
 </tr>
@@ -1211,10 +1207,10 @@ negative, zero is returned.</p>
 
 </div>
 <div class="section" id="wall">
-<h2>Wall<a class="headerlink" href="#wall" title="Permalink to this headline">¶</a></h2>
+<h2>Wall<a class="headerlink" href="#wall" title="Permalink to this headline">&#182;</a></h2>
 <dl class="class">
 <dt id="Wall">
-<em class="property">class </em><code class="descname">Wall</code><span class="sig-paren">(</span><em>left</em>, <em>right</em>, <em>area</em>, <em>k</em>, <em>u</em>, <em>q</em>, <em>v</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descname">Wall</code><span class="sig-paren">(</span><em>left</em>, <em>right</em>, <em>area</em>, <em>k</em>, <em>u</em>, <em>q</em>, <em>v</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Wall class constructor.</p>
 <p>A Wall separates two reactors, or a reactor and a reservoir. A wall has a
 finite area, may conduct heat between the two reactors on either
@@ -1247,23 +1243,23 @@ if the intention was to not use a particular argument. Thus, the velocity of
 the wall can be set by using empty strings or 0.0 for each of the arguments before
 the velocity with no harm.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>left</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> to be used as the bulk phase on
+<li><strong>left</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> to be used as the bulk phase on
 the left side of the wall. See <a class="reference internal" href="#Wall.install" title="Wall.install"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">install()</span></code></a></li>
-<li><strong>right</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> to be used as the bulk phase on
+<li><strong>right</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> to be used as the bulk phase on
 the right side of the wall. See <a class="reference internal" href="#Wall.install" title="Wall.install"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">install()</span></code></a></li>
-<li><strong>area</strong> – The area of the wall in m**2. See <a class="reference internal" href="#Wall.area" title="Wall.area"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">area()</span></code></a> and <a class="reference internal" href="#Wall.setArea" title="Wall.setArea"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setArea()</span></code></a>.
+<li><strong>area</strong> &#8211; The area of the wall in m**2. See <a class="reference internal" href="#Wall.area" title="Wall.area"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">area()</span></code></a> and <a class="reference internal" href="#Wall.setArea" title="Wall.setArea"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setArea()</span></code></a>.
 Defaults to 1.0 m**2 if not specified.</li>
-<li><strong>k</strong> – Expansion rate coefficient in m/(s-Pa). See <a class="reference internal" href="#Wall.setExpansionRateCoeff" title="Wall.setExpansionRateCoeff"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setExpansionRateCoeff()</span></code></a>
+<li><strong>k</strong> &#8211; Expansion rate coefficient in m/(s-Pa). See <a class="reference internal" href="#Wall.setExpansionRateCoeff" title="Wall.setExpansionRateCoeff"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setExpansionRateCoeff()</span></code></a>
 and <a class="reference internal" href="#Wall.vdot" title="Wall.vdot"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">vdot()</span></code></a>. Defaults to 0.0 if not specified.</li>
-<li><strong>u</strong> – Heat transfer coefficient in W/(m**2-K). See <a class="reference internal" href="#Wall.setHeatTransferCoeff" title="Wall.setHeatTransferCoeff"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setHeatTransferCoeff()</span></code></a>
+<li><strong>u</strong> &#8211; Heat transfer coefficient in W/(m**2-K). See <a class="reference internal" href="#Wall.setHeatTransferCoeff" title="Wall.setHeatTransferCoeff"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setHeatTransferCoeff()</span></code></a>
 and <a class="reference internal" href="#Wall.qdot" title="Wall.qdot"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">qdot()</span></code></a>. Defaults to 0.0 if not specified.</li>
-<li><strong>q</strong> – Heat flux in W/m**2. Must be an instance of <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>. See
+<li><strong>q</strong> &#8211; Heat flux in W/m**2. Must be an instance of <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>. See
 <a class="reference internal" href="#Wall.setHeatFlux" title="Wall.setHeatFlux"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setHeatFlux()</span></code></a> and <a class="reference internal" href="#Wall.qdot" title="Wall.qdot"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">qdot()</span></code></a>. Defaults to 0.0 if not specified.</li>
-<li><strong>v</strong> – Velocity of the wall in m/s. Must be an instance of <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>. See
+<li><strong>v</strong> &#8211; Velocity of the wall in m/s. Must be an instance of <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>. See
 <a class="reference internal" href="#Wall.setVelocity" title="Wall.setVelocity"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">setVelocity()</span></code></a> and <a class="reference internal" href="#Wall.vdot" title="Wall.vdot"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">vdot()</span></code></a>. Defaults to 0.0 if not specified.</li>
 </ul>
 </td>
@@ -1275,13 +1271,13 @@ and <a class="reference internal" href="#Wall.qdot" title="Wall.qdot"><code clas
 </table>
 <dl class="function">
 <dt id="Wall.area">
-<code class="descname">area</code><span class="sig-paren">(</span><em>w</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.area" title="Permalink to this definition">¶</a></dt>
+<code class="descname">area</code><span class="sig-paren">(</span><em>w</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.area" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the area of the wall.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>w</strong> – Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>w</strong> &#8211; Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Area of the wall in m**2</td>
 </tr>
@@ -1291,17 +1287,17 @@ and <a class="reference internal" href="#Wall.qdot" title="Wall.qdot"><code clas
 
 <dl class="function">
 <dt id="Wall.install">
-<code class="descname">install</code><span class="sig-paren">(</span><em>w</em>, <em>left</em>, <em>right</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.install" title="Permalink to this definition">¶</a></dt>
+<code class="descname">install</code><span class="sig-paren">(</span><em>w</em>, <em>left</em>, <em>right</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.install" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Install a wall between two reactors.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>w</strong> – Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
-<li><strong>left</strong> – Instance of class <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor`or</span>
+<li><strong>w</strong> &#8211; Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
+<li><strong>left</strong> &#8211; Instance of class <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor`or</span>
 <span class="pre">:mat:func:`Reservoir()</span></code></li>
-<li><strong>right</strong> – Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or
+<li><strong>right</strong> &#8211; Instance of class <a class="reference internal" href="#Reactor" title="Reactor"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reactor()</span></code></a> or
 <code class="xref mat mat-func docutils literal notranslate"><span class="pre">Reservoir()</span></code></li>
 </ul>
 </td>
@@ -1312,17 +1308,17 @@ and <a class="reference internal" href="#Wall.qdot" title="Wall.qdot"><code clas
 
 <dl class="function">
 <dt id="Wall.qdot">
-<code class="descname">qdot</code><span class="sig-paren">(</span><em>w</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.qdot" title="Permalink to this definition">¶</a></dt>
+<code class="descname">qdot</code><span class="sig-paren">(</span><em>w</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.qdot" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the total heat transfer through a wall given a time.</p>
 <p>A positive value corresponds to heat flowing from the left-hand
 reactor to the right-hand one.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>w</strong> – Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
-<li><strong>t</strong> – Time at which the heat transfer should be evaluated.</li>
+<li><strong>w</strong> &#8211; Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
+<li><strong>t</strong> &#8211; Time at which the heat transfer should be evaluated.</li>
 </ul>
 </td>
 </tr>
@@ -1335,13 +1331,13 @@ reactor to the right-hand one.</p>
 
 <dl class="function">
 <dt id="Wall.ready">
-<code class="descname">ready</code><span class="sig-paren">(</span><em>w</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.ready" title="Permalink to this definition">¶</a></dt>
+<code class="descname">ready</code><span class="sig-paren">(</span><em>w</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.ready" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Check whether a wall is ready.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>w</strong> – Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>w</strong> &#8211; Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></td>
 </tr>
 <tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Status of the wall</td>
 </tr>
@@ -1351,15 +1347,15 @@ reactor to the right-hand one.</p>
 
 <dl class="function">
 <dt id="Wall.setArea">
-<code class="descname">setArea</code><span class="sig-paren">(</span><em>w</em>, <em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setArea" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setArea</code><span class="sig-paren">(</span><em>w</em>, <em>a</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setArea" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the area of a wall.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>w</strong> – Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
-<li><strong>a</strong> – Double area of the wall.</li>
+<li><strong>w</strong> &#8211; Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
+<li><strong>a</strong> &#8211; Double area of the wall.</li>
 </ul>
 </td>
 </tr>
@@ -1369,7 +1365,7 @@ reactor to the right-hand one.</p>
 
 <dl class="function">
 <dt id="Wall.setExpansionRateCoeff">
-<code class="descname">setExpansionRateCoeff</code><span class="sig-paren">(</span><em>w</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setExpansionRateCoeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setExpansionRateCoeff</code><span class="sig-paren">(</span><em>w</em>, <em>k</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setExpansionRateCoeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the expansion rate coefficient.</p>
 <p>The expansion rate coefficient
 determines the velocity of the wall for a given pressure
@@ -1382,12 +1378,12 @@ formula</p>
 <p>where <span class="math">\(v\)</span> is velocity, <span class="math">\(K\)</span> is the expansion rate
 coefficient, and <span class="math">\(P\)</span> is the pressure.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>w</strong> – Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
-<li><strong>k</strong> – Double, wall expansion rate coefficient. Units: m/(s-Pa)</li>
+<li><strong>w</strong> &#8211; Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
+<li><strong>k</strong> &#8211; Double, wall expansion rate coefficient. Units: m/(s-Pa)</li>
 </ul>
 </td>
 </tr>
@@ -1397,7 +1393,7 @@ coefficient, and <span class="math">\(P\)</span> is the pressure.</p>
 
 <dl class="function">
 <dt id="Wall.setHeatFlux">
-<code class="descname">setHeatFlux</code><span class="sig-paren">(</span><em>w</em>, <em>f</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setHeatFlux" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setHeatFlux</code><span class="sig-paren">(</span><em>w</em>, <em>f</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setHeatFlux" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the heat flux using <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a></p>
 <p>Must be set by an instance of
 class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>, which allows the heat flux to be an
@@ -1405,18 +1401,18 @@ arbitrary function of time. It is possible to specify
 a constant heat flux by using the polynomial functor with
 only the first term specified:</p>
 <div class="highlight-matlab notranslate"><div class="highlight"><pre><span></span><span class="n">w</span> <span class="p">=</span> <span class="n">Wall</span><span class="p">()</span>
-<span class="n">f</span> <span class="p">=</span> <span class="n">Func</span><span class="p">(</span><span class="s">&#39;polynomial&#39;</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">10</span><span class="p">);</span> <span class="c">% Or f = polynom(10);</span>
+<span class="n">f</span> <span class="p">=</span> <span class="n">Func</span><span class="p">(</span><span class="s">'polynomial'</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">10</span><span class="p">);</span> <span class="c">% Or f = polynom(10);</span>
 <span class="n">setHeatFlux</span><span class="p">(</span><span class="n">w</span><span class="p">,</span> <span class="n">f</span><span class="p">);</span>
 </pre></div>
 </div>
 <p>sets the heat flux through the wall to 10 W/m**2.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>w</strong> – Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
-<li><strong>f</strong> – Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>. Units: W/m**2</li>
+<li><strong>w</strong> &#8211; Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
+<li><strong>f</strong> &#8211; Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>. Units: W/m**2</li>
 </ul>
 </td>
 </tr>
@@ -1426,15 +1422,15 @@ only the first term specified:</p>
 
 <dl class="function">
 <dt id="Wall.setHeatTransferCoeff">
-<code class="descname">setHeatTransferCoeff</code><span class="sig-paren">(</span><em>w</em>, <em>u</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setHeatTransferCoeff" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setHeatTransferCoeff</code><span class="sig-paren">(</span><em>w</em>, <em>u</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setHeatTransferCoeff" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the heat transfer coefficient.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>w</strong> – Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
-<li><strong>u</strong> – Heat transfer coefficient of the wall. Units: W/(m**2-K)</li>
+<li><strong>w</strong> &#8211; Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
+<li><strong>u</strong> &#8211; Heat transfer coefficient of the wall. Units: W/(m**2-K)</li>
 </ul>
 </td>
 </tr>
@@ -1444,15 +1440,15 @@ only the first term specified:</p>
 
 <dl class="function">
 <dt id="Wall.setThermalResistance">
-<code class="descname">setThermalResistance</code><span class="sig-paren">(</span><em>w</em>, <em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setThermalResistance" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setThermalResistance</code><span class="sig-paren">(</span><em>w</em>, <em>r</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setThermalResistance" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the thermal resistance.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>w</strong> – Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
-<li><strong>r</strong> – Double, thermal resistance. Units: K*m**2/W</li>
+<li><strong>w</strong> &#8211; Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
+<li><strong>r</strong> &#8211; Double, thermal resistance. Units: K*m**2/W</li>
 </ul>
 </td>
 </tr>
@@ -1462,25 +1458,25 @@ only the first term specified:</p>
 
 <dl class="function">
 <dt id="Wall.setVelocity">
-<code class="descname">setVelocity</code><span class="sig-paren">(</span><em>w</em>, <em>f</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setVelocity" title="Permalink to this definition">¶</a></dt>
+<code class="descname">setVelocity</code><span class="sig-paren">(</span><em>w</em>, <em>f</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.setVelocity" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Set the velocity of the wall using <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>.</p>
 <p>Must be set by an instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>, which allows
 the velocity to be an arbitrary function of time. It is possible
 to specify a constant velocity by using the polynomial functor with
 only the first term specified:</p>
 <div class="highlight-matlab notranslate"><div class="highlight"><pre><span></span><span class="n">w</span> <span class="p">=</span> <span class="n">Wall</span><span class="p">()</span>
-<span class="n">f</span> <span class="p">=</span> <span class="n">Func</span><span class="p">(</span><span class="s">&#39;polynomial&#39;</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">10</span><span class="p">);</span> <span class="c">% Or f = polynom(10);</span>
+<span class="n">f</span> <span class="p">=</span> <span class="n">Func</span><span class="p">(</span><span class="s">'polynomial'</span><span class="p">,</span><span class="mi">0</span><span class="p">,</span><span class="mi">10</span><span class="p">);</span> <span class="c">% Or f = polynom(10);</span>
 <span class="n">setVelocity</span><span class="p">(</span><span class="n">w</span><span class="p">,</span> <span class="n">f</span><span class="p">);</span>
 </pre></div>
 </div>
 <p>sets the velocity of the wall to 10 m/s.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
-<li><strong>w</strong> – Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
-<li><strong>f</strong> – Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>. Units: m/s</li>
+<li><strong>w</strong> &#8211; Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
+<li><strong>f</strong> &#8211; Instance of class <a class="reference internal" href="#Func" title="Func"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Func()</span></code></a>. Units: m/s</li>
 </ul>
 </td>
 </tr>
@@ -1490,17 +1486,17 @@ only the first term specified:</p>
 
 <dl class="function">
 <dt id="Wall.vdot">
-<code class="descname">vdot</code><span class="sig-paren">(</span><em>w</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.vdot" title="Permalink to this definition">¶</a></dt>
+<code class="descname">vdot</code><span class="sig-paren">(</span><em>w</em>, <em>t</em><span class="sig-paren">)</span><a class="headerlink" href="#Wall.vdot" title="Permalink to this definition">&#182;</a></dt>
 <dd><p>Get the rate of volumetric change at a given time.</p>
 <p>A positive value corresponds to the left-hand reactor volume
 increasing, and the right-hand reactor volume decreasing.</p>
 <table class="docutils field-list" frame="void" rules="none">
-<col class="field-name" />
-<col class="field-body" />
+<col class="field-name">
+<col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>w</strong> – Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
-<li><strong>t</strong> – Time at which the volumetric change should be calculated.</li>
+<li><strong>w</strong> &#8211; Instance of class <a class="reference internal" href="#Wall" title="Wall"><code class="xref mat mat-func docutils literal notranslate"><span class="pre">Wall()</span></code></a></li>
+<li><strong>t</strong> &#8211; Time at which the volumetric change should be calculated.</li>
 </ul>
 </td>
 </tr>
@@ -1538,7 +1534,7 @@ increasing, and the right-hand reactor volume decreasing.</p>
 <h3>Related Topics</h3>
 <ul>
   <li><a href="../index.html">Documentation overview</a><ul>
-  <li><a href="index.html">Matlab Interface User’s Guide</a><ul>
+  <li><a href="index.html">Matlab Interface User&#8217;s Guide</a><ul>
       <li>Previous: <a href="transport.html" title="previous chapter">Transport Properties</a></li>
       <li>Next: <a href="one-dim.html" title="next chapter">One-Dimensional Reacting Flows</a></li>
   </ul></li>
@@ -1548,25 +1544,24 @@ increasing, and the right-hand reactor volume decreasing.</p>
   <div role="note" aria-label="source link">
     <h3>This Page</h3>
     <ul class="this-page-menu">
-      <li><a href="../_sources/matlab/zero-dim.rst.txt"
-            rel="nofollow">Show Source</a></li>
+      <li><a href="../_sources/matlab/zero-dim.rst.txt" rel="nofollow">Show Source</a></li>
     </ul>
    </div>
 <div id="searchbox" style="display: none" role="search">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="../search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="../_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -1575,15 +1570,14 @@ increasing, and the right-hand reactor volume decreasing.</p>
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>
             &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.11</a>
 
             |
-            <a href="../_sources/matlab/zero-dim.rst.txt"
-                rel="nofollow">Page source</a>
+            <a href="../_sources/matlab/zero-dim.rst.txt" rel="nofollow">Page source</a>
           </div>
       </div>
   </div>

--- a/api-docs/docs-2.4/sphinx/html/matlab/zero-dim.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/zero-dim.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="../_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
     <script type="text/javascript" src="../_static/jquery.js"></script>
     <script type="text/javascript" src="../_static/underscore.js"></script>
     <script type="text/javascript" src="../_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="../_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/py-modindex.html
+++ b/api-docs/docs-2.4/sphinx/html/py-modindex.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Python Module Index | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -23,9 +19,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="_static/katex_autorenderer.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="search.html" />
+    <link rel="search" title="Search" href="search.html">
 
 
 
@@ -95,8 +91,7 @@ lang="en">
      <tr class="cap" id="cap-c"><td></td><td>
        <strong>c</strong></td><td></td></tr>
      <tr>
-       <td><img src="_static/minus.png" class="toggler"
-              id="toggle-1" style="display: none" alt="-" /></td>
+       <td><img src="_static/minus.png" class="toggler" id="toggle-1" style="display: none" alt="-"></td>
        <td>
        <code class="xref">cantera</code></td><td>
        <em></em></td></tr>
@@ -124,17 +119,17 @@ lang="en">
   <h3>Quick search</h3>
     <div class="searchformwrapper">
     <form class="search" action="search.html" method="get">
-      <input type="text" name="q" />
-      <input type="submit" value="Go" />
-      <input type="hidden" name="check_keywords" value="yes" />
-      <input type="hidden" name="area" value="default" />
+      <input type="text" name="q">
+      <input type="submit" value="Go">
+      <input type="hidden" name="check_keywords" value="yes">
+      <input type="hidden" name="area" value="default">
     </form>
     </div>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -143,7 +138,7 @@ lang="en">
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>

--- a/api-docs/docs-2.4/sphinx/html/py-modindex.html
+++ b/api-docs/docs-2.4/sphinx/html/py-modindex.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
     <script type="text/javascript" src="_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="_static/katex_autorenderer.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
 

--- a/api-docs/docs-2.4/sphinx/html/search.html
+++ b/api-docs/docs-2.4/sphinx/html/search.html
@@ -1,21 +1,17 @@
-
-
 <!DOCTYPE html>
-
 <html prefix="
 og: http://ogp.me/ns# article: http://ogp.me/ns/article#
-"
-lang="en">
+" lang="en">
 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Search | Cantera </title>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
-  <link rel="stylesheet" href="_static/cantera.css" type="text/css" />
-  <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+  <link rel="stylesheet" href="_static/cantera.css" type="text/css">
+  <link rel="stylesheet" href="_static/pygments.css" type="text/css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
-  <link rel="stylesheet" href="_static/katex-math.css" type="text/css" />
+  <link rel="stylesheet" href="_static/katex-math.css" type="text/css">
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
@@ -24,9 +20,9 @@ lang="en">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="_static/katex_autorenderer.js"></script>
     <script type="text/javascript" src="_static/searchtools.js"></script>
-    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>
+    <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
-    <link rel="search" title="Search" href="#" />
+    <link rel="search" title="Search" href="#">
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("searchindex.js"); });
   </script>
@@ -103,8 +99,8 @@ lang="en">
     containing fewer words won't appear in the result list.
   </p>
   <form action="" method="get">
-    <input type="text" name="q" value="" />
-    <input type="submit" value="search" />
+    <input type="text" name="q" value="">
+    <input type="submit" value="search">
     <span id="search-progress" style="padding-left: 10px"></span>
   </form>
 
@@ -126,7 +122,7 @@ lang="en">
 </div><div id="numfocus">
 <h3>Donate to Cantera</h3>
 <a href="https://numfocus.org/donate-to-cantera">
-<img src="_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"/></a>
+<img src="_static/powered_by_NumFOCUS.png" border="0" alt="NumFOCUS"></a>
 </div>
     </div>
   </div>
@@ -135,7 +131,7 @@ lang="en">
            <!--End of block content-->
 
           <div class="footer">
-            &copy;2001-2018, Cantera Developers.
+            &#169;2001-2018, Cantera Developers.
 
             |
             Powered by <a href="http://sphinx-doc.org/">Sphinx 1.7.8</a>

--- a/api-docs/docs-2.4/sphinx/html/search.html
+++ b/api-docs/docs-2.4/sphinx/html/search.html
@@ -14,14 +14,14 @@ lang="en">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous" />
   <link rel="stylesheet" href="_static/cantera.css" type="text/css" />
   <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css" type="text/css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
   <link rel="stylesheet" href="_static/katex-math.css" type="text/css" />
     <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
     <script type="text/javascript" src="_static/doctools.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/contrib/auto-render.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
     <script type="text/javascript" src="_static/katex_autorenderer.js"></script>
     <script type="text/javascript" src="_static/searchtools.js"></script>
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16"/>

--- a/themes/cantera/templates/math_helper.tmpl
+++ b/themes/cantera/templates/math_helper.tmpl
@@ -2,8 +2,8 @@
 {# KaTeX urls from: https://katex.org/docs/autorender.html #}
 
 {% macro math_scripts_files() %}
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.js" integrity="sha384-2BKqo+exmr9su6dir+qCw08N2ZKRucY4PrGQPPWU1A7FtlCGjmEGFqXCv5nyM5Ij" crossorigin="anonymous"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js" integrity="sha384-y23I5Q6l+B6vatafAwxRu/0oK/79VlbSz7Q9aiSZUvyWYIYsd+qj+o24G5ZU2zJz" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
 {% endmacro %}
 
 {% macro math_scripts() %}
@@ -41,7 +41,7 @@
 {% endmacro %}
 
 {% macro math_styles() %}
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.1/dist/katex.min.css" integrity="sha384-dbVIfZGuN1Yq7/1Ocstc1lUEm+AT+/rCkibIcC/OmWo5f0EA48Vf8CytHzGrSwbQ" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">
 {% endmacro %}
 
 {% macro math_scripts_ifpost(post) %}


### PR DESCRIPTION
Bump the KaTeX version in the theme and the built API docs for 2.4. Newer versions of sphinxcontrib-katex include 0.11.1 of KaTeX, so this will hopefully prevent people visiting the website from having to download multiple versions of the KaTeX CSS and JS.