### PR TITLE
Render C++ and Fortran example programs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -300,6 +300,7 @@ EXAMPLES_FOLDERS = {
     "../cantera/interfaces/cython/cantera/examples": "examples/python",
     "../cantera-jupyter": "examples/jupyter",
     "../cantera/samples/matlab": "examples/matlab",
+    "../cantera/samples/cxx": "examples/cxx",
 }
 # Which means process listings from 'listings' into 'output/listings'
 

--- a/conf.py
+++ b/conf.py
@@ -301,6 +301,7 @@ EXAMPLES_FOLDERS = {
     "../cantera-jupyter": "examples/jupyter",
     "../cantera/samples/matlab": "examples/matlab",
     "../cantera/samples/cxx": "examples/cxx",
+    "../cantera/samples/f90": "examples/fortran"
 }
 # Which means process listings from 'listings' into 'output/listings'
 

--- a/pages/examples/index.rst
+++ b/pages/examples/index.rst
@@ -13,55 +13,86 @@
       Cantera includes example scripts for a number of applications. Depending on which interface
       you're using, select one of the categories below.
 
-.. container:: card-deck
 
-   .. container:: card
+.. container:: container
 
-      .. container::
-         :tagname: a
-         :attributes: href="python/index.html"
-                      title="Python Examples"
+   .. row::
 
-         .. container:: card-header section-card
+      .. container:: col-12
 
-            Python Examples
+         .. container:: card-deck
 
-      .. container:: card-body
+            .. container:: card
 
-         .. container:: card-text
+               .. container::
+                  :tagname: a
+                  :attributes: href="python/index.html"
+                              title="Python Examples"
 
-            Examples of using the Python interface
+                  .. container:: card-header section-card
 
-   .. container:: card
+                     Python Examples
 
-      .. container::
-         :tagname: a
-         :attributes: href="matlab/index.html"
-                      title="Matlab Examples"
+               .. container:: card-body
 
-         .. container:: card-header section-card
+                  .. container:: card-text
 
-            Matlab Examples
+                     Examples of using the Python interface
 
-      .. container:: card-body
+            .. container:: card
 
-         .. container:: card-text
+               .. container::
+                  :tagname: a
+                  :attributes: href="matlab/index.html"
+                              title="Matlab Examples"
 
-            Examples of using the Matlab interface
+                  .. container:: card-header section-card
 
-   .. container:: card
+                     Matlab Examples
 
-      .. container::
-         :tagname: a
-         :attributes: href="jupyter/index.html"
-                      title="Jupyter Notebook Examples"
+               .. container:: card-body
 
-         .. container:: card-header section-card
+                  .. container:: card-text
 
-            Jupyter Notebook Examples
+                     Examples of using the Matlab interface
 
-      .. container:: card-body
+            .. container:: card
 
-         .. container:: card-text
+               .. container::
+                  :tagname: a
+                  :attributes: href="jupyter/index.html"
+                              title="Jupyter Notebook Examples"
 
-            Examples of using the Jupyter Notebook and the Python interface.
+                  .. container:: card-header section-card
+
+                     Jupyter Notebook Examples
+
+               .. container:: card-body
+
+                  .. container:: card-text
+
+                     Examples of using the Jupyter Notebook and the Python interface.
+
+   .. row::
+
+      .. container:: col-12
+
+         .. container:: card-deck
+
+            .. container:: card
+
+               .. container::
+                  :tagname: a
+                  :attributes: href="cxx/index.html"
+                              title="C++ Examples"
+
+                  .. container:: card-header section-card
+
+                     C++ Examples
+
+               .. container:: card-body
+
+                  .. container:: card-text
+
+                     Examples of using Cantera directly from C++ applications.
+

--- a/pages/examples/index.rst
+++ b/pages/examples/index.rst
@@ -96,3 +96,20 @@
 
                      Examples of using Cantera directly from C++ applications.
 
+            .. container:: card
+
+               .. container::
+                  :tagname: a
+                  :attributes: href="fortran/index.html"
+                              title="Fortran Examples"
+
+                  .. container:: card-header section-card
+
+                     Fortran Examples
+
+               .. container:: card-body
+
+                  .. container:: card-text
+
+                     Examples of using the Cantera Fortran 90 interface, and of using Cantera from Fortran 77.
+

--- a/plugins/render_cxx_examples.plugin
+++ b/plugins/render_cxx_examples.plugin
@@ -1,0 +1,8 @@
+[Core]
+Name = render_cxx_examples
+Module = render_cxx_examples
+
+[Documentation]
+Author = Ray Speth
+Version = 0.1
+Description = Build the Cantera C++ examples into the output

--- a/plugins/render_cxx_examples.py
+++ b/plugins/render_cxx_examples.py
@@ -1,0 +1,242 @@
+"""Render the C++ examples from the Cantera repository into Nikola listings.
+
+This plugin renders C++ examples from the main Cantera repository into the
+examples/cpp output folder. It looks for the examples in the folder configured
+in the top-level conf.py file in the ``EXAMPLES_FOLDERS`` dictionary. That
+dictionary has keys with the source folder and values with the destination
+folder (relative to the ``OUTPUT_FOLDER``). The relevant source folder is found
+as the key associated with the value that contains the string ``cxx``,
+typically ``"../cantera/samples/cxx": "examples/cxx"``.
+"""
+from pathlib import Path
+
+from nikola.plugin_categories import Task
+from nikola import utils
+from pygments import highlight
+from pygments.lexers import CppLexer
+from itertools import chain
+import re
+import natsort
+
+
+def render_example_index(site, kw, headers, output_file):
+    """Render the index of all of the C++ examples.
+
+    Parameters
+    ==========
+    site:
+        An instance of a Nikola site, available in any plugin as ``self.site``
+    kw:
+        A dictionary of keywords for this task
+    headers:
+        A dictionary of the example categories and the summaries of each example
+    output_file:
+        A pathlib.Path instance representing the output file that will be rendered
+
+    """
+    n = 3
+    for head_dict in headers.values():
+        head_files = head_dict["files"]
+        head_dict["files"] = [
+            head_files[i : i + n] for i in range(0, len(head_files), n)  # NOQA: E203
+        ]
+
+    permalink = output_file.relative_to(kw["output_folder"])
+    title = "C++ Examples"
+    context = {
+        "headers": headers,
+        "lang": kw["default_lang"],
+        "pagekind": ["example"],
+        "permalink": str(permalink),
+        "title": title,
+        "description": title,
+    }
+    site.render_template("cxx-example-index.tmpl", str(output_file), context)
+
+
+def render_example(site, kw, in_name, out_name):
+    """Render a single .m file to HTML with formatting.
+
+    Parameters
+    ==========
+    site:
+        An instance of a Nikola site, available in any plugin as ``self.site``
+    kw:
+        A dictionary of keywords for this task
+    in_name:
+        The file to be rendered, as an instance of pathlib.Path
+    out_name:
+        A pathlib.Path instance pointing to the rendered output file
+
+    """
+    code = highlight(
+        in_name.read_bytes(), CppLexer(), utils.NikolaPygmentsHTML(in_name.name)
+    )
+
+    title = in_name.name
+    permalink = out_name.relative_to(kw["output_folder"])
+    source_link = permalink.stem  # remove '.html'
+    context = {
+        "code": code,
+        "title": title,
+        "permalink": str(permalink),
+        "lang": kw["default_lang"],
+        "description": title,
+        "source_link": source_link,
+        "pagekind": ["example"],
+    }
+    site.render_template("examples.tmpl", str(out_name), context)
+
+
+class RenderCxxExamples(Task):
+    """Render the C++ examples with a Nikola Task.
+
+    As with all Nikola ``Tasks``, the key method here is the ``gen_tasks``
+    method, which yields dictionaries that represent tasks that doit needs
+    to run. There are two primary kinds of tasks, one that renders each
+    example file, and one that renders an index of all of the examples.
+    """
+
+    name = "render_cxx_examples"
+
+    def set_site(self, site):
+        """Set Nikola site."""
+        # Verify that a Python output folder appears only once in EXAMPLES_FOLDERS
+        found_cxx = False
+        for source, dest in site.config["EXAMPLES_FOLDERS"].items():
+            if "cxx" in dest:
+                if found_cxx:
+                    self.logger.error(
+                        "More than one folder to output C++ examples was found in "
+                        "EXAMPLES_FOLDERS, exiting"
+                    )
+                else:
+                    found_cxx = True
+                    self.input_folder = source
+                    self.examples_folder = dest
+
+        if not found_cxx:
+            self.logger.warn(
+                "Didn't find an output folder for C++ examples in EXAMPLES_FOLDERS"
+            )
+
+        return super().set_site(site)
+
+    def gen_tasks(self):
+        """Render examples."""
+        kw = {
+            "default_lang": self.site.config["DEFAULT_LANG"],
+            "examples_folders": self.site.config["EXAMPLES_FOLDERS"],
+            "output_folder": Path(self.site.config["OUTPUT_FOLDER"]),
+            "index_file": self.site.config["INDEX_FILE"],
+            "strip_indexes": self.site.config["STRIP_INDEXES"],
+        }
+
+        yield self.group_task()
+
+        # When any key or value in the uptodate dictionary changes, the
+        # examples pages need to be rebuilt.
+        uptodate = {"c": self.site.GLOBAL_CONTEXT}
+
+        for k, v in self.site.GLOBAL_CONTEXT["template_hooks"].items():
+            uptodate["||template_hooks|{0}||".format(k)] = v.calculate_deps()
+
+        for k in self.site._GLOBAL_CONTEXT_TRANSLATABLE:
+            uptodate[k] = self.site.GLOBAL_CONTEXT[k](kw["default_lang"])
+
+        # save navigation links as dependencies
+        uptodate["nav_links"] = uptodate["c"]["navigation_links"](kw["default_lang"])
+
+        uptodate["kw"] = kw
+
+        examples_template_deps = self.site.template_system.template_deps(
+            "examples.tmpl"
+        )
+
+        index_template_deps = self.site.template_system.template_deps(
+            "cxx-example-index.tmpl"
+        )
+        folder = Path(self.input_folder).resolve()
+        cxx_examples = list(chain(folder.glob("**/*.cpp"), folder.glob("**/*.h")))
+        cxx_headers = {
+            "examples": {"name": "Examples", "files": [], "summaries": {}}
+        }
+
+        uptodate["d"] = cxx_headers.keys()
+        uptodate["f"] = list(map(str, cxx_examples))
+
+        for cxx_ex_file in cxx_examples:
+            # Try to get the first comment block in the file to use as a description
+            cxx_headers["examples"]["files"].append(cxx_ex_file)
+            doc = []
+            in_block_comment = False
+            for line in cxx_ex_file.read_text(encoding="utf-8").split("\n"):
+                line = line.strip()
+                if '*/' in line:
+                    in_block_comment = False
+                    line = line[:line.find('*/')]
+                if line.startswith('/*'):
+                    doc.append(line.lstrip('/* !'))
+                    in_block_comment = True
+                if in_block_comment or line.startswith("//")  or line.startswith('* '):
+                    doc.append(line.lstrip('/* !'))
+                elif doc:
+                    break
+            doc = ' '.join(doc).strip()
+            print(cxx_ex_file, '======\n', doc, '\n================\n')
+            if doc.startswith('@file'):
+                doc = re.sub(r'@file \w+.\w+ ', '', doc)
+            if not doc:
+                self.logger.warn(
+                    "The C++ example {!s} doesn't have an appropriate summary. The "
+                    "first comment line of the C++ file is taken as the "
+                    "summary.".format(cxx_ex_file)
+                )
+            name = cxx_ex_file.stem.replace("_", " ")
+            cxx_headers["examples"]["summaries"][cxx_ex_file.name] = doc
+            out_name = kw["output_folder"].joinpath(
+                self.examples_folder, cxx_ex_file.name + '.html'
+            )
+
+            yield {
+                "basename": self.name,
+                "name": str(out_name),
+                "file_dep": examples_template_deps + [cxx_ex_file],
+                "targets": [out_name],
+                "actions": [(render_example, [self.site, kw, cxx_ex_file, out_name])],
+                # This is necessary to reflect changes in blog title,
+                # sidebar links, etc.
+                "uptodate": [utils.config_changed(uptodate, "cxx_examples:source")],
+                "clean": True,
+            }
+
+            out_name = kw["output_folder"].joinpath(
+                self.examples_folder, cxx_ex_file.name
+            )
+            yield {
+                "basename": self.name,
+                "name": str(out_name),
+                "file_dep": [cxx_ex_file],
+                "targets": [out_name],
+                "actions": [(utils.copy_file, [cxx_ex_file, out_name])],
+                "clean": True,
+            }
+
+        cxx_headers["examples"]["files"] = natsort.natsorted(
+            cxx_headers["examples"]["files"], alg=natsort.IC
+        )
+
+        out_name = kw["output_folder"].joinpath(self.examples_folder, kw["index_file"])
+        yield {
+            "basename": self.name,
+            "name": str(out_name),
+            "file_dep": index_template_deps + list(map(str, cxx_examples)),
+            "targets": [out_name],
+            "actions": [
+                (render_example_index, [self.site, kw, cxx_headers, out_name])
+            ],
+            # This is necessary to reflect changes in blog title,
+            # sidebar links, etc.
+            "uptodate": [utils.config_changed(uptodate, "cxx_examples:folder")],
+            "clean": True,
+        }

--- a/plugins/render_fortran_examples.plugin
+++ b/plugins/render_fortran_examples.plugin
@@ -1,0 +1,8 @@
+[Core]
+Name = render_fortran_examples
+Module = render_fortran_examples
+
+[Documentation]
+Author = Ray Speth
+Version = 0.1
+Description = Build the Cantera Fortran examples into the output

--- a/plugins/render_fortran_examples.py
+++ b/plugins/render_fortran_examples.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from nikola.plugin_categories import Task
 from nikola import utils
 from pygments import highlight
-from pygments.lexers import FortranLexer, CppLexer
+from pygments.lexers import FortranLexer, FortranFixedLexer, CppLexer
 from itertools import chain
 import re
 import natsort
@@ -71,6 +71,8 @@ def render_example(site, kw, in_name, out_name):
     """
     if str(in_name).endswith('.cpp'):
         lexer = CppLexer()
+    elif str(in_name).endswith('.f'):
+        lexer = FortranFixedLexer()
     else:
         lexer = FortranLexer()
     code = highlight(

--- a/plugins/render_fortran_examples.py
+++ b/plugins/render_fortran_examples.py
@@ -1,0 +1,252 @@
+"""Render the Fortran examples from the Cantera repository into Nikola listings.
+
+This plugin renders Fortran examples from the main Cantera repository into the
+examples/fortran output folder. It looks for the examples in the folder configured
+in the top-level conf.py file in the ``EXAMPLES_FOLDERS`` dictionary. That
+dictionary has keys with the source folder and values with the destination
+folder (relative to the ``OUTPUT_FOLDER``). The relevant source folder is found
+as the key associated with the value that contains the string ``fortran``,
+typically ``"../cantera/samples/f90": "examples/fortran"``.
+"""
+from pathlib import Path
+
+from nikola.plugin_categories import Task
+from nikola import utils
+from pygments import highlight
+from pygments.lexers import FortranLexer, CppLexer
+from itertools import chain
+import re
+import natsort
+
+
+def render_example_index(site, kw, headers, output_file):
+    """Render the index of all of the Fortran examples.
+
+    Parameters
+    ==========
+    site:
+        An instance of a Nikola site, available in any plugin as ``self.site``
+    kw:
+        A dictionary of keywords for this task
+    headers:
+        A dictionary of the example categories and the summaries of each example
+    output_file:
+        A pathlib.Path instance representing the output file that will be rendered
+
+    """
+    n = 3
+    for head_dict in headers.values():
+        head_files = head_dict["files"]
+        head_dict["files"] = [
+            head_files[i : i + n] for i in range(0, len(head_files), n)  # NOQA: E203
+        ]
+
+    permalink = output_file.relative_to(kw["output_folder"])
+    title = "Fortran Examples"
+    context = {
+        "headers": headers,
+        "lang": kw["default_lang"],
+        "pagekind": ["example"],
+        "permalink": str(permalink),
+        "title": title,
+        "description": title,
+    }
+    site.render_template("fortran-example-index.tmpl", str(output_file), context)
+
+
+def render_example(site, kw, in_name, out_name):
+    """Render a single source file to HTML with formatting.
+
+    Parameters
+    ==========
+    site:
+        An instance of a Nikola site, available in any plugin as ``self.site``
+    kw:
+        A dictionary of keywords for this task
+    in_name:
+        The file to be rendered, as an instance of pathlib.Path
+    out_name:
+        A pathlib.Path instance pointing to the rendered output file
+
+    """
+    if str(in_name).endswith('.cpp'):
+        lexer = CppLexer()
+    else:
+        lexer = FortranLexer()
+    code = highlight(
+        in_name.read_bytes(), lexer, utils.NikolaPygmentsHTML(in_name.name)
+    )
+
+    title = in_name.name
+    permalink = out_name.relative_to(kw["output_folder"])
+    source_link = permalink.stem  # remove '.html'
+    context = {
+        "code": code,
+        "title": title,
+        "permalink": str(permalink),
+        "lang": kw["default_lang"],
+        "description": title,
+        "source_link": source_link,
+        "pagekind": ["example"],
+    }
+    site.render_template("examples.tmpl", str(out_name), context)
+
+
+class RenderFortranExamples(Task):
+    """Render the Fortran examples with a Nikola Task.
+
+    As with all Nikola ``Tasks``, the key method here is the ``gen_tasks``
+    method, which yields dictionaries that represent tasks that doit needs
+    to run. There are two primary kinds of tasks, one that renders each
+    example file, and one that renders an index of all of the examples.
+    """
+
+    name = "render_fortran_examples"
+
+    def set_site(self, site):
+        """Set Nikola site."""
+        # Verify that an output folder appears only once in EXAMPLES_FOLDERS
+        found_fortran = False
+        for source, dest in site.config["EXAMPLES_FOLDERS"].items():
+            if "fortran" in dest:
+                if found_fortran:
+                    self.logger.error(
+                        "More than one folder to output Fortran examples was found in "
+                        "EXAMPLES_FOLDERS, exiting"
+                    )
+                else:
+                    found_fortran = True
+                    self.input_folder = source
+                    self.examples_folder = dest
+
+        if not found_fortran:
+            self.logger.warn(
+                "Didn't find an output folder for Fortran examples in EXAMPLES_FOLDERS"
+            )
+
+        return super().set_site(site)
+
+    def gen_tasks(self):
+        """Render examples."""
+        kw = {
+            "default_lang": self.site.config["DEFAULT_LANG"],
+            "examples_folders": self.site.config["EXAMPLES_FOLDERS"],
+            "output_folder": Path(self.site.config["OUTPUT_FOLDER"]),
+            "index_file": self.site.config["INDEX_FILE"],
+            "strip_indexes": self.site.config["STRIP_INDEXES"],
+        }
+
+        yield self.group_task()
+
+        # When any key or value in the uptodate dictionary changes, the
+        # examples pages need to be rebuilt.
+        uptodate = {"c": self.site.GLOBAL_CONTEXT}
+
+        for k, v in self.site.GLOBAL_CONTEXT["template_hooks"].items():
+            uptodate["||template_hooks|{0}||".format(k)] = v.calculate_deps()
+
+        for k in self.site._GLOBAL_CONTEXT_TRANSLATABLE:
+            uptodate[k] = self.site.GLOBAL_CONTEXT[k](kw["default_lang"])
+
+        # save navigation links as dependencies
+        uptodate["nav_links"] = uptodate["c"]["navigation_links"](kw["default_lang"])
+
+        uptodate["kw"] = kw
+
+        examples_template_deps = self.site.template_system.template_deps(
+            "examples.tmpl"
+        )
+
+        index_template_deps = self.site.template_system.template_deps(
+            "fortran-example-index.tmpl"
+        )
+        folder = Path(self.input_folder).resolve()
+        fortran_examples = list(chain(
+            folder.glob("*.f90"),
+            folder.glob("../f77/*.f"),  # hack to combine all Fortran samples on one page
+            folder.glob("../f77/*.cpp"),
+        ))
+        fortran_headers = {
+            "examples": {"name": "Examples", "files": [], "summaries": {}}
+        }
+
+        uptodate["d"] = fortran_headers.keys()
+        uptodate["f"] = list(map(str, fortran_examples))
+
+        for fortran_ex_file in fortran_examples:
+            # Try to get the first comment block in the file to use as a description
+            # Combination of detection for F77, F90, and C/C++ comments
+            fortran_headers["examples"]["files"].append(fortran_ex_file)
+            doc = []
+            in_block_comment = False
+            for line in fortran_ex_file.read_text(encoding="utf-8").split("\n"):
+                line = line.strip()
+                if '*/' in line:
+                    in_block_comment = False
+                    line = line[:line.find('*/')]
+                if line.startswith('/*'):
+                    doc.append(line.lstrip('/* !'))
+                    in_block_comment = True
+                if in_block_comment or line.startswith('!') or line.startswith("//")  or line.startswith('* '):
+                    doc.append(line.lstrip('/* !'))
+                elif line.startswith('c     '):
+                    doc.append(line[6:])
+                elif doc:
+                    break
+            doc = ' '.join(doc).strip()
+
+            print(fortran_ex_file, '======\n', doc, '\n================\n')
+            if not doc:
+                self.logger.warn(
+                    "The Fortran example {!s} doesn't have an appropriate summary. The "
+                    "first comment line of the Fortran file is taken as the "
+                    "summary.".format(fortran_ex_file)
+                )
+            name = fortran_ex_file.stem.replace("_", " ")
+            fortran_headers["examples"]["summaries"][fortran_ex_file.name] = doc
+            out_name = kw["output_folder"].joinpath(
+                self.examples_folder, fortran_ex_file.name + '.html'
+            )
+
+            yield {
+                "basename": self.name,
+                "name": str(out_name),
+                "file_dep": examples_template_deps + [fortran_ex_file],
+                "targets": [out_name],
+                "actions": [(render_example, [self.site, kw, fortran_ex_file, out_name])],
+                # This is necessary to reflect changes in blog title,
+                # sidebar links, etc.
+                "uptodate": [utils.config_changed(uptodate, "fortran_examples:source")],
+                "clean": True,
+            }
+
+            out_name = kw["output_folder"].joinpath(
+                self.examples_folder, fortran_ex_file.name
+            )
+            yield {
+                "basename": self.name,
+                "name": str(out_name),
+                "file_dep": [fortran_ex_file],
+                "targets": [out_name],
+                "actions": [(utils.copy_file, [fortran_ex_file, out_name])],
+                "clean": True,
+            }
+
+        fortran_headers["examples"]["files"] = natsort.natsorted(
+            fortran_headers["examples"]["files"], alg=natsort.IC
+        )
+
+        out_name = kw["output_folder"].joinpath(self.examples_folder, kw["index_file"])
+        yield {
+            "basename": self.name,
+            "name": str(out_name),
+            "file_dep": index_template_deps + list(map(str, fortran_examples)),
+            "targets": [out_name],
+            "actions": [
+                (render_example_index, [self.site, kw, fortran_headers, out_name])
+            ],
+            # This is necessary to reflect changes in blog title,
+            # sidebar links, etc.
+            "uptodate": [utils.config_changed(uptodate, "fortran_examples:folder")],
+            "clean": True,
+        }

--- a/themes/cantera/templates/cxx-example-index.tmpl
+++ b/themes/cantera/templates/cxx-example-index.tmpl
@@ -5,21 +5,20 @@
 
 <p>This is an index of the C++ examples included with Cantera.</p>
 
-{% for head, file_dict in headers.items() %}
+{% for head, ex_dict in headers.items() %}
   <div class="section" id="cxx-example">
     <h2 class="cxx-example-header example-header">
-      {{ file_dict['name'] }}
+      {{ ex_dict['name'] }}
       <a class="headerlink" href="#cxx-example" title="Permalink to this headline">¶</a>
     </h2>
-    {% for row in file_dict['files'] %}
+    {% for row in ex_dict.names %}
     <div class="card-deck cxx-example-row example-row">
-      {% for file in row %}
-      {% set fname = file.name %}
+      {% for name in row %}
       <!-- <div class="col-sm-4"> -->
         <div class="card">
-          <a href="{{ fname }}.html"><h5 class="card-header">{{ fname }}</h5></a>
+          <a href="{{ name }}.html"><h5 class="card-header">{{ ex_dict.titles[name] }}</h5></a>
           <div class="card-body">
-            <p class="card-text">{{ file_dict['summaries'][fname] }}</p>
+            <p class="card-text">{{ ex_dict.summaries[name] }}</p>
           </div>
         </div>
       <!-- </div> -->

--- a/themes/cantera/templates/cxx-example-index.tmpl
+++ b/themes/cantera/templates/cxx-example-index.tmpl
@@ -1,0 +1,37 @@
+{#  -*- coding: utf-8 -*- #}
+{% extends 'base.tmpl' %}
+{% block content %}
+<h1>Index of C++ Examples</h1>
+
+<p>This is an index of the C++ examples included with Cantera.</p>
+
+{% for head, file_dict in headers.items() %}
+  <div class="section" id="cxx-example">
+    <h2 class="cxx-example-header example-header">
+      {{ file_dict['name'] }}
+      <a class="headerlink" href="#cxx-example" title="Permalink to this headline">¶</a>
+    </h2>
+    {% for row in file_dict['files'] %}
+    <div class="card-deck cxx-example-row example-row">
+      {% for file in row %}
+      {% set fname = file.name %}
+      <!-- <div class="col-sm-4"> -->
+        <div class="card">
+          <a href="{{ fname }}.html"><h5 class="card-header">{{ fname }}</h5></a>
+          <div class="card-body">
+            <p class="card-text">{{ file_dict['summaries'][fname] }}</p>
+          </div>
+        </div>
+      <!-- </div> -->
+      {% endfor %}
+    </div>
+    {% endfor %}
+  </div>
+{% endfor %}
+{% endblock %}
+
+{% block sourcelink %}
+{% if source_link and show_sourcelink %}
+    {{ ui.show_sourcelink(source_link) }}
+{% endif %}
+{% endblock %}

--- a/themes/cantera/templates/fortran-example-index.tmpl
+++ b/themes/cantera/templates/fortran-example-index.tmpl
@@ -1,0 +1,37 @@
+{#  -*- coding: utf-8 -*- #}
+{% extends 'base.tmpl' %}
+{% block content %}
+<h1>Index of Fortran Examples</h1>
+
+<p>This is an index of the Fortran examples included with Cantera.</p>
+
+{% for head, file_dict in headers.items() %}
+  <div class="section" id="fortran-example">
+    <h2 class="fortran-example-header example-header">
+      {{ file_dict['name'] }}
+      <a class="headerlink" href="#fortran-example" title="Permalink to this headline">¶</a>
+    </h2>
+    {% for row in file_dict['files'] %}
+    <div class="card-deck fortran-example-row example-row">
+      {% for file in row %}
+      {% set fname = file.name %}
+      <!-- <div class="col-sm-4"> -->
+        <div class="card">
+          <a href="{{ fname }}.html"><h5 class="card-header">{{ fname }}</h5></a>
+          <div class="card-body">
+            <p class="card-text">{{ file_dict['summaries'][fname] }}</p>
+          </div>
+        </div>
+      <!-- </div> -->
+      {% endfor %}
+    </div>
+    {% endfor %}
+  </div>
+{% endfor %}
+{% endblock %}
+
+{% block sourcelink %}
+{% if source_link and show_sourcelink %}
+    {{ ui.show_sourcelink(source_link) }}
+{% endif %}
+{% endblock %}

--- a/themes/cantera/templates/fortran-example-index.tmpl
+++ b/themes/cantera/templates/fortran-example-index.tmpl
@@ -17,7 +17,7 @@
       {% set fname = file.name %}
       <!-- <div class="col-sm-4"> -->
         <div class="card">
-          <a href="{{ fname }}.html"><h5 class="card-header">{{ fname }}</h5></a>
+          <a href="{{ fname }}.html"><h5 class="card-header">{{ file_dict.titles[fname] }}</h5></a>
           <div class="card-body">
             <p class="card-text">{{ file_dict['summaries'][fname] }}</p>
           </div>

--- a/themes/cantera/templates/multifile-example.tmpl
+++ b/themes/cantera/templates/multifile-example.tmpl
@@ -1,0 +1,19 @@
+{#  -*- coding: utf-8 -*- #}
+{% extends 'base.tmpl' %}
+{% import 'math_helper.tmpl' as math with context %}
+{% block content %}
+  {% for item in items %}
+    {% if item.code %}
+      <h1>{{ item.title }}
+        {% if item.source_link %}
+          <small><a href="{{ item.source_link }}">({{ messages("Source") }})</a></small>
+        {% endif %}
+      </h1>
+      {{ item.code }}
+    {% endif %}
+
+    {% if item.source_link and show_sourcelink %}
+        {{ ui.show_sourcelink(item.source_link) }}
+    {% endif %}
+  {% endfor %}
+{% endblock %}


### PR DESCRIPTION
Resolves #73.

~A first step towards resolving #73, although it chooses the "dumb" answer of just putting the header files on pages by themselves.~
The first version of this had headers and source files on separate files, but now they're combined.

~A companion update to `Cantera/cantera` ~should probably be introduced at some point to update the comments for each of these files, since the strategy used here of pulling the first comment in each example doesn't always provide a very good summary.~
Cantera/cantera#983 improves these docstrings to provide consistently useful titles and summaries.

~This is incomplete, because I haven't figured out how to get the C++ examples to show up as a category on the `examples/index.html` page. The `examples/cxx/index.html` page renders fine.~