### PR TITLE
Fix Binder and add 2.4 docs landing page

### DIFF
--- a/api-docs/add_warning.py
+++ b/api-docs/add_warning.py
@@ -4,27 +4,31 @@ import lxml.html as lh
 from lxml import etree
 from pathlib import Path
 
-bquote = etree.Element('blockquote')
-d = etree.SubElement(bquote, 'div')
-admonition = etree.SubElement(d, 'div', {'class': 'admonition warning'})
-head = etree.SubElement(admonition, 'p', {'class': 'first admonition-title'})
-head.text = 'Warning'
-last = etree.SubElement(admonition, 'p', {'class': 'last'})
-last.text = 'This documentation is for an old version of Cantera. You can find docs for newer versions '
-link = etree.SubElement(last, 'a', {'class': 'reference external', 'href': 'https://cantera.org/documentation'})
-link.text = 'here'
-link.tail = '.'
+bquote = etree.Element("blockquote")
+d = etree.SubElement(bquote, "div")
+admonition = etree.SubElement(d, "div", {"class": "admonition warning"})
+head = etree.SubElement(admonition, "p", {"class": "first admonition-title"})
+head.text = "Warning"
+last = etree.SubElement(admonition, "p", {"class": "last"})
+last.text = "This documentation is for an old version of Cantera. You can find docs for newer versions "
+link = etree.SubElement(
+    last,
+    "a",
+    {"class": "reference external", "href": "https://cantera.org/documentation"},
+)
+link.text = "here"
+link.tail = "."
 
-folders = [Path(f'api-docs/docs-{x}') for x in [2.3, 2.2, 2.1, 2.0]]
+folders = [Path(f"api-docs/docs-{x}") for x in (2.4,)]
 for folder in folders:
-    for html_file in folder.glob('sphinx/**/*.html'):
+    for html_file in folder.glob("sphinx/**/*.html"):
         print(html_file)
 
         doc = lh.parse(str(html_file))
         body = doc.xpath('//div[@class="body"]')[0]
         body.insert(0, bquote)
 
-        head = doc.find('head')
-        meta = etree.SubElement(head, 'meta', {'name': 'robots', 'content': 'noindex'})
-        with open(html_file, 'w', encoding='utf-8') as file_obj:
-            file_obj.write(lh.tostring(doc).decode('utf-8'))
+        head = doc.find("head")
+        meta = etree.SubElement(head, "meta", {"name": "robots", "content": "noindex"})
+        with open(html_file, "w", encoding="utf-8") as file_obj:
+            file_obj.write(lh.tostring(doc).decode("utf-8"))

--- a/api-docs/docs-2.4/index.html
+++ b/api-docs/docs-2.4/index.html
@@ -1,133 +1,278 @@
-<!--
-.. title: Cantera Documentation
-.. slug: index
-.. date: 2018-06-09 13:57:46 UTC-04:00
-.. description: API documentation for the Cantera interfaces
-.. type: text
--->
+<!DOCTYPE html>
+<html prefix="
+og: http://ogp.me/ns# article: http://ogp.me/ns/article#
+" lang="en">
 
-<div class="jumbotron">
-  <h1 class="display-3">Cantera 2.4.0 Documentation</h1>
-  <p class="lead">
-    Sometimes you just need a little more detail. You'll find documentation for
-    (almost) every function in Cantera right here. This is the documentation for
-    a deprecated release, Cantera 2.4.0. For other versions, see the links
-    at the bottom of the page.
-  </p>
+<head>
+  <meta charset="utf-8">
+  <meta name="description" content="API documentation for the Cantera interfaces">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Cantera Documentation | Cantera</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+    integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.1/baguetteBox.min.css"
+    integrity="sha256-cLMYWYYutHkt+KpNqjg7NVkYSQ+E2VbrXsEvOqU7mL0=" crossorigin="anonymous">
+  <link href="/assets/css/rst.css" rel="stylesheet" type="text/css">
+  <link href="/assets/css/code.css" rel="stylesheet" type="text/css">
+  <link href="/assets/css/theme.css" rel="stylesheet" type="text/css">
+  <link href="/assets/css/custom.css" rel="stylesheet" type="text/css">
+  <link href="/assets/css/ipython.min.css" rel="stylesheet" type="text/css">
+  <link href="/assets/css/nikola_ipython.css" rel="stylesheet" type="text/css">
+  <meta name="theme-color" content="#5670d4">
+  <meta name="generator" content="Nikola (getnikola.com)">
+  <link rel="alternate" type="application/rss+xml" title="RSS" hreflang="en" href="/rss.xml">
+  <link rel="canonical" href="https://cantera.org/documentation/">
+  <link rel="icon" href="/assets/img/favicon.ico" sizes="16x16">
+  <!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+  <meta name="author" content="Cantera Developers">
+  <meta property="og:site_name" content="Cantera">
+  <meta property="og:title" content="Cantera Documentation">
+  <meta property="og:url" content="https://cantera.org/documentation/">
+  <meta property="og:description" content="API documentation for the Cantera interfaces">
+  <meta property="og:type" content="article">
+  <meta property="article:published_time" content="2018-06-09T13:57:46-04:00">
+</head>
 
-  <div id="searchbox" style="display: inline-block" role="search">
-    <h3>Search the documentation</h3>
-    <div class="searchformwrapper">
-      <form class="search" action="sphinx/html/search.html" method="get">
-        <input type="text" name="q" size="50" />
-        <input type="submit" value="Go" />
-        <input type="hidden" name="check_keywords" value="yes" />
-        <input type="hidden" name="area" value="default" />
-      </form>
+<body>
+  <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
+
+  <!-- Menubar -->
+
+  <nav class="navbar navbar-expand-md static-top mb-4
+navbar-light bg-light
+">
+    <div class="container">
+      <!-- This keeps the margins nice -->
+      <a class="navbar-brand" href="https://cantera.org/">
+        <img src="/assets/img/cantera-logo.png" alt="Cantera" id="logo" class="d-inline-block align-top"></a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#bs-navbar"
+        aria-controls="bs-navbar" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="bs-navbar">
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-item">
+            <a href="/install/index.html" class="nav-link">Install</a>
+          </li>
+          <li class="nav-item">
+            <a href="/tutorials/index.html" class="nav-link">Tutorials</a>
+          </li>
+          <li class="nav-item">
+            <a href="/examples/index.html" class="nav-link">Examples</a>
+          </li>
+          <li class="nav-item">
+            <a href="/community.html" class="nav-link">Community</a>
+          </li>
+          <li class="nav-item">
+            <a href="/science/index.html" class="nav-link">Science</a>
+          </li>
+          <li class="nav-item">
+            <a href="#" class="nav-link">Documentation</a>
+          </li>
+          <li class="nav-item">
+            <a href="/blog/index.html" class="nav-link">Blog</a>
+
+
+          </li>
+        </ul>
+        <ul class="navbar-nav navbar-right"></ul>
+      </div>
+      <!-- /.navbar-collapse -->
+    </div>
+    <!-- /.container -->
+  </nav><!-- End of Menubar -->
+  <div class="container" id="content" role="main">
+    <div class="body-content">
+      <!--Body content-->
+
+      <article class="post-text storypage" itemscope="itemscope" itemtype="http://schema.org/Article">
+        <div class="e-content entry-content" itemprop="articleBody text">
+
+          <div class="jumbotron">
+            <h1 class="display-3">Cantera 2.4.0 Documentation</h1>
+            <p class="lead">
+              Sometimes you just need a little more detail. You'll find documentation for
+              (almost) every function in Cantera right here. This is the documentation for
+              a deprecated release, Cantera 2.4.0. For other versions, see the links
+              at the bottom of the page.
+            </p>
+
+            <div id="searchbox" style="display: inline-block" role="search">
+              <h3>Search the documentation</h3>
+              <div class="searchformwrapper">
+                <form class="search" action="sphinx/html/search.html" method="get">
+                  <input type="text" name="q" size="50" />
+                  <input type="submit" value="Go" />
+                  <input type="hidden" name="check_keywords" value="yes" />
+                  <input type="hidden" name="area" value="default" />
+                </form>
+              </div>
+            </div>
+          </div>
+          <blockquote>
+            <div>
+              <div class="admonition warning">
+                <p class="first admonition-title">Warning</p>
+                <p class="last">This documentation is for an old version of Cantera. You can find docs for newer
+                  versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p>
+              </div>
+            </div>
+          </blockquote>
+          <div class="row">
+            <div class="col-sm-6">
+              <div class="card" id="python-docs">
+                <div class="card-header section-card">
+                  Python
+                </div>
+                <div class="list-group list-group-flush">
+                  <a href="sphinx/html/cython/importing.html" class="list-group-item docs">
+                    Objects Representing Phases (<code>Solution</code>s, <code>PureFluid</code>s,
+                    <code>Interface</code>s, etc.)
+                  </a>
+                  <a href="sphinx/html/cython/thermo.html" class="list-group-item docs">
+                    Thermodynamic Properties (Temperature, pressure, energy, etc.)
+                  </a>
+                  <a href="sphinx/html/cython/kinetics.html" class="list-group-item docs">
+                    Chemical Kinetics (Reactions, rates of progress, reaction path analysis, etc.)
+                  </a>
+                  <a href="sphinx/html/cython/transport.html" class="list-group-item docs">
+                    Transport Properties (Diffusion, viscosity, thermal conductivity, etc.)
+                  </a>
+                  <a href="sphinx/html/cython/zerodim.html" class="list-group-item docs">
+                    Zero-Dimensional Reactor Networks (<code>Reactor</code>s, <code>IdealGasReactor</code>s,
+                    <code>Wall</code>s,
+                    etc.)
+                  </a>
+                  <a href="sphinx/html/cython/onedim.html" class="list-group-item docs">
+                    One-dimensional Reacting Flows (<code>FreeFlame</code>s, <code>BurnerFlame</code>s, Flow Domains,
+                    Boundaries,
+                    etc.)
+                  </a>
+                  <a href="sphinx/html/cython/constants.html" class="list-group-item docs">
+                    Physical Constants (Universal constants, built into Cantera for convenience)
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div class="col-sm-6">
+              <div class="card" id="matlab-docs">
+                <div class="card-header section-card">
+                  Matlab
+                </div>
+                <div class="list-group list-group-flush">
+                  <a href="sphinx/html/matlab/importing.html" class="list-group-item docs">
+                    Objects Representing Phases (<code>Solution</code>s, <code>PureFluid</code>s,
+                    <code>Interface</code>s, etc.)
+                  </a>
+                  <a href="sphinx/html/matlab/thermodynamics.html" class="list-group-item docs">
+                    Thermodynamic Properties (Temperature, pressure, energy, etc.)
+                  </a>
+                  <a href="sphinx/html/matlab/kinetics.html" class="list-group-item docs">
+                    Chemical Kinetics (Reactions, rates of progress, reaction path analysis, etc.)
+                  </a>
+                  <a href="sphinx/html/matlab/transport.html" class="list-group-item docs">
+                    Transport Properties (Diffusion, viscosity, thermal conductivity, etc.)
+                  </a>
+                  <a href="sphinx/html/matlab/zero-dim.html" class="list-group-item docs">
+                    Zero-Dimensional Reactor Networks (<code>Reactor</code>s, <code>IdealGasReactor</code>s,
+                    <code>Wall</code>s,
+                    etc.)
+                  </a>
+                  <a href="sphinx/html/matlab/one-dim.html" class="list-group-item docs">
+                    One-dimensional Reacting Flows (<code>FreeFlame</code>s, <code>BurnerFlame</code>s, Flow Domains,
+                    Boundaries,
+                    etc.)
+                  </a>
+                  <a href="sphinx/html/matlab/data.html" class="list-group-item docs">
+                    Physical Constants (Universal constants, built into Cantera for convenience)
+                  </a>
+                  <a href="sphinx/html/matlab/utilities.html" class="list-group-item docs">
+                    Utility functions (XML Parsers, conversion scripts, etc.)
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="col-sm-6">
+              <div class="card" id="cxx-docs">
+                <div class="card-header section-card">
+                  C++
+                </div>
+                <div class="list-group list-group-flush">
+                  <a href="doxygen/html/modules.html" class="list-group-item docs">List of Cantera Modules</a>
+                  <a href="doxygen/html/classes.html" class="list-group-item docs">List of Cantera Classes</a>
+                  <a href="doxygen/html/da/d58/deprecated.html" class="list-group-item docs">List of Deprecated
+                    Functions and Classes</a>
+                </div>
+              </div>
+            </div>
+            <div class="col-sm-6">
+              <div class="card" id="other-docs">
+                <div class="card-header section-card">
+                  Other Documentation
+                </div>
+                <div class="list-group list-group-flush">
+                  <a href="/tutorials/input-files.html" class="list-group-item docs">CTI Input File Tutorial</a>
+                  <a href="sphinx/html/cti/classes.html" class="list-group-item docs">
+                    CTI Input File Class Reference
+                  </a>
+                  <a href="/documentation/glossary.html" class="list-group-item docs">Glossary of Terms</a>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <p class="text-center">
+            <a href="/documentation/index.html" class="btn btn-lg btn-outline-primary">Go Back to the Current
+              Documentation</a>
+          </p>
+
+      </article>
+      <!--End of body content-->
+      <footer id="footer">
+        <div class="footer" role="navigation">
+          <div class="navbar-text">
+            <ul class="footer-text">
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/community.html#citing-cantera">Citing</a></li>
+              <li><a href="/install/index.html">Install</a></li>
+              <li><a href="/tutorials/index.html">Tutorials</a></li>
+              <li><a href="/examples/index.html">Examples</a></li>
+              <li><a href="/community.html">Community</a></li>
+              <li><a href="/science/index.html">Science</a></li>
+              <li><a href="#">Documentation</a></li>
+              <li><a href="/blog/index.html">Blog</a></li>
+            </ul>
+          </div>
+          <p>Contents © 2021 <a href="mailto:steering@cantera.org">Cantera Developers</a> - Powered by <a
+              href="https://getnikola.com" rel="nofollow">Nikola</a> </p>
+
+        </div>
+      </footer>
     </div>
   </div>
-</div>
 
-<div class="row">
-  <div class="col-sm-6">
-    <div class="card" id="python-docs">
-      <div class="card-header section-card">
-        Python
-      </div>
-      <div class="list-group list-group-flush">
-        <a href="sphinx/html/cython/importing.html" class="list-group-item docs">
-          Objects Representing Phases (<code>Solution</code>s, <code>PureFluid</code>s, <code>Interface</code>s, etc.)
-        </a>
-        <a href="sphinx/html/cython/thermo.html" class="list-group-item docs">
-          Thermodynamic Properties (Temperature, pressure, energy, etc.)
-        </a>
-        <a href="sphinx/html/cython/kinetics.html" class="list-group-item docs">
-          Chemical Kinetics (Reactions, rates of progress, reaction path analysis, etc.)
-        </a>
-        <a href="sphinx/html/cython/transport.html" class="list-group-item docs">
-          Transport Properties (Diffusion, viscosity, thermal conductivity, etc.)
-        </a>
-        <a href="sphinx/html/cython/zerodim.html" class="list-group-item docs">
-          Zero-Dimensional Reactor Networks (<code>Reactor</code>s, <code>IdealGasReactor</code>s, <code>Wall</code>s,
-          etc.)
-        </a>
-        <a href="sphinx/html/cython/onedim.html" class="list-group-item docs">
-          One-dimensional Reacting Flows (<code>FreeFlame</code>s, <code>BurnerFlame</code>s, Flow Domains, Boundaries,
-          etc.)
-        </a>
-        <a href="sphinx/html/cython/constants.html" class="list-group-item docs">
-          Physical Constants (Universal constants, built into Cantera for convenience)
-        </a>
-      </div>
-    </div>
-  </div>
-  <div class="col-sm-6">
-    <div class="card" id="matlab-docs">
-      <div class="card-header section-card">
-        Matlab
-      </div>
-      <div class="list-group list-group-flush">
-        <a href="sphinx/html/matlab/importing.html" class="list-group-item docs">
-          Objects Representing Phases (<code>Solution</code>s, <code>PureFluid</code>s, <code>Interface</code>s, etc.)
-        </a>
-        <a href="sphinx/html/matlab/thermodynamics.html" class="list-group-item docs">
-          Thermodynamic Properties (Temperature, pressure, energy, etc.)
-        </a>
-        <a href="sphinx/html/matlab/kinetics.html" class="list-group-item docs">
-          Chemical Kinetics (Reactions, rates of progress, reaction path analysis, etc.)
-        </a>
-        <a href="sphinx/html/matlab/transport.html" class="list-group-item docs">
-          Transport Properties (Diffusion, viscosity, thermal conductivity, etc.)
-        </a>
-        <a href="sphinx/html/matlab/zero-dim.html" class="list-group-item docs">
-          Zero-Dimensional Reactor Networks (<code>Reactor</code>s, <code>IdealGasReactor</code>s, <code>Wall</code>s,
-          etc.)
-        </a>
-        <a href="sphinx/html/matlab/one-dim.html" class="list-group-item docs">
-          One-dimensional Reacting Flows (<code>FreeFlame</code>s, <code>BurnerFlame</code>s, Flow Domains, Boundaries,
-          etc.)
-        </a>
-        <a href="sphinx/html/matlab/data.html" class="list-group-item docs">
-          Physical Constants (Universal constants, built into Cantera for convenience)
-        </a>
-        <a href="sphinx/html/matlab/utilities.html" class="list-group-item docs">
-          Utility functions (XML Parsers, conversion scripts, etc.)
-        </a>
-      </div>
-    </div>
-  </div>
-</div>
+  <script src="https://code.jquery.com/jquery-3.5.1.min.js"
+    integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.1/umd/popper.min.js"
+    integrity="sha256-/ijcOLwFf26xEYAjW75FizKVo5tnTYiQddPZoLUHHZ8=" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js"
+    integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI"
+    crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.1/baguetteBox.min.js"
+    integrity="sha256-ULQV01VS9LCI2ePpLsmka+W0mawFpEA0rtxnezUj4A4=" crossorigin="anonymous"></script>
+  <script src="/assets/js/copybutton.js"></script>
+  <script>
+    baguetteBox.run('div#content', {
+      ignoreClass: 'islink',
+      captions: function (element) {
+        return element.getElementsByTagName('img')[0].alt;
+      }
+    });
+  </script>
+</body>
 
-<div class="row">
-  <div class="col-sm-6">
-    <div class="card" id="cxx-docs">
-      <div class="card-header section-card">
-        C++
-      </div>
-      <div class="list-group list-group-flush">
-        <a href="doxygen/html/modules.html" class="list-group-item docs">List of Cantera Modules</a>
-        <a href="doxygen/html/classes.html" class="list-group-item docs">List of Cantera Classes</a>
-        <a href="doxygen/html/da/d58/deprecated.html" class="list-group-item docs">List of Deprecated
-          Functions and Classes</a>
-      </div>
-    </div>
-  </div>
-  <div class="col-sm-6">
-    <div class="card" id="other-docs">
-      <div class="card-header section-card">
-        Other Documentation
-      </div>
-      <div class="list-group list-group-flush">
-        <a href="/tutorials/input-files.html" class="list-group-item docs">CTI Input File Tutorial</a>
-        <a href="sphinx/html/cti/classes.html" class="list-group-item docs">
-          CTI Input File Class Reference
-        </a>
-        <a href="/documentation/glossary.html" class="list-group-item docs">Glossary of Terms</a>
-      </div>
-    </div>
-  </div>
-</div>
-
-<p class="text-center">
-  <a href="/documentation/index.html" class="btn btn-lg btn-outline-primary">Go Back to the Current Documentation</a>
-</p>
+</html>

--- a/api-docs/docs-2.4/index.html
+++ b/api-docs/docs-2.4/index.html
@@ -1,0 +1,133 @@
+<!--
+.. title: Cantera Documentation
+.. slug: index
+.. date: 2018-06-09 13:57:46 UTC-04:00
+.. description: API documentation for the Cantera interfaces
+.. type: text
+-->
+
+<div class="jumbotron">
+  <h1 class="display-3">Cantera 2.4.0 Documentation</h1>
+  <p class="lead">
+    Sometimes you just need a little more detail. You'll find documentation for
+    (almost) every function in Cantera right here. This is the documentation for
+    a deprecated release, Cantera 2.4.0. For other versions, see the links
+    at the bottom of the page.
+  </p>
+
+  <div id="searchbox" style="display: inline-block" role="search">
+    <h3>Search the documentation</h3>
+    <div class="searchformwrapper">
+      <form class="search" action="sphinx/html/search.html" method="get">
+        <input type="text" name="q" size="50" />
+        <input type="submit" value="Go" />
+        <input type="hidden" name="check_keywords" value="yes" />
+        <input type="hidden" name="area" value="default" />
+      </form>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-6">
+    <div class="card" id="python-docs">
+      <div class="card-header section-card">
+        Python
+      </div>
+      <div class="list-group list-group-flush">
+        <a href="sphinx/html/cython/importing.html" class="list-group-item docs">
+          Objects Representing Phases (<code>Solution</code>s, <code>PureFluid</code>s, <code>Interface</code>s, etc.)
+        </a>
+        <a href="sphinx/html/cython/thermo.html" class="list-group-item docs">
+          Thermodynamic Properties (Temperature, pressure, energy, etc.)
+        </a>
+        <a href="sphinx/html/cython/kinetics.html" class="list-group-item docs">
+          Chemical Kinetics (Reactions, rates of progress, reaction path analysis, etc.)
+        </a>
+        <a href="sphinx/html/cython/transport.html" class="list-group-item docs">
+          Transport Properties (Diffusion, viscosity, thermal conductivity, etc.)
+        </a>
+        <a href="sphinx/html/cython/zerodim.html" class="list-group-item docs">
+          Zero-Dimensional Reactor Networks (<code>Reactor</code>s, <code>IdealGasReactor</code>s, <code>Wall</code>s,
+          etc.)
+        </a>
+        <a href="sphinx/html/cython/onedim.html" class="list-group-item docs">
+          One-dimensional Reacting Flows (<code>FreeFlame</code>s, <code>BurnerFlame</code>s, Flow Domains, Boundaries,
+          etc.)
+        </a>
+        <a href="sphinx/html/cython/constants.html" class="list-group-item docs">
+          Physical Constants (Universal constants, built into Cantera for convenience)
+        </a>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6">
+    <div class="card" id="matlab-docs">
+      <div class="card-header section-card">
+        Matlab
+      </div>
+      <div class="list-group list-group-flush">
+        <a href="sphinx/html/matlab/importing.html" class="list-group-item docs">
+          Objects Representing Phases (<code>Solution</code>s, <code>PureFluid</code>s, <code>Interface</code>s, etc.)
+        </a>
+        <a href="sphinx/html/matlab/thermodynamics.html" class="list-group-item docs">
+          Thermodynamic Properties (Temperature, pressure, energy, etc.)
+        </a>
+        <a href="sphinx/html/matlab/kinetics.html" class="list-group-item docs">
+          Chemical Kinetics (Reactions, rates of progress, reaction path analysis, etc.)
+        </a>
+        <a href="sphinx/html/matlab/transport.html" class="list-group-item docs">
+          Transport Properties (Diffusion, viscosity, thermal conductivity, etc.)
+        </a>
+        <a href="sphinx/html/matlab/zero-dim.html" class="list-group-item docs">
+          Zero-Dimensional Reactor Networks (<code>Reactor</code>s, <code>IdealGasReactor</code>s, <code>Wall</code>s,
+          etc.)
+        </a>
+        <a href="sphinx/html/matlab/one-dim.html" class="list-group-item docs">
+          One-dimensional Reacting Flows (<code>FreeFlame</code>s, <code>BurnerFlame</code>s, Flow Domains, Boundaries,
+          etc.)
+        </a>
+        <a href="sphinx/html/matlab/data.html" class="list-group-item docs">
+          Physical Constants (Universal constants, built into Cantera for convenience)
+        </a>
+        <a href="sphinx/html/matlab/utilities.html" class="list-group-item docs">
+          Utility functions (XML Parsers, conversion scripts, etc.)
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-6">
+    <div class="card" id="cxx-docs">
+      <div class="card-header section-card">
+        C++
+      </div>
+      <div class="list-group list-group-flush">
+        <a href="doxygen/html/modules.html" class="list-group-item docs">List of Cantera Modules</a>
+        <a href="doxygen/html/classes.html" class="list-group-item docs">List of Cantera Classes</a>
+        <a href="doxygen/html/da/d58/deprecated.html" class="list-group-item docs">List of Deprecated
+          Functions and Classes</a>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6">
+    <div class="card" id="other-docs">
+      <div class="card-header section-card">
+        Other Documentation
+      </div>
+      <div class="list-group list-group-flush">
+        <a href="/tutorials/input-files.html" class="list-group-item docs">CTI Input File Tutorial</a>
+        <a href="sphinx/html/cti/classes.html" class="list-group-item docs">
+          CTI Input File Class Reference
+        </a>
+        <a href="/documentation/glossary.html" class="list-group-item docs">Glossary of Terms</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<p class="text-center">
+  <a href="/documentation/index.html" class="btn btn-lg btn-outline-primary">Go Back to the Current Documentation</a>
+</p>

--- a/api-docs/docs-2.4/sphinx/html/cti/classes.html
+++ b/api-docs/docs-2.4/sphinx/html/cti/classes.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="module-cantera.ctml_writer">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="module-cantera.ctml_writer">
 <span id="cti-class-reference"></span><h1>CTI Class Reference<a class="headerlink" href="#module-cantera.ctml_writer" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="basic-classes-functions">
 <h2>Basic Classes &amp; Functions<a class="headerlink" href="#basic-classes-functions" title="Permalink to this headline">&#182;</a></h2>

--- a/api-docs/docs-2.4/sphinx/html/cython/constants.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/constants.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="physical-constants">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="physical-constants">
 <h1>Physical Constants<a class="headerlink" href="#physical-constants" title="Permalink to this headline">&#182;</a></h1>
 <p>These values are the same as those in the Cantera C++ header file ct_defs.h.</p>
 <dl class="data">

--- a/api-docs/docs-2.4/sphinx/html/cython/importing.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/importing.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="objects-representing-phases">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="objects-representing-phases">
 <h1>Objects Representing Phases<a class="headerlink" href="#objects-representing-phases" title="Permalink to this headline">&#182;</a></h1>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/api-docs/docs-2.4/sphinx/html/cython/index.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/index.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="python-module-documentation">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="python-module-documentation">
 <span id="sec-cython-documentation"></span><h1>Python Module Documentation<a class="headerlink" href="#python-module-documentation" title="Permalink to this headline">&#182;</a></h1>
 <p>Contents:</p>
 <div class="toctree-wrapper compound">

--- a/api-docs/docs-2.4/sphinx/html/cython/kinetics.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/kinetics.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="chemical-kinetics">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="chemical-kinetics">
 <h1>Chemical Kinetics<a class="headerlink" href="#chemical-kinetics" title="Permalink to this headline">&#182;</a></h1>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/api-docs/docs-2.4/sphinx/html/cython/onedim.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/onedim.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="one-dimensional-reacting-flows">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="one-dimensional-reacting-flows">
 <span id="sec-cython-onedim"></span><h1>One-dimensional Reacting Flows<a class="headerlink" href="#one-dimensional-reacting-flows" title="Permalink to this headline">&#182;</a></h1>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/api-docs/docs-2.4/sphinx/html/cython/thermo.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/thermo.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="thermodynamic-properties">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="thermodynamic-properties">
 <h1>Thermodynamic Properties<a class="headerlink" href="#thermodynamic-properties" title="Permalink to this headline">&#182;</a></h1>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/api-docs/docs-2.4/sphinx/html/cython/transport.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/transport.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="transport-properties">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="transport-properties">
 <h1>Transport Properties<a class="headerlink" href="#transport-properties" title="Permalink to this headline">&#182;</a></h1>
 <dl class="class">
 <dt id="cantera.Transport">

--- a/api-docs/docs-2.4/sphinx/html/cython/zerodim.html
+++ b/api-docs/docs-2.4/sphinx/html/cython/zerodim.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="zero-dimensional-reactor-networks">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="zero-dimensional-reactor-networks">
 <span id="sec-cython-zerodim"></span><h1>Zero-Dimensional Reactor Networks<a class="headerlink" href="#zero-dimensional-reactor-networks" title="Permalink to this headline">&#182;</a></h1>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/api-docs/docs-2.4/sphinx/html/genindex.html
+++ b/api-docs/docs-2.4/sphinx/html/genindex.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -77,7 +77,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="body" role="main">
 
 
-<h1 id="index">Index</h1>
+<blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><h1 id="index">Index</h1>
 
 <div class="genindex-jumpbox">
  <a href="#A"><strong>A</strong></a>

--- a/api-docs/docs-2.4/sphinx/html/index.html
+++ b/api-docs/docs-2.4/sphinx/html/index.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="documentation">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="documentation">
 <h1>Documentation<a class="headerlink" href="#documentation" title="Permalink to this headline">&#182;</a></h1>
 <p>These are the detailed API documentation pages for the Python and Matlab
 interfaces for Cantera. There is also documentation of the CTI input file

--- a/api-docs/docs-2.4/sphinx/html/matlab/data.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/data.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="physical-constants">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="physical-constants">
 <h1>Physical Constants<a class="headerlink" href="#physical-constants" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="data">
 <h2>Data<a class="headerlink" href="#data" title="Permalink to this headline">&#182;</a></h2>

--- a/api-docs/docs-2.4/sphinx/html/matlab/importing.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/importing.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="objects-representing-phases">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="objects-representing-phases">
 <h1>Objects Representing Phases<a class="headerlink" href="#objects-representing-phases" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="solution">
 <h2>Solution<a class="headerlink" href="#solution" title="Permalink to this headline">&#182;</a></h2>

--- a/api-docs/docs-2.4/sphinx/html/matlab/index.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/index.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="matlab-interface-user-s-guide">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="matlab-interface-user-s-guide">
 <h1>Matlab Interface User&#8217;s Guide<a class="headerlink" href="#matlab-interface-user-s-guide" title="Permalink to this headline">&#182;</a></h1>
 <div class="toctree-wrapper compound">
 <ul>

--- a/api-docs/docs-2.4/sphinx/html/matlab/kinetics.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/kinetics.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="chemical-kinetics">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="chemical-kinetics">
 <h1>Chemical Kinetics<a class="headerlink" href="#chemical-kinetics" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="kinetics">
 <h2>Kinetics<a class="headerlink" href="#kinetics" title="Permalink to this headline">&#182;</a></h2>

--- a/api-docs/docs-2.4/sphinx/html/matlab/one-dim.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/one-dim.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="one-dimensional-reacting-flows">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="one-dimensional-reacting-flows">
 <h1>One-Dimensional Reacting Flows<a class="headerlink" href="#one-dimensional-reacting-flows" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="domain1d">
 <h2>Domain1D<a class="headerlink" href="#domain1d" title="Permalink to this headline">&#182;</a></h2>

--- a/api-docs/docs-2.4/sphinx/html/matlab/thermodynamics.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/thermodynamics.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="thermodynamic-properties">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="thermodynamic-properties">
 <h1>Thermodynamic Properties<a class="headerlink" href="#thermodynamic-properties" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="thermophase">
 <h2>ThermoPhase<a class="headerlink" href="#thermophase" title="Permalink to this headline">&#182;</a></h2>

--- a/api-docs/docs-2.4/sphinx/html/matlab/transport.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/transport.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="transport-properties">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="transport-properties">
 <h1>Transport Properties<a class="headerlink" href="#transport-properties" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="transport">
 <h2>Transport<a class="headerlink" href="#transport" title="Permalink to this headline">&#182;</a></h2>

--- a/api-docs/docs-2.4/sphinx/html/matlab/utilities.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/utilities.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="utility-functions">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="utility-functions">
 <h1>Utility Functions<a class="headerlink" href="#utility-functions" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="utilities">
 <h2>Utilities<a class="headerlink" href="#utilities" title="Permalink to this headline">&#182;</a></h2>

--- a/api-docs/docs-2.4/sphinx/html/matlab/zero-dim.html
+++ b/api-docs/docs-2.4/sphinx/html/matlab/zero-dim.html
@@ -22,7 +22,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
     <link rel="shortcut icon" href="/assets/img/favicon.ico" sizes="16x16">
 
     <link rel="search" title="Search" href="../search.html">
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -76,7 +76,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <div class="section" id="zero-dimensional-reactor-networks">
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><div class="section" id="zero-dimensional-reactor-networks">
 <h1>Zero-Dimensional Reactor Networks<a class="headerlink" href="#zero-dimensional-reactor-networks" title="Permalink to this headline">&#182;</a></h1>
 <div class="section" id="func">
 <h2>Func<a class="headerlink" href="#func" title="Permalink to this headline">&#182;</a></h2>

--- a/api-docs/docs-2.4/sphinx/html/py-modindex.html
+++ b/api-docs/docs-2.4/sphinx/html/py-modindex.html
@@ -25,7 +25,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
 
 
 
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -80,7 +80,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="body" role="main">
 
 
-   <h1>Python Module Index</h1>
+   <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><h1>Python Module Index</h1>
 
    <div class="modindex-jumpbox">
    <a href="#cap-c"><strong>c</strong></a>

--- a/api-docs/docs-2.4/sphinx/html/search.html
+++ b/api-docs/docs-2.4/sphinx/html/search.html
@@ -30,7 +30,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
   <script type="text/javascript" id="searchindexloader"></script>
 
 
-  </head>
+  <meta name="robots" content="noindex"></head>
   <body>
   <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
 
@@ -84,7 +84,7 @@ og: http://ogp.me/ns# article: http://ogp.me/ns/article#
                 <div class="bodywrapper">
                 <div class="body" role="main">
 
-  <h1 id="search-documentation">Search</h1>
+  <blockquote><div><div class="admonition warning"><p class="first admonition-title">Warning</p><p class="last">This documentation is for an old version of Cantera. You can find docs for newer versions <a class="reference external" href="https://cantera.org/documentation">here</a>.</p></div></div></blockquote><h1 id="search-documentation">Search</h1>
   <div id="fallback" class="admonition warning">
   <script type="text/javascript">$('#fallback').hide();</script>
   <p>

--- a/pages/documentation/index.html
+++ b/pages/documentation/index.html
@@ -19,10 +19,10 @@
     <h3>Search the documentation</h3>
     <div class="searchformwrapper">
       <form class="search" action="{{% ct_docs sphinx/html/search.html %}}" method="get">
-        <input type="text" name="q" size="50"/>
-        <input type="submit" value="Go"/>
-        <input type="hidden" name="check_keywords" value="yes"/>
-        <input type="hidden" name="area" value="default"/>
+        <input type="text" name="q" size="50" />
+        <input type="submit" value="Go" />
+        <input type="hidden" name="check_keywords" value="yes" />
+        <input type="hidden" name="area" value="default" />
       </form>
     </div>
   </div>
@@ -151,7 +151,7 @@
       </div>
       <div class="list-group list-group-flush">
         <a href="/documentation/dev-docs.html" class="list-group-item dev-docs">Development Version</a>
-        <a href="docs-2.4/sphinx/html/index.html" class="list-group-item dev-docs">Cantera 2.4.0</a>
+        <a href="docs-2.4/index.html" class="list-group-item dev-docs">Cantera 2.4.0</a>
         <a href="docs-2.3/sphinx/html/index.html" class="list-group-item dev-docs">Cantera 2.3.0</a>
         <a href="docs-2.2/sphinx/html/index.html" class="list-group-item dev-docs">Cantera 2.2.1</a>
         <a href="docs-2.1/sphinx/html/index.html" class="list-group-item dev-docs">Cantera 2.1.2</a>

--- a/pages/index.html
+++ b/pages/index.html
@@ -75,25 +75,8 @@
             <!-- <a href="/install/index.html" class="card-link" title="Installation Instructions">Install</a> -->
             <a href="/tutorials/python-tutorial.html" class="card-link" title="Python Tutorial">Python</a>
             <a href="/tutorials/matlab-tutorial.html" class="card-link" title="Matlab Tutorial">Matlab</a>
-            <a href="/tutorials/ck2yaml-tutorial.html" class="card-link" title="CK2YAML Tutorial">Convert Input Files</a>
-          </div>
-        </div>
-        <div class="card">
-          <a href="http://mybinder.org:/repo/cantera/cantera-jupyter" rel="nofollow" title="Binder">
-            <div class="card-header section-card">Open Binder</div>
-          </a>
-          <div class="card-body">
-            <h5 class="card-title">
-              Try Cantera in your Browser!
-            </h5>
-            <p class="card-text">
-              Cantera can be used online in Jupyter Notebooks via the Binder service! Try it out now!
-            </p>
-            <a href="http://mybinder.org:/repo/cantera/cantera-jupyter" rel="nofollow" class="card-link">
-              <img
-                src="https://camo.githubusercontent.com/70c5b4d050d4019f4f20b170d75679a9316ac5e5/687474703a2f2f6d7962696e6465722e6f72672f62616467652e737667"
-                alt="Binder" data-canonical-src="http://mybinder.org/badge.svg" style="max-width:100%;">
-            </a>
+            <a href="/tutorials/ck2yaml-tutorial.html" class="card-link" title="CK2YAML Tutorial">Convert Input
+              Files</a>
           </div>
         </div>
         <div class="card">
@@ -111,12 +94,6 @@
               Notebook</a>
           </div>
         </div>
-      </div>
-    </div>
-  </div>
-  <div class="container">
-    <div class="row">
-      <div class="card-deck">
         <div class="card">
           <a href="/install/index.html" title="Install">
             <div class="card-header section-card">
@@ -127,6 +104,12 @@
             Instructions to install pre-built Cantera binaries or to build Cantera from the source
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+  <div class="container">
+    <div class="row">
+      <div class="card-deck">
         <div class="card">
           <a href="/science/index.html" title="Science">
             <div class="card-header section-card">
@@ -146,6 +129,24 @@
           </a>
           <div class="card-body">
             Documentation for the classes and functions that make up Cantera.
+          </div>
+        </div>
+        <div class="card">
+          <a href="https://mybinder.org/v2/gh/Cantera/cantera-jupyter/main" rel="nofollow" title="Binder">
+            <div class="card-header section-card">Open Binder</div>
+          </a>
+          <div class="card-body">
+            <h5 class="card-title">
+              Try Cantera in your Browser!
+            </h5>
+            <p class="card-text">
+              The Binder service allows you to try out Cantera in the cloud without installing it on your computer.
+              You'll see some of our examples and be able to run them yourself!
+            </p>
+            <a href="https://mybinder.org/v2/gh/Cantera/cantera-jupyter/main" rel="nofollow" class="card-link">
+              <img src="https://mybinder.org/badge_logo.svg" alt="Binder"
+                data-canonical-src="https://mybinder.org/badge_logo.svg" style="max-width:100%;">
+            </a>
           </div>
         </div>
       </div>

--- a/plugins/copy_tree.py
+++ b/plugins/copy_tree.py
@@ -9,6 +9,7 @@ for the API documentation.
 """
 from shutil import copytree, ignore_patterns, rmtree
 import os
+from pathlib import Path
 
 from nikola.plugin_categories import Task
 from nikola.utils import config_changed
@@ -21,6 +22,8 @@ class CopyTree(Task):
 
     def gen_tasks(self):
         """Copy docs files into the output folder."""
+        # Put these into a dictionary so that if they change,
+        # the task is marked as out-of-date
         kw = {
             "docs_folders": self.site.config["DOCS_FOLDERS"],
             "output_folder": self.site.config["OUTPUT_FOLDER"],
@@ -37,11 +40,13 @@ class CopyTree(Task):
 
         for src, rel_dst in kw["docs_folders"].items():
             final_dst = os.path.join(kw["output_folder"], rel_dst)
+            all_files = [i for i in Path(src).glob("**/*") if not i.is_dir()]
             yield {
                 "basename": self.name,
                 "name": rel_dst,
                 "targets": [final_dst],
                 "uptodate": [config_changed(kw, "copy_tree")],
+                "file_dep": all_files,
                 "actions": [
                     (
                         copytree_task,


### PR DESCRIPTION
As discussed in the website working group meeting, move the Binder link to the second row and fix the link.

Also, add an index page with access to the 2.4.0 documentation. Fixes #149.