### PR TITLE
Add documentations about Blowers-Masel reaction 

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -701,7 +701,7 @@ OUTPUT_FOLDER = os.getenv("NIKOLA_OUTPUT_DIR", "output")
 #
 from nikola import filters
 
-FILTERS = {".html": [filters.typogrify, filters.add_header_permalinks]}
+FILTERS = {".html": [filters.add_header_permalinks]}
 
 # Executable for the "yui_compressor" filter (defaults to 'yui-compressor').
 # YUI_COMPRESSOR_EXECUTABLE = 'yui-compressor'

--- a/pages/affiliated.rst
+++ b/pages/affiliated.rst
@@ -118,3 +118,10 @@ post on the `Google Users' Group <https://groups.google.com/forum/#!forum/canter
 
 | `Website <http://shepherd.caltech.edu/EDL/PublicResources/sdt/>`__
 | Maintainer(s): Joseph E. Shepherd
+
+------------
+
+**ChemCheck**: A tool to help Cantera users to detect chemical and syntax errors in kinetic models
+
+ | `Repository <https://github.com/comocheng/ChemCheck>`__
+ | Maintainer(s): Chao Xu, Richard West

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -398,6 +398,8 @@ in the YAML format by specifying the rate constant in the reaction's
 Surface Blowers-Masel Reactions
 -------------------------------
 
+**New in Cantera 2.6**
+
 .. TODO: Update the link once version 2.6 is released
 
 Surface Blowers-Masel Reactions have the same Arrhenius-like rate expression described in

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -314,7 +314,7 @@ where
 
 :math:`w` is the average of the bond dissociation energy of the bond breaking and that being formed,
 :math:`E_a^0` is the intrinsic activation energy, and :math:`\Delta H` is the enthalpy change of the reaction.
-Note that the expression is very insensitive to :math:`w` as long as :math:`w \ge 2 E_a^0`, so we can use
+Note that the expression is insensitive to :math:`w` as long as :math:`w \ge 2 E_a^0`, so we can use
 an arbitrary high value of :math:`w = 1000 kJ/mol`.
 
 After :math:`E_a` is evaluated, the reaction rate can be calculated as modified Arrhenius expression

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -323,7 +323,7 @@ where
 Note that the expression is insensitive to :math:`w` as long as :math:`w \ge 2 E_a^0`, so we can use
 an arbitrarily high value of :math:`w = 1000\text{ kJ/mol}`.
 
-After :math:`E_a` is evaluated, the reaction rate can be calculated as modified Arrhenius expression
+After :math:`E_a` is evaluated, the reaction rate can be calculated using the modified Arrhenius expression
 
 .. math::
 

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -412,8 +412,8 @@ the `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/react
 reaction ``type`` in a YAML input file.
 
 Note that surface Blowers-Masel reactions also support all the `additional options <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#interface>`__
-described in `Surface Reactions <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#interface>`__
-and `sticking-coefficient <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#interface>`__ field in YAML format.
+described in the `Surface Reactions <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#interface>`__
+and `sticking-coefficient <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#interface>`__ fields in a YAML input file.
 
 Additional Options
 ------------------

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -294,13 +294,11 @@ Blowers-Masel Reactions
 
 In some circumstances like thermodynamic sensitivity analysis, or
 modeling heterogeneous reactions from one catalyst surface to another,
-the enthalpy of reactions needs to be tweaked. Since reactions' energetics
-is changed, the activation energy of reactions should also be adjusted accordingly
-to provide accurate simulation results. The enthalpy can be modified by changing
-temperature and revising NASA polynomial coefficients in Cantera. To predict the
-activation energy change, the Blowers-Masel rate expression is implemented, which
-is an approximation proposed by Blowers and Masel [#BlowersMasel2000]_ to automatically
-scale activation energy as species' enthalpies are changed in hydrogen transfer reactions.
+the enthalpy change of a reaction (:math:`\Delta H`) can be modified. Due to the change in :math:`\Delta H`,
+the activation energy of the reaction must be adjusted accordingly to provide accurate simulation results. To
+adjust the activation energy due to changes in the reaction enthalpy, the Blowers-Masel rate expression is
+available. This approximation was proposed by Blowers and Masel [#BlowersMasel2000]_ to automatically
+scale activation energy as the reaction enthalpy is changed.
 The activation energy estimation can be written as:
 
 .. math::

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -408,8 +408,8 @@ and the activation energy :math:`E_a` is determined
 as described in `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-blowers-masel>`__.
 
 Surface Blowers-Masel reactions can be identified by the presence of surface spcecies and
-the defined `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-surface-blowers-masel>`__
-reaction ``type`` in YAML format.
+the `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-surface-blowers-masel>`__
+reaction ``type`` in a YAML input file.
 
 Note that surface Blowers-Masel reactions also support all the `additional options <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#interface>`__
 described in `Surface Reactions <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#interface>`__

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -315,7 +315,7 @@ where
 :math:`w` is the average of the bond dissociation energy of the bond breaking and that being formed,
 :math:`E_a^0` is the intrinsic activation energy, and :math:`\Delta H` is the enthalpy change of the reaction.
 Note that the expression is insensitive to :math:`w` as long as :math:`w \ge 2 E_a^0`, so we can use
-an arbitrary high value of :math:`w = 1000 kJ/mol`.
+an arbitrarily high value of :math:`w = 1000\text{ kJ/mol}`.
 
 After :math:`E_a` is evaluated, the reaction rate can be calculated as modified Arrhenius expression
 

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -285,6 +285,47 @@ Chebyshev reactions can be defined in the CTI format using the
 :cti:class:`chebyshev_reaction` entry, or in the YAML format using the
 :ref:`Chebyshev <sec-yaml-Chebyshev>` reaction ``type``.
 
+.. _sec-Blowers-Masel:
+
+Blowers-Masel Reactions
+-----------------------
+
+Blowers-Masel rate expression represents the approximation porposed by Blowers
+and Masel [#BlowersMasel2000]_ to automatically scale activation energy
+as we change species' enthalpies. The activation energy estimation can be written
+as:
+
+.. math::
+
+   E_a = 0 \;\text{if } \Delta H \leq -4 E_a^0
+
+   E_a = \Delta H \;\text{if } \Delta H \geq 4 E_a^0
+
+   E_a =  \frac{\left( w + \frac{\Delta H }{2} \right)  (V_P - 2 w + \Delta H) ^2}
+               {V_P^2 - 4 w^2 + \Delta H^2} \;\text{Otherwise}
+
+where
+
+.. math::
+
+   V_P = 2 w \frac{w + E_a^0}{w - E_a^0},
+
+:math:`w` is the average of the bond dissociation energy of the bond breaking and that being formed,
+:math:`E_a^0` is the intrinsic activation energy, and :math:`\Delta H` is the enthalpy change of the reaction.
+Note that the expression is very insensitive to :math:`w` as long as :math:`w \ge 2 E_a^0`, so we can use
+an arbitrary high value of :math:`w = 1000 kJ/mol`.
+
+After :math:`E_a` is evaluated, the reaction rate can be calculated as modified Arrhenius expression
+
+.. math::
+
+   k_f = A T^b e^{-E_a / RT}.
+
+Blowers Masel reaction can be defined in the YAML format using the
+:ref:`Blowers-Masel <sec-yaml-Blowers-Masel>` reaction ``type``.
+
+.. _sec-surface:
+
 Surface Reactions
 -----------------
 
@@ -344,6 +385,21 @@ Sticking reactions can be defined in the CTI format using the `stick` entry, or
 in the YAML format by specifying the rate constant in the reaction's
 :ref:`sticking-coefficient <sec-yaml-interface-reaction>` field.
 
+Surface Blowers-Masel Reactions
+-------------------------------
+
+Surface Blowers-Masel Reactions have the same Arrhenius-like rate expression described in
+:ref:`Surface Reactions<sec-surface>`, and the activation energy :math:`E_a` is determined
+as described in :ref:`Blowers-Masel Reactions<sec-Blowers-Masel>`.
+
+Surface Blowers-Masel reactions can be identified by the presence of surface spcecies and
+the defined :ref:`Blowers-Masel<sec-yaml-surface-Blowers-Masel>` reaction ``type`` in YAML
+format.
+
+Note that surface Blowers-Masel reactions also support all the :ref:`additional options <sec-yaml-interface-reaction>`
+described in :ref:`Surface Reactions<sec-surface>` and :ref:`sticking-coefficient <sec-yaml-interface-reaction>` field in YAML
+format.
+
 Additional Options
 ------------------
 
@@ -398,3 +454,7 @@ these cases, the default behavior may be overridden in the input file.
 .. [#Westbrook1981] C. K. Westbrook and F. L. Dryer. Simplified reaction
    mechanisms for the oxidation of hydrocarbon fuels in flames. *Combustion
    Science and Technology* **27**, pp. 31--43. 1981.
+
+.. [#BlowersMasel2000] Blowers, P., & Masel, R. (2000). Engineering approximations
+   for activation energies in hydrogen transfer reactions. *AIChE Journal*, 46(10),
+   2041-2052. https://doi.org/10.1002/aic.690461015

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -403,7 +403,7 @@ Surface Blowers-Masel Reactions
 Surface Blowers-Masel Reactions have the same Arrhenius-like rate expression described in
 `Surface Reactions <https://cantera.org/science/reactions.html#surface-reactions>`__,
 and the activation energy :math:`E_a` is determined
-as described in :ref:`Blowers-Masel Reactions<sec-Blowers-Masel>`.
+as described in `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-blowers-masel>`__.
 
 Surface Blowers-Masel reactions can be identified by the presence of surface spcecies and
 the defined `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-surface-blowers-masel>`__

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -290,7 +290,9 @@ Chebyshev reactions can be defined in the CTI format using the
 Blowers-Masel Reactions
 -----------------------
 
-Blowers-Masel rate expression represents the approximation porposed by Blowers
+**New in Cantera 2.6**
+
+The Blowers-Masel rate expression is an approximation proposed by Blowers
 and Masel [#BlowersMasel2000]_ to automatically scale activation energy
 as we change species' enthalpies. The activation energy estimation can be written
 as:

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -401,9 +401,8 @@ Surface Blowers-Masel Reactions
 .. TODO: Update the link once version 2.6 is released
 
 Surface Blowers-Masel Reactions have the same Arrhenius-like rate expression described in
-`Surface Reactions <https://cantera.org/science/reactions.html#surface-reactions>`__,
-and the activation energy :math:`E_a` is determined
-as described in `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-blowers-masel>`__.
+:ref:`Surface Reactions<sec-surface>`, and the activation energy :math:`E_a` is determined
+as described in :ref:`Blowers-Masel Reactions<sec-Blowers-Masel>`.
 
 Surface Blowers-Masel reactions can be identified by the presence of surface spcecies and
 the `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-surface-blowers-masel>`__

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -299,12 +299,12 @@ as:
 
 .. math::
 
-   E_a = 0 \;\text{if } \Delta H \leq -4 E_a^0
-
-   E_a = \Delta H \;\text{if } \Delta H \geq 4 E_a^0
-
-   E_a =  \frac{\left( w + \frac{\Delta H }{2} \right)  (V_P - 2 w + \Delta H) ^2}
-               {V_P^2 - 4 w^2 + \Delta H^2} \;\text{Otherwise}
+   E_a = \begin{cases}
+      0 & \text{if } \Delta H \leq -4 E_a^0 \\
+      \Delta H & \text{if } \Delta H \geq 4 E_a^0 \\
+      \frac{\left( w + \frac{\Delta H }{2} \right)  (V_P - 2 w + \Delta H) ^2}
+               {V_P^2 - 4 w^2 + \Delta H^2} & \text{Otherwise}
+      \end{cases}
 
 where
 

--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -292,10 +292,16 @@ Blowers-Masel Reactions
 
 **New in Cantera 2.6**
 
-The Blowers-Masel rate expression is an approximation proposed by Blowers
-and Masel [#BlowersMasel2000]_ to automatically scale activation energy
-as we change species' enthalpies. The activation energy estimation can be written
-as:
+In some circumstances like thermodynamic sensitivity analysis, or
+modeling heterogeneous reactions from one catalyst surface to another,
+the enthalpy of reactions needs to be tweaked. Since reactions' energetics
+is changed, the activation energy of reactions should also be adjusted accordingly
+to provide accurate simulation results. The enthalpy can be modified by changing
+temperature and revising NASA polynomial coefficients in Cantera. To predict the
+activation energy change, the Blowers-Masel rate expression is implemented, which
+is an approximation proposed by Blowers and Masel [#BlowersMasel2000]_ to automatically
+scale activation energy as species' enthalpies are changed in hydrogen transfer reactions.
+The activation energy estimation can be written as:
 
 .. math::
 
@@ -323,8 +329,10 @@ After :math:`E_a` is evaluated, the reaction rate can be calculated as modified 
 
    k_f = A T^b e^{-E_a / RT}.
 
+.. TODO: Update the link once version 2.6 is released
+
 Blowers Masel reaction can be defined in the YAML format using the
-:ref:`Blowers-Masel <sec-yaml-Blowers-Masel>` reaction ``type``.
+`Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-blowers-masel>`__ reaction ``type``.
 
 .. _sec-surface:
 
@@ -390,17 +398,20 @@ in the YAML format by specifying the rate constant in the reaction's
 Surface Blowers-Masel Reactions
 -------------------------------
 
+.. TODO: Update the link once version 2.6 is released
+
 Surface Blowers-Masel Reactions have the same Arrhenius-like rate expression described in
-:ref:`Surface Reactions<sec-surface>`, and the activation energy :math:`E_a` is determined
+`Surface Reactions <https://cantera.org/science/reactions.html#surface-reactions>`__,
+and the activation energy :math:`E_a` is determined
 as described in :ref:`Blowers-Masel Reactions<sec-Blowers-Masel>`.
 
 Surface Blowers-Masel reactions can be identified by the presence of surface spcecies and
-the defined :ref:`Blowers-Masel<sec-yaml-surface-Blowers-Masel>` reaction ``type`` in YAML
-format.
+the defined `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-surface-blowers-masel>`__
+reaction ``type`` in YAML format.
 
-Note that surface Blowers-Masel reactions also support all the :ref:`additional options <sec-yaml-interface-reaction>`
-described in :ref:`Surface Reactions<sec-surface>` and :ref:`sticking-coefficient <sec-yaml-interface-reaction>` field in YAML
-format.
+Note that surface Blowers-Masel reactions also support all the `additional options <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#interface>`__
+described in `Surface Reactions <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#interface>`__
+and `sticking-coefficient <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#interface>`__ field in YAML format.
 
 Additional Options
 ------------------

--- a/pages/tutorials/yaml/reactions.rst
+++ b/pages/tutorials/yaml/reactions.rst
@@ -65,14 +65,18 @@ The type of the rate coefficient parameterization may be specified in the
   Arrhenius expressions at different pressures
 - :ref:`Chebyshev <sec-yaml-Chebyshev>`: A reaction rate parameterized by a
   bivariate Chebyshev polynomial in pressure and temperature
+- :ref:`Blowers-Masel <sec-yaml-Blowers-Masel>`: A reaction rate constant parameterized
+   as modified Arrhenius reaction with one additional bond energy parameter to
+   scale the activation energy according to the enthalpy of the reaction.
 
 Additional parameters defining the rate constant for each of these reaction
 types are described in the documentation linked above.
 
 The default parameterization is ``elementary``. Reactions involving surface
 species are automatically identified as :ref:`interface <sec-yaml-interface-reaction>`
-reactions, and reactions involving charge transfer are
-automatically identified as :ref:`electrochemical <sec-yaml-electrochemical-reaction>`
+reactions, reactions involving surface species with specified ``type`` as ``Blowers-Masel``
+are treated as :ref:`surface-Blowers-Masel <sec-yaml-surface-Blowers-Masel>`, and reactions
+involving charge transfer are automatically identified as :ref:`electrochemical <sec-yaml-electrochemical-reaction>`
 reactions.
 
 Arrhenius Expressions

--- a/pages/tutorials/yaml/reactions.rst
+++ b/pages/tutorials/yaml/reactions.rst
@@ -66,7 +66,7 @@ The type of the rate coefficient parameterization may be specified in the
 - :ref:`Chebyshev <sec-yaml-Chebyshev>`: A reaction rate parameterized by a
   bivariate Chebyshev polynomial in pressure and temperature
 - :ref:`Blowers-Masel <sec-yaml-Blowers-Masel>`: A reaction rate constant parameterized
-   as modified Arrhenius reaction with one additional bond energy parameter to
+   as a modified Arrhenius reaction with one additional bond energy parameter to
    scale the activation energy according to the enthalpy of the reaction.
 
 Additional parameters defining the rate constant for each of these reaction


### PR DESCRIPTION
This is the documentation for the new reaction class proposed in pull request [#987](https://github.com/Cantera/cantera/pull/987) in Cantera. One concern is that the new reference like `:ref:surface-Blowers-Masel <sec-yaml-surface-Blowers-Masel>` cannot be rendered.