### PR TITLE
Move comments about --permissive option in CK tutorials

### DIFF
--- a/pages/tutorials/ck2cti-tutorial.rst
+++ b/pages/tutorials/ck2cti-tutorial.rst
@@ -77,14 +77,16 @@ An input file containing only species definitions (which can be referenced from
 phase definitions in other input files) can be created by specifying only a
 thermo file.
 
-Many existing CK format files cause errors in ``ck2cti`` when they are
-processed. Some of these errors may be avoided by specifying the
-``--permissive`` option. This option allows certain recoverable parsing errors
-(for example, duplicate transport or thermodynamic data) to be ignored. Other errors
-may be caused by incorrect formatting of lines in one or more of the input files.
-
 Debugging common errors in CK files
 -----------------------------------
+
+.. note::
+
+   Many existing CK format files cause errors in ``ck2cti`` when they are
+   processed. Some of these errors may be avoided by specifying the
+   ``--permissive`` option. This option allows certain recoverable parsing errors
+   (for example, duplicate transport or thermodynamic data) to be ignored. Other errors
+   may be caused by incorrect formatting of lines in one or more of the input files.
 
 When ``ck2cti`` encounters an error, it attempts to print the surrounding
 information to help you to locate the error. Many of the most common errors

--- a/pages/tutorials/ck2yaml-tutorial.rst
+++ b/pages/tutorials/ck2yaml-tutorial.rst
@@ -95,15 +95,17 @@ An input file containing only species definitions (which can be referenced from
 phase definitions in other input files) can be created by specifying only a
 thermo file.
 
-Many existing CK format files cause errors in ``ck2yaml`` when they are
-processed. Some of these errors may be avoided by specifying the
-``--permissive`` option. This option allows certain recoverable parsing errors
-(for example, duplicate transport or thermodynamic data) to be ignored. Other
-errors may be caused by incorrect formatting of lines in one or more of the
-input files.
-
 Debugging common errors in CK files
 -----------------------------------
+
+.. note::
+
+   Many existing CK format files cause errors in ``ck2yaml`` when they are
+   processed. Some of these errors may be avoided by specifying the
+   ``--permissive`` option. This option allows certain recoverable parsing errors
+   (for example, duplicate transport or thermodynamic data) to be ignored. Other
+   errors may be caused by incorrect formatting of lines in one or more of the
+   input files.
 
 When ``ck2yaml`` encounters an error, it attempts to print the surrounding
 information to help you to locate the error. Many of the most common errors


### PR DESCRIPTION
Per Cantera/enhancements#98, there are many user group questions about relatively minor CK conversion issues (most of which are fixed by adding the `--permissive` option). 

Currently, users are already directed to the website for more information, i.e.
```
Please check https://cantera.org/tutorials/ck2yaml-tutorial.html#debugging-common-errors-in-ck-files
for the correct Chemkin syntax.
```
but the link provided to users directs them to a section that - at least on my browser - starts *below* the portion with the essential information needed (which is just above the #debugging-common-errors-in-ck-files section).

This PR simply moves the paragraph and marks the comment with a `note` admonition.