### PR TITLE
Updates for 2.5.0 release

### DIFF
--- a/pages/compiling/config-options-dev.rst
+++ b/pages/compiling/config-options-dev.rst
@@ -256,6 +256,17 @@ Options List
 
     - default: ``'default'``
 
+.. _system-yamlcpp-dev:
+
+* ``system_yamlcpp``: [``default`` | ``y`` | ``n`` ]
+    Select whether to use the yaml-cpp library from a system installation
+    (``y``), from a Git submodule (``n``), or to decide automatically
+    (``default``). If yaml-cpp is not installed directly into system
+    include and library directories, then you will need to add those
+    directories to ``extra_inc_dirs`` and ``extra_lib_dirs``.
+
+    - default: ``'default'``
+
 .. _system-sundials-dev:
 
 * ``system_sundials``: [ ``default`` | ``y`` | ``n`` ]

--- a/pages/compiling/config-options-dev.rst
+++ b/pages/compiling/config-options-dev.rst
@@ -65,7 +65,11 @@ Options List
 * ``toolchain``: [ ``msvc`` | ``mingw`` | ``intel`` ]
     The preferred compiler toolchain. Windows only.
 
-    - default: ``'msvc'``
+    - default:
+
+      - ``g++`` is on the path, MSVC is not on the path, and ``msvc_version``
+        is not specified: ``'mingw'``
+      - Otherwise: ``'msvc'``
 
 .. _cxx-dev:
 
@@ -86,7 +90,10 @@ Options List
 * ``prefix``: [ ``/path/to/prefix`` ]
     Set this to the directory where Cantera should be installed.
 
-    - default: ``''``
+    - default:
+
+      - Linux / macOS / other Unix systems: ``'/usr/local'``
+      - Windows: ``'C:\Program Files\Cantera'``
 
 .. _python-package-dev:
 
@@ -124,7 +131,10 @@ Options List
     To install to the current user's ``site-packages`` directory, use
     ``python_prefix=USER``.
 
-    - default: ``''``
+    - default:
+
+      - Windows: ``''``
+      - Otherwise: ``'$prefix'``
 
 .. _python3-package-dev:
 
@@ -357,7 +367,10 @@ Options List
 * ``use_pch``: [ ``yes`` | ``no`` ]
     Use a precompiled-header to speed up compilation
 
-    - default: ``'yes'``
+    - default:
+
+      - If using the Intel C/C++ compiler: ``'no'``
+      - Otherwise: ``'yes'``
 
 .. _cxx-flags-dev:
 
@@ -365,7 +378,13 @@ Options List
     Compiler flags passed to the C++ compiler only. Separate multiple
     options with spaces -- for example, ``cxx_flags='-g -Wextra -O3 --std=c++11'``
 
-    - default: ``''``
+    - default:
+
+      - If using GCC: ``'-std=c++0x'``
+      - If using GCC on Cygwin: ``'-std=gnu++0x'``
+      - If using MSVC: ``'/EHsc'``
+      - If using Clang: ``'-std=c++11'``
+      - If using ICC: ``'-std=c++0x'``
 
 .. _cc-flags-dev:
 
@@ -373,14 +392,22 @@ Options List
     Compiler flags passed to both the C and C++ compilers, regardless of
     optimization level
 
-    - default: ``''``
+    - default:
+
+      - If using GCC: ``''``
+      - If using MSVC: ``'/MD /nologo /D_SCL_SECURE_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS'``
+      - If using Clang: ``'-fcolor-diagnostics'``
+      - If using ICC: ``'-vec-report0 -diag-disable 1478'``
 
 .. _thread-flags-dev:
 
 * ``thread_flags``: [ ``string`` ]
     Compiler and linker flags for POSIX multithreading support.
 
-    - default: ``''``
+    - default:
+
+      - If compiling on Windows: ``''``
+      - Otherwise: ``'-pthread'``
 
 .. _optimize-dev:
 
@@ -397,7 +424,12 @@ Options List
     Additional compiler flags passed to the C/C++ compiler when
     ``optimize=yes``.
 
-    - default: ``''``
+    - default:
+
+      - If using GCC: ``'-O3 -Wno-inline'``
+      - If using MSVC: ``'/O2'``
+      - If using Clang: ``'-O3'``
+      - If using ICC: ``'-O3'``
 
 .. _no-optimize-flags-dev:
 
@@ -405,7 +437,10 @@ Options List
     Additional compiler flags passed to the C/C++ compiler when
     ``optimize=no``.
 
-    - default: ``''``
+    - default:
+
+      - If using MSVC: ``'/Od /Ob0'``
+      - Otherwise: ``'-O0'``
 
 .. _debug-dev:
 
@@ -420,7 +455,10 @@ Options List
     Additional compiler flags passed to the C/C++ compiler when
     ``debug=yes``.
 
-    - default: ``''``
+    - default:
+
+      - If using MSVC: ``'/Zi /Fd${TARGET}.pdb'``
+      - Otherwise: ``'-g'``
 
 .. _no-debug-flags-dev:
 
@@ -435,7 +473,10 @@ Options List
 * ``debug_linker_flags``: [ ``string`` ]
     Additional options passed to the linker when ``debug=yes``.
 
-    - default: ``''``
+    - default:
+
+      - If using MSVC: ``'/DEBUG'``
+      - Otherwise: ``''``
 
 .. _no-debug-linker-flags-dev:
 
@@ -451,7 +492,11 @@ Options List
     extra warnings. Used only when compiling source code that is part of
     Cantera (for example, excluding code in the 'ext' directory).
 
-    - default: ``''``
+    - default:
+
+      - If using MSVC: ``'/W3'``
+      - If using ICC: ``'-Wcheck'``
+      - Otherwise: ``'-Wall'``
 
 .. _extra-inc-dirs-dev:
 
@@ -519,7 +564,10 @@ Options List
     actual library and ``libcantera_shared.so`` and ``libcantera_shared.so.2``
     as symlinks.
 
-    - default: ``'no'``
+    - default:
+
+      - If compiling with MinGW or when using SCons < 2.4.0: ``'no'``
+      - Otherwise: ``'yes'``
 
 .. _layout-dev:
 
@@ -532,4 +580,7 @@ Options List
     with a prefix like '/opt/cantera'. 'debian' installs to the
     stage directory in a layout used for generating Debian packages.
 
-    - default: ``'standard'``
+    - default:
+
+      - Windows: ``'compact'``
+      - Otherwise: ``'standard'``

--- a/pages/compiling/config-options-dev.rst
+++ b/pages/compiling/config-options-dev.rst
@@ -360,7 +360,7 @@ Options List
     string ``all`` or a comma separated list of variable names such as
     ``LD_LIBRARY_PATH,HOME``.
 
-    - default: ``'LD_LIBRARY_PATH,PYTHONPATH'``
+    - default: ``'PATH,LD_LIBRARY_PATH,PYTHONPATH'``
 
 .. _use-pch-dev:
 
@@ -560,7 +560,7 @@ Options List
 
 * ``versioned_shared_library``: [ ``yes`` | ``no`` ]
     If enabled, create a versioned shared library, with symlinks to the
-    more generic library name, for example ``libcantera_shared.so.2.4.0`` as the
+    more generic library name, for example ``libcantera_shared.so.2.5.0`` as the
     actual library and ``libcantera_shared.so`` and ``libcantera_shared.so.2``
     as symlinks.
 

--- a/pages/compiling/configure-build-dev.rst
+++ b/pages/compiling/configure-build-dev.rst
@@ -186,10 +186,10 @@ argument after ``scons``):
 * ``scons clean``
     Delete files created while building Cantera.
 
-* ``[sudo] scons install``
+* ``scons install``
     Install Cantera.
 
-* ``[sudo] scons uninstall``
+* ``scons uninstall``
     Uninstall Cantera.
 
 * ``scons test``
@@ -240,7 +240,7 @@ Compile Cantera & Test
     Compilation completed successfully.
 
     - To run the test suite, type 'scons test'.
-    - To install, type '[sudo] scons install'.
+    - To install, type 'scons install'.
     *******************************************************
 
 * If you do not see this message, check the output for errors to see what went

--- a/pages/compiling/configure-build.rst
+++ b/pages/compiling/configure-build.rst
@@ -175,10 +175,10 @@ argument after ``scons``):
 * ``scons clean``
     Delete files created while building Cantera.
 
-* ``[sudo] scons install``
+* ``scons install``
     Install Cantera.
 
-* ``[sudo] scons uninstall``
+* ``scons uninstall``
     Uninstall Cantera.
 
 * ``scons test``
@@ -240,7 +240,7 @@ Compile Cantera & Test
     Compilation completed successfully.
 
     - To run the test suite, type 'scons test'.
-    - To install, type '[sudo] scons install'.
+    - To install, type 'scons install'.
     *******************************************************
 
 * If you do not see this message, check the output for errors to see what went

--- a/pages/compiling/configure-build.rst
+++ b/pages/compiling/configure-build.rst
@@ -86,45 +86,6 @@ options control how the Python module is built:
 * :ref:`python_package <python-package>`
 * :ref:`python_prefix <python-prefix>`
 
-Note that these general options should not be used at the same time
-as the Python-version specific options discussed below. If SCons
-detects that it is being run with Python 2, and the
-:ref:`python2_package <python2-package>` option is set, the build will
-raise an error and exit; or if SCons detects that it is being run with
-Python 3, and the :ref:`python3_package <python3-package>` option is
-set, the build will raise an error and exit.
-
-If a user wishes to build multiple Python interfaces, or a Python
-interface for the version of Python that is not running SCons, they
-should use the version-specific options below, and set the
-:ref:`python_package <python-package>` option to ``none``.
-
-Python 2 Module Options
-^^^^^^^^^^^^^^^^^^^^^^^
-
-By default, if SCons detects a Python 2 interpreter installed in a
-default location (that is, if ``python2`` is on the ``PATH`` environment
-variable) or ``python2_package`` is ``full``, SCons will try to build
-the Python module for Python 2. The following SCons options control how
-the Python 2 module is built:
-
-* :ref:`python2_cmd <python2-cmd>`
-* :ref:`python2_package <python2-package>`
-* :ref:`python2_prefix <python2-prefix>`
-
-Python 3 Module Options
-^^^^^^^^^^^^^^^^^^^^^^^
-
-By default, if SCons detects a Python 3 interpreter installed in a
-default location (that is, if ``python3`` is on the ``PATH`` environment
-variable) or ``python3_package`` is ``full``, SCons will try to build
-the Python module for Python 3. The following SCons options control how
-the Python 3 module is built:
-
-* :ref:`python3_cmd <python3-cmd>`
-* :ref:`python3_package <python3-package>`
-* :ref:`python3_prefix <python3-prefix>`
-
 Windows Only Options
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/pages/compiling/configure-build.rst
+++ b/pages/compiling/configure-build.rst
@@ -167,7 +167,7 @@ option:
 Fortran Module Options
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Building the Fortran module requires a compatible Fortran comiler. SCons will
+Building the Fortran module requires a compatible Fortran compiler. SCons will
 attempt to find a compatible compiler by default in the ``PATH`` environment
 variable. The following options control how the Fortran module is built:
 

--- a/pages/compiling/dependencies.rst
+++ b/pages/compiling/dependencies.rst
@@ -61,7 +61,7 @@ Other Required Software
 * Python:
 
   * https://python.org/downloads/
-  * Known to work with 2.7 and 3.6. Expected to work with versions >= 3.3.
+  * Works with versions >= 3.5.
 
 * Boost
 
@@ -144,11 +144,6 @@ Optional Programs
     format
   * Known to work with versions 0.15.42, 0.15.87, and 0.16.5
   * Expected to work with versions >= 0.15.0
-
-* `3to2 <https://pypi.org/project/3to2>`__
-
-  * Used to convert Python examples to Python 2 syntax.
-  * Known to work with version 1.0
 
 * Matlab
 

--- a/pages/compiling/dependencies.rst
+++ b/pages/compiling/dependencies.rst
@@ -116,6 +116,13 @@ Other Required Software
   * http://fmtlib.net/latest/index.html
   * Version 3.0.1 or newer is required.
 
+* yaml-cpp
+
+  * If yaml-cpp is not installed, it will be automatically downloaded and the
+    necessary portions will be compiled and installed with Cantera.
+  * https://github.com/jbeder/yaml-cpp
+  * Known to work with version 0.6.3. Version 0.6.0 or newer is required.
+
 * Google Test
 
   * If Google Test is not installed, it will be automatically downloaded and the

--- a/pages/compiling/dependencies.rst
+++ b/pages/compiling/dependencies.rst
@@ -21,7 +21,7 @@ Fortran compiler is required only if you plan to build the Fortran module.
 
 * GNU compilers (C/C++/Fortran)
 
-  * Known to work with version 4.8; Expected to work with version >= 4.6
+  * Known to work with version 7.4 and 9.3. Expected to work with version >= 4.6.
 
 * Clang/LLVM (C/C++)
 
@@ -38,8 +38,9 @@ Fortran compiler is required only if you plan to build the Fortran module.
 
 * Microsoft compilers (C/C++)
 
-  * Known to work with versions 12.0 (Visual Studio 2013) and 14.0 (Visual
-    Studio 2015).
+    * Known to work with Visual Studio 2013 (MSVC 12.0), Visual Studio 2015
+      (MSVC 14.0), Visual Studio 2017 (MSVC 14.1), and Visual Studio 2019
+      (MSVC 14.2).
 
 * MinGW (C/C++/Fortran)
 
@@ -75,7 +76,7 @@ Other Required Software
   * If SUNDIALS is not installed, it will be automatically downloaded and the
     necessary portions will be compiled and installed with Cantera.
   * https://computation.llnl.gov/projects/sundials/sundials-software
-  * Known to work with versions >= 2.4, including the 3.x series.
+  * Known to work with versions >= 2.4.
   * To use SUNDIALS with Cantera on a Linux/Unix system, it must be compiled
     with the ``-fPIC`` flag. You can specify this flag when configuring
     SUNDIALS (2.4 or 2.5)::
@@ -129,14 +130,11 @@ Optional Programs
 
   * Required to build the Cantera Python module, and to run significant portions
     of the test suite.
-  * Known to work with versions 1.8.1-1.14.0. Expected to work with
-    versions >= 1.8.1.
-  * Must be installed for each of the Python packages that will be built
+  * Expected to work with versions >= 1.12.0. 1.14.0 or newer is recommended.
 
 * `Cython <http://cython.org/>`__
 
-  * Required version >=0.23 to build the Python module. Must be installed for
-    the same Python where SCons is installed.
+  * Required version >=0.23 to build the Python module.
 
 * `Ruamel.yaml <https://pypi.org/project/ruamel.yaml/>`__
 

--- a/pages/compiling/installation-reqs.rst
+++ b/pages/compiling/installation-reqs.rst
@@ -258,7 +258,7 @@ Fedora & RHEL
 OpenSUSE & SUSE Linux Enterprise
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* OpenSUSE 13.2 or newer; Leap 42.2 or newer recommended
+* OpenSUSE Leap 15.1 or newer recommended
 
 * The following packages must be installed to build any of the Cantera modules using
   your choice of package manager::
@@ -315,10 +315,7 @@ General Notes
 * If you want to build the Matlab toolbox and you have a 64-bit copy of Windows,
   by default you will be using a 64-bit copy of Matlab, and therefore you need
   to compile Cantera in 64-bit mode. For simplicity, it is highly recommended
-  that you use a 64-bit version of Python to handle this automatically. Note
-  that the default download from the Python website
-  (https://www.python.org) is for a 32-bit installer, and you will
-  need to select the 64-bit installer specifically.
+  that you use a 64-bit version of Python to handle this automatically.
 
 * It is generally helpful to have SCons and Python in your ``PATH`` environment
   variable. This can be done by checking the appropriate box during the
@@ -370,8 +367,9 @@ Windows Requirements
 
       * https://visualstudio.microsoft.com/downloads/
 
-      * Known to work with Visual Studio 2013 (MSVC 12.0) and Visual Studio 2015
-        (MSVC 14.0)
+      * Known to work with Visual Studio 2013 (MSVC 12.0), Visual Studio 2015
+        (MSVC 14.0), Visual Studio 2017 (MSVC 14.1), and Visual Studio 2019
+        (MSVC 14.2).
 
     * MinGW compilers
 

--- a/pages/compiling/installation-reqs.rst
+++ b/pages/compiling/installation-reqs.rst
@@ -95,40 +95,6 @@ Conda Requirements
      conda install sphinx doxygen graphviz
      pip install sphinxcontrib-matlabdomain sphinxcontrib-katex sphinxcontrib-doxylink
 
-* (Optional) If you also want to build the Python 2 interface (this is unlikely), create another
-  environment for those dependencies:
-
-  .. code:: bash
-
-     conda create --name py2k python=2 numpy
-     conda activate py2k
-     pip install 3to2
-     conda activate cantera
-
-  and after you've :ref:`cloned the source code <sec-source-code>`, add the following lines to a
-  file called ``cantera.conf``  in the root of the source directory (creating the file if it
-  doesn't exist).
-
-  On macOS and Linux, add the following code to your ``cantera.conf`` file:
-
-  .. code:: python
-
-     python2_package = 'full'
-     python2_cmd = '/path/to/conda/install/folder/envs/py2k/bin/python'
-
-  On Windows, add the following code to your ``cantera.conf`` file:
-
-  .. code:: python
-
-     python2_package = 'full'
-     python2_cmd = '/path/to/conda/install/folder/envs/py2k/python.exe'
-
-  Note that it is not possible to simultaneously install the Python 2 and Python 3 interfaces;
-  you'll have to use separate builds if you want to install both (however, this is an unlikely
-  scenario). In addition, note Cantera 2.4 is the last version that will support Python 2. If
-  you checked out the most recent commit on the ``main`` branch of the git repository,
-  support for Python 2 has already been dropped and you cannot use these options.
-
 * After you've :ref:`cloned the source code <sec-source-code>`, configure the Cantera build by
   adding the following options to a file called ``cantera.conf`` in the root of the source directory
   (creating the file if it doesn't exist).
@@ -137,22 +103,15 @@ Conda Requirements
 
   .. code:: python
 
-     python3_package = 'full'
+     python_package = 'full'
      boost_inc_dir = '/path/to/conda/install/folder/envs/cantera/include'
 
   On Windows, add the following code to your ``cantera.conf`` file:
 
   .. code:: python
 
-     python3_package = 'full'
+     python_package = 'full'
      boost_inc_dir = '/path/to/conda/install/folder/envs/cantera/Library/include'
-
-  .. note::
-
-     If you're using commits from the ``main`` branch of the git repository, Python 2 is no
-     longer supported and the version-specific Python package options have been dropped. You
-     should just use ``python_package`` instead of ``python3_package`` if you're compiling the
-     ``main`` branch.
 
 * Now you can build Cantera with
 
@@ -224,10 +183,6 @@ Ubuntu & Debian
 
       g++ python scons libboost-dev
 
-* In addition to the general packages, building the Python 2 module also requires::
-
-      cython python-dev python-numpy python-numpy-dev python-setuptools
-
 * In addition to the general packages, building the Python 3 module also requires::
 
       cython python3 python3-dev python3-setuptools python3-numpy python3-ruamel.yaml
@@ -267,10 +222,6 @@ Fedora & RHEL
   your choice of package manager::
 
       gcc-c++ python scons boost-devel
-
-* In addition to the general packages, building the Python 2 module also requires::
-
-      python-setuptools python-devel Cython numpy
 
 * In addition to the general packages, building the Python 3 module also requires::
 
@@ -312,15 +263,11 @@ OpenSUSE & SUSE Linux Enterprise
 * The following packages must be installed to build any of the Cantera modules using
   your choice of package manager::
 
-      gcc-c++ python scons boost-devel
+      gcc-c++ python3 scons boost-devel
 
-* In addition to the general packages, building the Python 2 module also requires::
+* In addition to the general packages, building the Python module also requires::
 
-      python-Cython python-devel python-numpy python-numpy-devel python-setuptools
-
-* In addition to the general packages, building the Python 3 module also requires::
-
-      python-Cython python3 python3-devel python3-setuptools python3-numpy python3-numpy-devel python3-ruamel.yaml
+      python3-devel python3-setuptools python3-numpy python3-numpy-devel python3-ruamel.yaml
 
 * In addition to the general packages, building the Fortran module also requires::
 
@@ -451,45 +398,6 @@ Windows Requirements
     * Most packages will be downloaded as Wheel (``*.whl``) files. To install
       these files, type::
 
-          pip install C:\Path\to\downloaded\file\package-file-name.whl
-
-  * Cython
-
-    * http://www.lfd.uci.edu/~gohlke/pythonlibs/#cython
-
-    * Download the ``*.whl`` file for your Python architecture (32-bit or 64-bit)
-      and Python X.Y (indicated by ``cpXY`` in the file name), where X and Y are the
-      major and minor versions of the Python where you installed SCons.
-
-    * Cython must be installed in the version of Python that has SCons installed
-
-  * NumPy
-
-    * http://www.lfd.uci.edu/~gohlke/pythonlibs/#numpy
-
-    * Download the ``*.whl`` file for your Python architecture (32-bit or 64-bit)
-      and Python X.Y (indicated by ``cpXY`` in the file name), where X and Y are the
-      major and minor versions of Python.
-
-* In addition to the general software, building the Python 3 module also requires
-
-  * Python 3
-
-    * https://www.python.org/downloads/
-
-    * Cantera supports Python 3.3 and higher
-
-    * Be sure to choose the appropriate architecture for your system - either
-      32-bit or 64-bit
-
-    * Be careful that the installation of Python with SCons installed comes before the one without,
-      if you have multiple versions of Python installed.
-
-  * Pip
-
-    * Most packages will be downloaded as Wheel (``*.whl``) files. To install
-      these files, type::
-
           pip3 install C:\Path\to\downloaded\file\package-file-name.whl
 
   * Cython
@@ -497,8 +405,8 @@ Windows Requirements
     * http://www.lfd.uci.edu/~gohlke/pythonlibs/#cython
 
     * Download the ``*.whl`` file for your Python architecture (32-bit or 64-bit)
-      and Python X.Y (indicated by ``cpXY`` in the file name), where X and Y are the
-      major and minor versions of the Python where you installed SCons.
+      and Python 3.X (indicated by ``cp3X`` in the file name), where X is the
+      minor version of the Python where you installed SCons.
 
     * Cython must be installed in the version of Python that has SCons installed
 
@@ -507,8 +415,8 @@ Windows Requirements
     * http://www.lfd.uci.edu/~gohlke/pythonlibs/#numpy
 
     * Download the ``*.whl`` file for your Python architecture (32-bit or 64-bit)
-      and Python X.Y (indicated by ``cpXY`` in the file name), where X and Y are the
-      major and minor versions of Python.
+      and Python 3.X (indicated by ``cp3X`` in the file name), where X is the minor
+      version of Python.
 
   * Ruamel.yaml::
 

--- a/pages/compiling/installation-reqs.rst
+++ b/pages/compiling/installation-reqs.rst
@@ -446,29 +446,24 @@ Windows Requirements
 
 .. _sec-macos:
 
-OS X & macOS
-------------
+macOS
+-----
 
 General Notes
 ^^^^^^^^^^^^^
 
-* It is not recommended to use the system-installed version of Python to build
-  Cantera. Instead, the following instructions use Homebrew to install a
-  separate copy of Python, independent from the system Python.
+* Cantera 2.5.0 and higher do not support Python 2, which may be installed by default
+  on your computer. You must install Python 3 from another source to be able to build
+  Cantera. The instructions below use Homebrew.
 
 * To download the source code, installing ``git`` via HomeBrew is highly recommended.
 
-* Cython is only required to be installed for the version of Python that also
-  has SCons installed; following the instructions below will install Cython for
-  the version of Python 2 installed in the system directories. The minimum
-  compatible Cython version is 0.23.
-
 .. _sec-mac-os-reqs:
 
-OS X & macOS Requirements
-^^^^^^^^^^^^^^^^^^^^^^^^^
+macOS Requirements
+^^^^^^^^^^^^^^^^^^
 
-* OS X 10.9 (Mavericks) or newer required; 10.10 (Yosemite) or newer is recommended
+* macOS 10.14 (Mojave) or newer required to install Homebrew
 
 * To build any of the Cantera modules, you will need to install
 
@@ -492,32 +487,22 @@ OS X & macOS Requirements
 
       .. code:: bash
 
-         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
   * Once Homebrew is installed, the rest of the dependencies can be installed with:
 
     .. code:: bash
 
-       brew install python scons boost
+       brew install python scons boost git libomp
 
     Note that brew installs Python 3 by default, but does not over-write the existing system Python.
-    When you want to use the brew-installed Python, you should use ``python3``.
+    When you want to use the brew-installed Python, you should use ``$(brew --prefix)/bin/python3``.
 
-* In addition to the general software, building the Python 2 module also requires:
-
-  .. code:: bash
-
-     brew install python@2
-     pip install numpy
-
-* In addition to the general software, building the Python 3 module also requires:
+* In addition to the general software, building the Python module also requires:
 
   .. code:: bash
 
-     pip3 install cython numpy
-
-  Note that Cython should be installed into the version of Python that has SCons
-  installed.
+     $(brew --prefix)/bin/pip3 install cython numpy ruamel.yaml
 
 * In addition to the general software, building the Fortran module also requires:
 

--- a/pages/compiling/installation-reqs.rst
+++ b/pages/compiling/installation-reqs.rst
@@ -173,10 +173,10 @@ General Notes
 Ubuntu & Debian
 ^^^^^^^^^^^^^^^
 
-* Ubuntu 14.04 LTS (Trusty Tahr) or newer is required; 18.04 LTS (Bionic Beaver)
+* Ubuntu 16.04 LTS (Xenial Xerus) or newer is required; 20.04 LTS (Focal Fossa)
   or newer is recommended
 
-* Debian 7.0 (Wheezy) or newer; 9.0 (Stretch) or newer is recommended
+* Debian 9.0 (Stretch) or newer; 10.0 (Buster) or newer is recommended
 
 * The following packages must be installed to build any of the Cantera modules using
   your choice of package manager::
@@ -349,6 +349,8 @@ Windows Requirements
   * Python
 
     * https://www.python.org/downloads/
+
+    * Cantera supports Python 3.5 and higher
 
     * Be sure to choose the appropriate architecture for your system - either
       32-bit or 64-bit

--- a/pages/compiling/source-code.rst
+++ b/pages/compiling/source-code.rst
@@ -23,7 +23,7 @@ Stable Release
 
   .. code:: bash
 
-      git checkout tags/v2.4.0
+      git checkout tags/v2.5.0
       git submodule update
 
   A list of all the tags can be shown by:
@@ -52,7 +52,7 @@ Beta Release
 
   .. code:: bash
 
-     git checkout tags/v2.4.0b2
+     git checkout tags/v2.5.0b1
      git submodule update
 
   Note that the most recent beta version might be older than the most recent
@@ -68,10 +68,10 @@ Beta Release
 
   .. code:: bash
 
-     git checkout 2.4
+     git checkout 2.5
      git submodule update
 
-  This branch has all the work on the 2.4.x version of the software.
+  This branch has all the work on the 2.5.x version of the software.
 
 Development Version
 -------------------

--- a/pages/compiling/special-cases.rst
+++ b/pages/compiling/special-cases.rst
@@ -89,8 +89,7 @@ Intel Compilers
 
   Another option is to set the :ref:`prefix <prefix>` option to a directory
   for which you have write permissions, and specify the ``USER`` value to the
-  :ref:`python2_prefix <python2-prefix>` or :ref:`python3_prefix <python3-prefix>`
-  option.
+  :ref:`python_prefix <python-prefix>` option.
 
 .. container:: container
 

--- a/pages/documentation/dev-docs.html
+++ b/pages/documentation/dev-docs.html
@@ -102,7 +102,7 @@
       <div class="list-group list-group-flush">
         <a href="{{% ct_dev_docs doxygen/html/modules.html %}}" class="list-group-item dev-docs">List of Cantera Modules</a>
         <a href="{{% ct_dev_docs doxygen/html/classes.html %}}" class="list-group-item dev-docs">List of Cantera Classes</a>
-        <a href="{{% ct_dev_docs doxygen/html/deprecated.html %}}" class="list-group-item dev-docs">List of Deprecated Functions and Classes</a>
+        <a href="{{% ct_dev_docs doxygen/html/da/d58/deprecated.html %}}" class="list-group-item dev-docs">List of Deprecated Functions and Classes</a>
       </div>
     </div>
   </div>

--- a/pages/install/macos-install.rst
+++ b/pages/install/macos-install.rst
@@ -63,8 +63,8 @@ Open Matlab and enter the following code:
 
 .. code-block:: matlab
 
-   gas = Solution('gri30.cti')
-   h2o = Solution('liquidvapor.xml','water')
+   gas = Solution('gri30.yaml')
+   h2o = Solution('liquidvapor.yaml','water')
 
 If the installer cannot find the Cantera Python package, it will cause a warning message
 to be printed to the Matlab console when Matlab starts. To resolve this, edit the ``startup.m``

--- a/pages/install/ubuntu-install.rst
+++ b/pages/install/ubuntu-install.rst
@@ -20,7 +20,7 @@
 As of Cantera 2.5.0, packages are available for Ubuntu 18.04 (Bionic Beaver), Ubuntu 20.04
 (Focal Fossa), and Ubuntu 20.10 (Groovy Gorilla). To see which Ubuntu releases and Cantera
 versions are currently available, visit
-https://launchpad.net/~speth/+archive/ubuntu/cantera
+https://launchpad.net/~cantera-team/+archive/ubuntu/cantera
 
 The available packages are:
 
@@ -36,7 +36,7 @@ To add the Cantera PPA:
 .. code-block:: bash
 
    sudo apt install software-properties-common
-   sudo apt-add-repository ppa:speth/cantera
+   sudo apt-add-repository ppa:cantera-team/cantera
 
 To install all of the Cantera packages:
 

--- a/pages/install/ubuntu-install.rst
+++ b/pages/install/ubuntu-install.rst
@@ -23,8 +23,6 @@ https://launchpad.net/~speth/+archive/ubuntu/cantera
 
 The available packages are:
 
-- ``cantera-python`` - The Cantera Python module for Python 2.
-
 - ``cantera-python3`` - The Cantera Python module for Python 3.
 
 - ``cantera-dev`` - Libraries and header files for compiling your own C++ and

--- a/pages/install/ubuntu-install.rst
+++ b/pages/install/ubuntu-install.rst
@@ -17,8 +17,9 @@
       (PPA). Note that the Matlab packages are not available from this archive; to install the
       Matlab packages on Ubuntu, you must :ref:`compile the source code <sec-compiling>`.
 
-As of Cantera 2.4.0, packages are available for Ubuntu 16.04 (Xenial Xerus) and Ubuntu 18.04 (Bionic
-Beaver). To see which Ubuntu releases and Cantera versions are currently available, visit
+As of Cantera 2.5.0, packages are available for Ubuntu 18.04 (Bionic Beaver), Ubuntu 20.04
+(Focal Fossa), and Ubuntu 20.10 (Groovy Gorilla). To see which Ubuntu releases and Cantera
+versions are currently available, visit
 https://launchpad.net/~speth/+archive/ubuntu/cantera
 
 The available packages are:
@@ -28,40 +29,30 @@ The available packages are:
 - ``cantera-dev`` - Libraries and header files for compiling your own C++ and
   Fortran 90 programs that use Cantera.
 
+- ``cantera-common`` - Cantera data files and example programs
+
 To add the Cantera PPA:
 
 .. code-block:: bash
 
-   sudo aptitude install python-software-properties
+   sudo apt install software-properties-common
    sudo apt-add-repository ppa:speth/cantera
-   sudo aptitude update
 
 To install all of the Cantera packages:
 
 .. code-block:: bash
 
-   sudo aptitude install cantera-python cantera-python3 cantera-dev
+   sudo apt install cantera-python3 cantera-dev
 
-or install whichever subset you need by adjusting the above command.
+or install whichever subset you need by adjusting the above command. The ``cantera-common``
+package is installed as a dependency if any other Cantera packages are selected.
 
 If you plan on using Cantera from Python, you may also want to install IPython
 (an advanced interactive Python interpreter) and Matplotlib (a plotting
-library). Matplotlib is required to run some of the Python examples. For Python
-2, these packages can be installed with:
+library). Matplotlib is required to run some of the Python examples. These packages
+can be installed with:
 
 .. code-block:: bash
 
-    pip2 install ipython matplotlib
-
-And for Python 3, these packages can be installed with:
-
-.. code-block:: bash
-
+    sudo apt install python3-pip
     pip3 install ipython matplotlib
-
-You may need to install ``pip`` first; instructions can be found on the `pip
-installation instructions <https://pip.pypa.io/en/latest/installing/index.html#install-pip>`__.
-You may need to
-have superuser access to install packages into the system directories.
-Alternatively, you can add ``--user`` after ``pip install`` but before the
-package names to install into your local user directory.

--- a/pages/install/windows-install.rst
+++ b/pages/install/windows-install.rst
@@ -21,11 +21,8 @@
 
 **Choose your Python version and architecture**
 
-- On Windows, Installers are provided for Python 2.7, Python 3.5, Python 3.6,
-  and Python 3.7. Python 3.7 is recommended unless you need to use legacy
-  code that does not work with Python 3. You can install multiple Cantera
-  Python modules simultaneously. Note that Cantera 2.4 will be the last
-  version to support Python 2.7.
+- On Windows, Installers are provided for Python 3.6, Python 3.7, Python 3.8
+  and Python 3.9. You can install multiple Cantera Python modules simultaneously.
 
 - Cantera supports both 32- and 64-bit Python installations.
 
@@ -59,25 +56,6 @@
   version of Python, and will include Numpy as well as many other
   packages useful for scientific users.
 
-**Install the Visual C++ Redistributable for Visual Studio 2015**
-
-- If you are using Python 3.5 or higher you can skip this step as this
-  will have already been installed when you installed Python.
-
-- Go to the `Microsoft Visual C++ Redistributable Download Page
-  <https://www.microsoft.com/en-us/download/details.aspx?id=48145>`__.
-
-  - *64-bit*: Download ``vc_redist.x64.exe``
-
-  - *32-bit*: Download ``vc_redist.x86.exe``
-
-- Run the installer.
-
-- If this package is not installed, you will encounter the following error
-  when importing the ``cantera`` module::
-
-     ImportError: DLL load failed: The specified module could not be found.
-
 **Install NumPy and optional Python packages**
 
 - Go to the `Unofficial Windows Binaries for Python Extension Packages page
@@ -109,7 +87,7 @@
 
 - Remove both the main Cantera package and the Python module.
 
-- The Python module will be listed as "Python *X.Y* Cantera ..."
+- The Python module will be listed as "Python *3.X* Cantera ..."
 
 **Install Cantera**
 

--- a/pages/install/windows-install.rst
+++ b/pages/install/windows-install.rst
@@ -133,12 +133,12 @@
   .. code-block:: python
 
      import cantera
-     gas = cantera.Solution('gri30.cti')
-     h2o = cantera.PureFluid('liquidvapor.cti', 'water')
+     gas = cantera.Solution('gri30.yaml')
+     h2o = cantera.PureFluid('liquidvapor.yaml', 'water')
 
 - Matlab:
 
   .. code-block:: matlab
 
-     gas = IdealGasMix('gri30.cti')
-     h2o = Solution('liquidvapor.cti','water')
+     gas = IdealGasMix('gri30.yaml')
+     h2o = Solution('liquidvapor.yaml','water')

--- a/pages/install/windows-install.rst
+++ b/pages/install/windows-install.rst
@@ -64,14 +64,14 @@
 - Download the most recent release (distributed as a "wheel" archive) of the
   1.x series for Python *X.Y* that matches your Python architecture. In the
   filename, the digits after "cp" indicate the Python version. For example,
-  ``numpy‑1.11.2+mkl‑cp37‑none‑win_amd64.whl`` is the installer for 64-bit
-  Python 3.7. The Windows installers for Cantera 2.4.0 require NumPy 1.10 or
-  newer.
+  ``numpy‑1.19.5+mkl‑cp39‑cp39‑win_amd64.whl`` is the installer for 64-bit
+  Python 3.9. The Windows installers for Cantera 2.5.0 require NumPy 1.12 or
+  newer (1.14 or newer is recommended).
 
 - From an administrative command prompt, install the downloaded wheel using
   pip. For example::
 
-      c:\python37\scripts\pip.exe install "%USERPROFILE%\Downloads\numpy‑1.11.2+mkl‑cp37‑none‑win_amd64.whl"
+      c:\python39\scripts\pip.exe install "%USERPROFILE%\Downloads\numpy‑1.19.5+mkl‑cp39‑cp39‑win_amd64.whl"
 
 - If you plan on using Cantera from Python, note that we highly recommend
   installing the conda package. If you plan to continue using this Python
@@ -94,10 +94,10 @@
 - Go to the `Cantera Releases <https://github.com/Cantera/cantera/releases>`_
   page.
 
-  - *64-bit*: Download **Cantera-2.4.0-x64.msi** and
-    **Cantera-Python-2.4.0-x64-pyX.Y.msi**.
-  - *32-bit*: Download **Cantera-2.4.0-x86.msi** and
-    **Cantera-Python-2.4.0-x86-pyX.Y.msi**.
+  - *64-bit*: Download **Cantera-2.5.0-x64.msi** and
+    **Cantera-Python-2.5.0-x64-py3.X.msi**.
+  - *32-bit*: Download **Cantera-2.5.0-x86.msi** and
+    **Cantera-Python-2.5.0-x86-py3.Y.msi**.
 
 - If you are only using the Python module, you do not need to download and
   install the base package (the one without Python in the name).

--- a/pages/tutorials/MatlabTutorial.rst
+++ b/pages/tutorials/MatlabTutorial.rst
@@ -65,7 +65,7 @@ temperature, a pressure, species mole and mass fractions, etc. As we'll soon
 see, it has many more properties.
 
 The summary of the state of ``gas1`` printed above shows that new objects
-created from the ``gri30.cti`` input file start out with a temperature of 300 K,
+created from the ``gri30.yaml`` input file start out with a temperature of 300 K,
 a pressure of 1 atm, and have a composition that consists of only one species,
 in this case hydrogen. There is nothing special about H2, it just happens to
 be the first species listed in the input file defining GRI-Mech 3.0. In
@@ -220,13 +220,13 @@ Importing multiple phases or interfaces
 A Cantera input file may contain more than one phase specification,
 or may contain specifications of interfaces (surfaces). Here we
 import definitions of two bulk phases and the interface between them
-from file ``diamond.cti``:
+from file ``diamond.yaml``:
 
 .. code:: matlabsession
 
-    >> gas2 = Solution('diamond.cti', 'gas');        % a gas
-    >> diamond = Solution('diamond.cti','diamond');  % bulk diamond
-    >> diamonnd_surf = importInterface('diamond.cti','diamond_100',...
+    >> gas2 = Solution('diamond.yaml', 'gas');        % a gas
+    >> diamond = Solution('diamond.yaml','diamond');  % bulk diamond
+    >> diamonnd_surf = importInterface('diamond.yaml','diamond_100',...
                                        gas2, diamond);
 
 Note that the bulk (3D) phases that participate in the surface
@@ -253,11 +253,11 @@ this is shown here:
 
 .. code:: matlabsession
 
-    >> gas1 = Solution('gri30.cti', 'gri30');
+    >> gas1 = Solution('gri30.yaml', 'gri30');
 
 Function :mat:func:`Solution` constructs an object representing a phase of
 matter by reading in attributes of the phase from a file, which in
-this case is ``gri30.cti``. This file contains several phase
+this case is ``gri30.yaml``. This file contains several phase
 specifications; the one we want here is ``gri30``, which is specified
 by the second argument. This file contains a complete specification
 of the GRI-Mech 3.0 reaction mechanism, including element data
@@ -265,8 +265,8 @@ of the GRI-Mech 3.0 reaction mechanism, including element data
 coefficients to compute thermodynamic and transport properties), and
 reaction data (stoichiometry, rate coefficient parameters).
 
-CTI files distributed with Cantera
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Input files distributed with Cantera
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Several reaction mechanism files in this format are included in the
 Cantera distribution, including ones that model high-temperature
@@ -287,26 +287,15 @@ directory where they are located. Alternatively, you can call function
 
     >> adddir('/usr/local/cantera/my_data_files');
 
-XML files
-~~~~~~~~~
+Cantera currently supports three input formats for data. The primary format,
+introduced in Cantera 2.5.0, is the YAML format. Two older formats (CTI and XML)
+can also be used, but they are deprecated and support for them will be removed
+in a future release. Utilities are provided for converting existing CTI and XML
+files to YAML. For more info, see
+`Converting CTI and XML input files to YAML <legacy2yaml.html>`__.
 
-Note that Cantera has two input formats for data, the human-readable and -writable
-CTI format, and the lower-level XML format. All of the CTI files distributed with
-Cantera are also available as XML files; using the XML files may be somewhat faster
-and does not invoke the Python interpreter to read the CTI file. More information
-on why Cantera uses two file formats is available in the
-:ref:`input files tutorial <sec-two-file-formats>`.
-
-.. code:: matlabsession
-
-    >> gas4 = Solution('gri30.xml','gri30');
-
-Interfaces can be imported from XML files too:
-
-.. code:: matlabsession
-
-   >> diamonnd_surf2 = importInterface('diamond.xml','diamond_100',...
-                                       gas2, diamond);
+To learn more about the input files already available with Cantera and how to
+create new input files, see :doc:`Working With Input Files <input-files>`.
 
 Let's clear out all our Matlab and Cantera objects, before we move on:
 
@@ -315,8 +304,6 @@ Let's clear out all our Matlab and Cantera objects, before we move on:
     >> clear all
     >> cleanup
 
-To learn more about the cti files already available with Cantera and how to
-create new cti files, see :doc:`Working With Input Files <input-files>`
 
 Getting Help
 ============

--- a/pages/tutorials/PythonTutorial.rst
+++ b/pages/tutorials/PythonTutorial.rst
@@ -27,7 +27,7 @@ some phase of matter. Here, we'll create a gas mixture
 
 .. code:: pycon
 
-    >>> gas1 = ct.Solution('gri30.xml')
+    >>> gas1 = ct.Solution('gri30.yaml')
 
 To view the state of the mixture, *call* the ``gas1`` object as if it were a
 function:
@@ -73,7 +73,7 @@ temperature, a pressure, species mole and mass fractions, etc. As we'll soon
 see, it has many more properties.
 
 The summary of the state of ``gas1`` printed above shows that new objects
-created from the ``gri30.xml`` input file start out with a temperature of 300 K,
+created from the ``gri30.yaml`` input file start out with a temperature of 300 K,
 a pressure of 1 atm, and have a composition that consists of only one species,
 in this case hydrogen. There is nothing special about H2 - it just happens to
 be the first species listed in the input file defining GRI-Mech 3.0. In
@@ -258,12 +258,10 @@ Working With Mechanism Files
 ============================
 
 In previous example, we created an object that models an ideal gas mixture
-with the species and reactions of GRI-Mech 3.0, using the ``gri30.xml`` input
-file included with Cantera. This is a "pre-processed" XML input file written
-in a format that is easy for Cantera to parse. Cantera also supports an input
-file format that is easier to write, called *CTI*. Several reaction mechanism
-files in this format are included with Cantera, including ones that model
-high- temperature air, a hydrogen/oxygen reaction mechanism, and a few surface
+with the species and reactions of GRI-Mech 3.0, using the ``gri30.yaml`` input
+file included with Cantera. Several other reaction mechanism files are
+included with Cantera, including ones that model high- temperature air,
+a hydrogen/oxygen reaction mechanism, and a few surface
 reaction mechanisms. These files are usually located in the ``data``
 subdirectory of the Cantera installation directory, for example ``C:\\Program
 Files\\Cantera\\data`` on Windows or ``/usr/local/cantera/data/`` on
@@ -286,13 +284,13 @@ information.
 
 A Cantera input file may contain more than one phase specification, or may
 contain specifications of interfaces (surfaces). Here we import definitions of
-two bulk phases and the interface between them from file ``diamond.cti``:
+two bulk phases and the interface between them from file ``diamond.yaml``:
 
 .. code:: pycon
 
-    >>> gas2 = ct.Solution('diamond.cti', 'gas')
-    >>> diamond = ct.Solution('diamond.cti', 'diamond')
-    >>> diamond_surf = ct.Interface('diamond.cti' , 'diamond_100',
+    >>> gas2 = ct.Solution('diamond.yaml', 'gas')
+    >>> diamond = ct.Solution('diamond.yaml', 'diamond')
+    >>> diamond_surf = ct.Interface('diamond.yaml' , 'diamond_100',
     ...                             [gas2, diamond])
 
 Note that the bulk (3D) phases that participate in the surface reactions must
@@ -301,8 +299,8 @@ also be passed as arguments to :py:class:`Interface`.
 Converting CK-format files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See the :doc:`Converting CK-format Files <ck2cti-tutorial>` documentation for
-information on how to convert from CK-format to CTI format.
+See the :doc:`Converting CK-format Files <ck2yaml-tutorial>` documentation for
+information on how to convert from CK-format to Cantera's YAML format.
 
 Getting Help
 ============
@@ -316,7 +314,7 @@ available for it, and get help on using the methods:
 
 .. code:: pycon
 
-    >>> g = ct.Solution('gri30.xml')
+    >>> g = ct.Solution('gri30.yaml')
 
 To get help on the Python class that this object is an instance of:
 
@@ -366,7 +364,7 @@ method:
 .. code:: pycon
 
     >>> import cantera as ct
-    >>> g = ct.Solution('gri30.xml')
+    >>> g = ct.Solution('gri30.yaml')
     >>> g.TPX = 300.0, ct.one_atm, 'CH4:0.95,O2:2,N2:7.52'
     >>> g.equilibrate('TP')
 
@@ -438,7 +436,7 @@ state can be obtained by accessing :py:class:`Reaction` objects with the
 
 .. code:: pycon
 
-    >>> g = ct.Solution('gri30.cti')
+    >>> g = ct.Solution('gri30.yaml')
     >>> r = g.reaction(2) # get a Reaction object
     >>> r
     <ElementaryReaction: H2 + O <=> H + OH>

--- a/pages/tutorials/cxx-guide/compiling.rst
+++ b/pages/tutorials/cxx-guide/compiling.rst
@@ -115,8 +115,8 @@ program that uses Cantera might look like this:
 
 Several example ``CMakeLists.txt`` files are included with the C++ examples
 contained in the ``samples`` subdirectory of the Cantera installation directory,
-which have the paths and lists of libraries correctly configured for system on
-which they are installed.
+which have the paths and lists of libraries correctly configured for the
+system on which they are installed.
 
 Make
 ====

--- a/pages/tutorials/cxx-guide/demo1a.cpp
+++ b/pages/tutorials/cxx-guide/demo1a.cpp
@@ -8,7 +8,7 @@ using namespace Cantera;
 void simple_demo()
 {
     // Create a new phase
-    std::unique_ptr<ThermoPhase> gas(newPhase("h2o2.cti","ohmech"));
+    std::unique_ptr<ThermoPhase> gas(newPhase("h2o2.yaml", "ohmech"));
 
     // Set its state by specifying T (500 K) P (2 atm) and the mole
     // fractions. Note that the mole fractions do not need to sum to

--- a/pages/tutorials/cxx-guide/demo1b.cpp
+++ b/pages/tutorials/cxx-guide/demo1b.cpp
@@ -1,6 +1,7 @@
 #include "cantera/thermo.h"
 #include "cantera/kinetics.h"
 #include "cantera/transport.h"
+#include "cantera/base/Solution.h"
 
 using namespace Cantera;
 
@@ -8,18 +9,12 @@ using namespace Cantera;
 // program.
 void simple_demo2()
 {
-    // Create a new phase
-    std::unique_ptr<ThermoPhase> gas(newPhase("gri30.cti", "gri30_mix"));
+    // Create a new Phase, including Kinetics and Transport objects
+    std::shared_ptr<Solution> soln = newSolution("gri30.yaml", "gri30", "mixture-averaged");
+    std::shared_ptr<ThermoPhase> gas = soln->thermo();
+    std::shared_ptr<Kinetics> kin = soln->kinetics();
 
-    // List of phases participating in reactions (just one for homogeneous
-    // kinetics)
-    std::vector<ThermoPhase*> phases{gas.get()};
-
-    // Create the Kinetics object. Based on the phase definition used, this will
-    // be a GasKinetics object.
-    std::unique_ptr<Kinetics> kin(newKineticsMgr(gas->xml(), phases));
-
-    // Set an "interesting" mixture state where we will observe non-zero reacton
+    // Set an "interesting" mixture state where we will observe non-zero reaction
     // rates.
     gas->setState_TPX(500.0, 2.0*OneAtm, "CH4:1.0, O2:1.0, N2:3.76");
     gas->equilibrate("HP");
@@ -40,9 +35,8 @@ void simple_demo2()
     }
     writelog("\n");
 
-    // Create a Transport object. Based on the transport model specified in the
-    // "gri30_mix" phase, this will be a MixGasTransport object.
-    std::unique_ptr<Transport> trans(newDefaultTransportMgr(gas.get()));
+    // Create a Transport object
+    std::shared_ptr<Transport> trans = soln->transport();
     writelog("T        viscosity     thermal conductivity\n");
     writelog("------   -----------   --------------------\n");
     for (size_t n = 0; n < 5; n++) {

--- a/pages/tutorials/cxx-guide/demoequil.cpp
+++ b/pages/tutorials/cxx-guide/demoequil.cpp
@@ -1,4 +1,5 @@
 #include "cantera/thermo.h"
+#include <iostream>
 
 using namespace Cantera;
 

--- a/pages/tutorials/cxx-guide/demoequil.cpp
+++ b/pages/tutorials/cxx-guide/demoequil.cpp
@@ -5,7 +5,7 @@ using namespace Cantera;
 
 void equil_demo()
 {
-    std::unique_ptr<ThermoPhase> gas(newPhase("h2o2.cti","ohmech"));
+    std::unique_ptr<ThermoPhase> gas(newPhase("h2o2.yaml"));
     gas->setState_TPX(1500.0, 2.0*OneAtm, "O2:1.0, H2:3.0, AR:1.0");
     gas->equilibrate("TP");
     std::cout << gas->report() << std::endl;

--- a/pages/tutorials/cxx-guide/factories.rst
+++ b/pages/tutorials/cxx-guide/factories.rst
@@ -19,7 +19,7 @@ object types:
 - ``Transport`` - computes transport properties for a `ThermoPhase`
 
 This program uses "factory" functions to create derived objects objects of the
-appropriate type which are specified in the input file ``gri30.cti``.
+appropriate type which are specified in the input file ``gri30.yaml``.
 
 .. include:: pages/tutorials/cxx-guide/demo1b.cpp
    :code: c++

--- a/pages/tutorials/cxx-guide/thermo.rst
+++ b/pages/tutorials/cxx-guide/thermo.rst
@@ -28,7 +28,7 @@ prints its temperature is shown below:
    int main(int argc, char** argv)
    {
        std::unique_ptr<Cantera::ThermoPhase> gas(
-           Cantera::newPhase("h2o2.cti", "ohmech"));
+           Cantera::newPhase("h2o2.yaml", "ohmech"));
        std::cout << gas->temperature() << std::endl;
        return 0;
    }

--- a/pages/tutorials/cxx-guide/thermodemo.cpp
+++ b/pages/tutorials/cxx-guide/thermodemo.cpp
@@ -34,7 +34,7 @@ void thermo_demo(const std::string& file, const std::string& phase)
 int main(int argc, char** argv)
 {
     try {
-        thermo_demo("h2o2.cti","ohmech");
+        thermo_demo("h2o2.yaml", "ohmech");
     } catch (CanteraError& err) {
         std::cout << err.what() << std::endl;
         return 1;

--- a/pages/tutorials/cxx-guide/thermodemo.cpp
+++ b/pages/tutorials/cxx-guide/thermodemo.cpp
@@ -1,4 +1,5 @@
 #include "cantera/thermo.h"
+#include <iostream>
 
 using namespace Cantera;
 

--- a/pages/tutorials/input-files.rst
+++ b/pages/tutorials/input-files.rst
@@ -19,12 +19,12 @@ The required input files can be provided via one of several methods:
 - Use one of the pre-existing input files provided with Cantera
 - Convert a pre-existing mechanism from Chemkin (CK) format to YAML format *(New
   in Cantera 2.5)*
-- Convert a pre-existing mechanism from Chemkin (CK) format to Cantera (CTI) format
+- Convert a pre-existing mechanism from Chemkin (CK) format to Cantera (CTI) format (not recommended)
 - Create your own YAML file from scratch or by editing an existing file *(New in
   Cantera 2.5)*
 - Create your own CTI file, either from scratch (not recommended) or by editing an existing file
 
-The first two options will suffice for a majority of Cantera users. Advanced
+The first option will suffice for a majority of Cantera users. Advanced
 users may, however, need to edit an existing input file in order to define
 additional species, reactions, or entirely new phases. Even if you need to
 create an entirely new input file, it is still advisable to start from an existing
@@ -37,15 +37,15 @@ easily lead to errors, if one forgets that this file does not represent the orig
 Input files distributed with Cantera
 ====================================
 
-Several reaction mechanism files in the CTI format are included in the Cantera distribution,
-including ones that model natural gas combustion (``gri30.cti``), high-temperature air
-(``air.cti``), a hydrogen/oxygen reaction mechanism (``h2o2.cti``), some pure fluids in the
-liquid-vapor region (``liquidvapor.cti``), and a few surface reaction mechanisms (such as
-``ptcombust.cti``, ``diamond.cti``, etc.), among others. Under Windows, these files may be located
+Several reaction mechanism files are included in the Cantera distribution,
+including ones that model natural gas combustion (``gri30.yaml``), high-temperature air
+(``air.yaml``), a hydrogen/oxygen reaction mechanism (``h2o2.yaml``), some pure fluids in the
+liquid-vapor region (``liquidvapor.yaml``), and a few surface reaction mechanisms (such as
+``ptcombust.yaml``, ``diamond.yaml``, etc.), among others. Under Windows, these files may be located
 in ``C:\Program Files\Cantera\data`` depending on how you installed Cantera and the options you
 specified. On a Unix/Linux/macOS machine, they are usually kept in the ``data`` subdirectory
-within the Cantera installation directory. Starting with Cantera 2.5, corresponding
-versions of these input files in the YAML format are also installed.
+within the Cantera installation directory. Corresponding versions of these input files in the
+CTI and XML format are also installed, for backwards compatibility.
 
 Please see the tutorials for :doc:`Python <python-tutorial>` and :doc:`Matlab <matlab-tutorial>`
 for instructions on how to import from these pre-existing files.

--- a/plugins/new_release.py
+++ b/plugins/new_release.py
@@ -100,6 +100,7 @@ class NewRelease(Command):
             "(https://github.com/Cantera/cantera/releases/tag/{})".format(date, slug)
             + release_text[end_of_firstline:]
         )
+        release_text = release_text.replace("\r\n", "\n").replace("\r", "\n")
 
         # Create a new markdown page with the formatted release information
         self.site.plugin_manager.getPluginByName(


### PR DESCRIPTION
Just collecting some updates to be merged into the website in conjunction with the release of Cantera 2.5.0.

Some remaining To-do items:
- [x] The section "OS X & macOS" in installation-reqs.txt needs to be updated to reflect the end of Python 2 support, but I'm not actually sure what the right instructions here are.
- [x] Figure out what the minimum Numpy version is going to be for the Windows binaries

Resolves #97 
Resolves Cantera/cantera#565
