### PR TITLE
Mark CTI as deprecated

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -64,6 +64,17 @@ jobs:
       run: NIKOLA_DEBUG=1 nikola build
       working-directory: ${{ env.WEBSITE_CLONE_DIR }}
 
+    # Create artifact containing output
+    - name: Create archive for website output
+      run: |
+        cd ${{ env.WEBSITE_CLONE_DIR }}; \
+        tar -czf website.tar.gz ${{ env.NIKOLA_OUTPUT_DIR }}
+    - name: Store archive of website output
+      uses: actions/upload-artifact@v2
+      with:
+        path: ${{ env.WEBSITE_CLONE_DIR }}/website.tar.gz
+        retention-days: 5
+
     # The known_hosts key is generated with `ssh-keygen -F cantera.org` from a
     # machine that has previously logged in to cantera.org and trusts
     # that it logged in to the right machine

--- a/pages/tutorials/ck2cti-tutorial.rst
+++ b/pages/tutorials/ck2cti-tutorial.rst
@@ -13,6 +13,9 @@
       If you want to convert a Chemkin-format file to CTI format, or you're having
       errors when you try to do so, this section will help.
 
+      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
+      and fully replaced by the YAML input file format in Cantera 3.0.
+
 CK2CTI
 ------
 

--- a/pages/tutorials/ck2cti-tutorial.rst
+++ b/pages/tutorials/ck2cti-tutorial.rst
@@ -14,7 +14,7 @@
       errors when you try to do so, this section will help.
 
       Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by the YAML input file format in Cantera 3.0.
+      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
 
 CK2CTI
 ------

--- a/pages/tutorials/cti/cti-processing.rst
+++ b/pages/tutorials/cti/cti-processing.rst
@@ -270,7 +270,7 @@ extract a portion of a large reaction mechanism, as described in :ref:`sec-phase
 
          .. container:: btn btn-primary
             :tagname: a
-            :attributes: href=defining-phases.html
+            :attributes: href=defining-phases-cti.html
 
             Return: Defining Phases
 

--- a/pages/tutorials/cti/cti-processing.rst
+++ b/pages/tutorials/cti/cti-processing.rst
@@ -14,7 +14,7 @@
       debugging any errors that occur.
 
       Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by the YAML input file format in Cantera 3.0.
+      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
 
 Cantera Input Files
 ===================

--- a/pages/tutorials/cti/cti-processing.rst
+++ b/pages/tutorials/cti/cti-processing.rst
@@ -10,8 +10,11 @@
 
    .. class:: lead
 
-      A description of how Cantera processes input files, to help with debugging any errors that
-      occur.
+      A description of how Cantera processes legacy CTI input files, to help with
+      debugging any errors that occur.
+
+      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
+      and fully replaced by the YAML input file format in Cantera 3.0.
 
 Cantera Input Files
 ===================

--- a/pages/tutorials/cti/cti-syntax.rst
+++ b/pages/tutorials/cti/cti-syntax.rst
@@ -12,7 +12,7 @@
       CTI is the legacy human-readable input format for Cantera, and we describe it's syntax here
 
       Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by the YAML input file format in Cantera 3.0.
+      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
 
 Input File Syntax
 =================

--- a/pages/tutorials/cti/cti-syntax.rst
+++ b/pages/tutorials/cti/cti-syntax.rst
@@ -9,7 +9,10 @@
 
    .. class:: lead
 
-      CTI is the human-readable input format for Cantera, and we describe it's syntax here
+      CTI is the legacy human-readable input format for Cantera, and we describe it's syntax here
+
+      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
+      and fully replaced by the YAML input file format in Cantera 3.0.
 
 Input File Syntax
 =================

--- a/pages/tutorials/cti/cti-syntax.rst
+++ b/pages/tutorials/cti/cti-syntax.rst
@@ -321,7 +321,7 @@ pressure     ``'Pa', 'atm', 'bar'``
 
          .. container:: btn btn-primary
             :tagname: a
-            :attributes: href=defining-phases.html
+            :attributes: href=defining-phases-cti.html
                          title="Defining Phases"
 
             Return: Defining Phases

--- a/pages/tutorials/cti/defining-phases-cti.rst
+++ b/pages/tutorials/cti/defining-phases-cti.rst
@@ -1,4 +1,4 @@
-.. slug: defining-phases
+.. slug: defining-phases-cti
 .. title: Defining Phases
 
 .. jumbotron::

--- a/pages/tutorials/cti/defining-phases-cti.rst
+++ b/pages/tutorials/cti/defining-phases-cti.rst
@@ -12,7 +12,7 @@
       A guide to Cantera's legacy CTI input file format
 
       Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by the YAML input file format in Cantera 3.0.
+      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
 
 Virtually every Cantera simulation involves one or more phases of
 matter. Depending on the calculation being performed, it may be necessary to

--- a/pages/tutorials/cti/defining-phases.rst
+++ b/pages/tutorials/cti/defining-phases.rst
@@ -9,7 +9,10 @@
 
    .. class:: lead
 
-      A guide to Cantera's input file format
+      A guide to Cantera's legacy CTI input file format
+
+      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
+      and fully replaced by the YAML input file format in Cantera 3.0.
 
 Virtually every Cantera simulation involves one or more phases of
 matter. Depending on the calculation being performed, it may be necessary to

--- a/pages/tutorials/cti/phases.rst
+++ b/pages/tutorials/cti/phases.rst
@@ -12,6 +12,9 @@
       Cantera simulations model interactions between and within different phases of matter, as
       described here.
 
+      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
+      and fully replaced by the YAML input file format in Cantera 3.0.
+
 Phases
 ======
 

--- a/pages/tutorials/cti/phases.rst
+++ b/pages/tutorials/cti/phases.rst
@@ -13,7 +13,7 @@
       described here.
 
       Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by the YAML input file format in Cantera 3.0.
+      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
 
 Phases
 ======

--- a/pages/tutorials/cti/phases.rst
+++ b/pages/tutorials/cti/phases.rst
@@ -398,7 +398,7 @@ If we import this into Matlab, for example, we get a gas mixture containing the
 
          .. container:: btn btn-primary
             :tagname: a
-            :attributes: href=defining-phases.html
+            :attributes: href=defining-phases-cti.html
 
             Return: Defining Phases
 

--- a/pages/tutorials/cti/reactions.rst
+++ b/pages/tutorials/cti/reactions.rst
@@ -13,7 +13,7 @@
       A description of how reactions are defined in legacy CTI input files
 
       Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by the YAML input file format in Cantera 3.0.
+      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
 
 Basic Reactions
 ===============

--- a/pages/tutorials/cti/reactions.rst
+++ b/pages/tutorials/cti/reactions.rst
@@ -292,7 +292,7 @@ Other Examples
 
          .. container:: btn btn-primary
             :tagname: a
-            :attributes: href=defining-phases.html
+            :attributes: href=defining-phases-cti.html
                          title="Defining Phases"
 
             Return: Defining Phases

--- a/pages/tutorials/cti/reactions.rst
+++ b/pages/tutorials/cti/reactions.rst
@@ -10,7 +10,10 @@
 
    .. class:: lead
 
-      A description of how reactions are defined in CTI input files
+      A description of how reactions are defined in legacy CTI input files
+
+      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
+      and fully replaced by the YAML input file format in Cantera 3.0.
 
 Basic Reactions
 ===============

--- a/pages/tutorials/cti/species.rst
+++ b/pages/tutorials/cti/species.rst
@@ -10,7 +10,10 @@
 
    .. class:: lead
 
-      A description of how elements and species are defined in CTI input files
+      A description of how elements and species are defined in legacy CTI input files
+
+      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
+      and fully replaced by the YAML input file format in Cantera 3.0.
 
 Elements
 ========

--- a/pages/tutorials/cti/species.rst
+++ b/pages/tutorials/cti/species.rst
@@ -265,7 +265,7 @@ no attached units string.
 
          .. container:: btn btn-primary
             :tagname: a
-            :attributes: href=defining-phases.html
+            :attributes: href=defining-phases-cti.html
                          title="Defining Phases"
 
             Return: Defining Phases

--- a/pages/tutorials/cti/species.rst
+++ b/pages/tutorials/cti/species.rst
@@ -13,7 +13,7 @@
       A description of how elements and species are defined in legacy CTI input files
 
       Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by the YAML input file format in Cantera 3.0.
+      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
 
 Elements
 ========

--- a/pages/tutorials/input-files.rst
+++ b/pages/tutorials/input-files.rst
@@ -23,9 +23,9 @@ The required input files can be provided via one of several methods:
 - Create your own YAML file from scratch or by editing an existing file *(New in
   Cantera 2.5)*
 - Convert a pre-existing mechanism from Chemkin (CK) format to the legacy Cantera (CTI)
-  format *(Not recommended due to deprecation of CTI in Cantera 2.6)*
-- Create your own CTI file, either from scratch (not recommended) or by editing an existing file
-  *(Not recommended due to deprecation of CTI in Cantera 2.6)*
+  format *(Not recommended due to pending deprecation of CTI in Cantera 2.6)*
+- Create your own CTI file, either from scratch or by editing an existing file
+  *(Not recommended due to pending deprecation of CTI in Cantera 2.6)*
 
 The first option will suffice for tutorials and introductory work with thermodynamic
 phases and reaction kinetics. Most modern reaction mechanisms are published in Chemkin
@@ -105,7 +105,7 @@ There are three primary options for creating a new Cantera input file:
 
                   Convert a Chemkin-formatted ('CK') file to the Cantera legacy input
                   format (CTI).
-                  *(Not recommended due to deprecation of CTI in favor of YAML)*
+                  *(Not recommended due to pending deprecation of CTI in favor of YAML)*
 
    .. row::
 
@@ -147,7 +147,7 @@ There are three primary options for creating a new Cantera input file:
 
                   Create a completely new mechanism, by defining new species,
                   phases, and/or reactions, using the legacy CTI format.
-                  *(Deprecated in Cantera 2.6)*
+                  *(Not recommended due to pending deprecation of CTI in favor of YAML)*
 
    .. row::
 
@@ -218,4 +218,5 @@ to errors in the CK syntax formatting).
          .. container:: card-text
 
             This tutorial covers the details of the legacy CTI format and its syntax
-            *(Deprecated in Cantera 2.6)*
+            *(Note that the legacy CTI input file format will be deprecated in Cantera 2.6
+            and fully replaced by YAML input in Cantera 3.0.)*

--- a/pages/tutorials/input-files.rst
+++ b/pages/tutorials/input-files.rst
@@ -16,20 +16,24 @@
 
 The required input files can be provided via one of several methods:
 
-- Use one of the pre-existing input files provided with Cantera
+- Use one of the pre-existing input files that are distributed with Cantera (note that
+  these input files are provided for convenience, and may not be suited for research)
 - Convert a pre-existing mechanism from Chemkin (CK) format to YAML format *(New
   in Cantera 2.5)*
-- Convert a pre-existing mechanism from Chemkin (CK) format to Cantera (CTI) format (not recommended)
 - Create your own YAML file from scratch or by editing an existing file *(New in
   Cantera 2.5)*
+- Convert a pre-existing mechanism from Chemkin (CK) format to the legacy Cantera (CTI)
+  format *(Not recommended due to deprecation of CTI in Cantera 2.6)*
 - Create your own CTI file, either from scratch (not recommended) or by editing an existing file
   *(Not recommended due to deprecation of CTI in Cantera 2.6)*
 
-The first option will suffice for a majority of Cantera users. Advanced
-users may, however, need to edit an existing input file in order to define
-additional species, reactions, or entirely new phases. Even if you need to
-create an entirely new input file, it is still advisable to start from an existing
-file, to cut down on syntax errors.
+The first option will suffice for tutorials and introductory work with thermodynamic
+phases and reaction kinetics. Most modern reaction mechanisms are published in Chemkin
+(CK) format, and can be converted to Cantera's YAML format using the ``ck2yaml``
+conversion tool (option 2). Advanced users may, however, need to edit an existing input
+file in order to define additional species, reactions, or entirely new phases. Even if
+you need to create an entirely new input file, it is still advisable to start from an
+existing file, to cut down on syntax errors.
 
 Whenever you edit a Cantera input file, it is *highly advised* that you begin by copying the existing file and
 saving it under a new name, before editing the new file. Editing a file under its original name can

--- a/pages/tutorials/input-files.rst
+++ b/pages/tutorials/input-files.rst
@@ -23,6 +23,7 @@ The required input files can be provided via one of several methods:
 - Create your own YAML file from scratch or by editing an existing file *(New in
   Cantera 2.5)*
 - Create your own CTI file, either from scratch (not recommended) or by editing an existing file
+  *(Not recommended due to deprecation of CTI in Cantera 2.6)*
 
 The first option will suffice for a majority of Cantera users. Advanced
 users may, however, need to edit an existing input file in order to define
@@ -98,8 +99,9 @@ There are three primary options for creating a new Cantera input file:
 
                .. container:: card-text
 
-                  Convert a Chemkin-formatted ('CK') file to the Cantera input
+                  Convert a Chemkin-formatted ('CK') file to the Cantera legacy input
                   format (CTI).
+                  *(Not recommended due to deprecation of CTI in favor of YAML)*
 
    .. row::
 
@@ -140,7 +142,8 @@ There are three primary options for creating a new Cantera input file:
                .. container:: card-text
 
                   Create a completely new mechanism, by defining new species,
-                  phases, and/or reactions, using the CTI format.
+                  phases, and/or reactions, using the legacy CTI format.
+                  *(Deprecated in Cantera 2.6)*
 
    .. row::
 
@@ -210,4 +213,5 @@ to errors in the CK syntax formatting).
 
          .. container:: card-text
 
-            This tutorial covers the details of the CTI format and its syntax
+            This tutorial covers the details of the legacy CTI format and its syntax
+            *(Deprecated in Cantera 2.6)*

--- a/pages/tutorials/input-files.rst
+++ b/pages/tutorials/input-files.rst
@@ -134,7 +134,7 @@ There are three primary options for creating a new Cantera input file:
 
             .. container::
                :tagname: a
-               :attributes: href="cti/defining-phases.html"
+               :attributes: href="cti/defining-phases-cti.html"
                             title="Defining Phases in CTI"
 
                .. container:: card-header section-card

--- a/pages/tutorials/yaml/defining-phases.rst
+++ b/pages/tutorials/yaml/defining-phases.rst
@@ -119,7 +119,7 @@ Additional Information
 
       .. container::
          :tagname: a
-         :attributes: href={{% ct_dev_docs sphinx/html/yaml/index.html %}}
+         :attributes: href={{% ct_docs sphinx/html/yaml/index.html %}}
                       title="YAML Format Reference"
 
          .. container:: card-header section-card

--- a/pages/tutorials/yaml/reactions.rst
+++ b/pages/tutorials/yaml/reactions.rst
@@ -65,9 +65,10 @@ The type of the rate coefficient parameterization may be specified in the
   Arrhenius expressions at different pressures
 - :ref:`Chebyshev <sec-yaml-Chebyshev>`: A reaction rate parameterized by a
   bivariate Chebyshev polynomial in pressure and temperature
-- :ref:`Blowers-Masel <sec-yaml-Blowers-Masel>`: A reaction rate constant parameterized
-   as a modified Arrhenius reaction with one additional bond energy parameter to
-   scale the activation energy according to the enthalpy of the reaction.
+- `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-blowers-masel>`__: A
+  reaction rate constant parameterized as a modified Arrhenius reaction with
+  one additional bond energy parameter to scale the activation energy according
+  to the enthalpy of the reaction *(New in Cantera 2.6)*
 
 Additional parameters defining the rate constant for each of these reaction
 types are described in the documentation linked above.
@@ -75,9 +76,12 @@ types are described in the documentation linked above.
 The default parameterization is ``elementary``. Reactions involving surface
 species are automatically identified as :ref:`interface <sec-yaml-interface-reaction>`
 reactions, reactions involving surface species with specified ``type`` as ``Blowers-Masel``
-are treated as :ref:`surface-Blowers-Masel <sec-yaml-surface-Blowers-Masel>`, and reactions
-involving charge transfer are automatically identified as :ref:`electrochemical <sec-yaml-electrochemical-reaction>`
-reactions.
+are treated as
+`surface-Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-surface-blowers-masel>`__,
+and reactions involving charge transfer are automatically identified as
+:ref:`electrochemical <sec-yaml-electrochemical-reaction>` reactions.
+
+.. TODO: Update Blowers-Masel links once version 2.6 is released
 
 Arrhenius Expressions
 ---------------------

--- a/pages/tutorials/yaml/yaml-format.rst
+++ b/pages/tutorials/yaml/yaml-format.rst
@@ -192,7 +192,7 @@ Examples of compound units:
    A: 1.0e20 cm^6/mol^2-s  # error ('s' should be in denominator)
    density: 3.0g/cm^3  # error (missing space between value and units)
 
-See the `Units API <{{% ct_dev_docs sphinx/html/yaml/general.html#units %}}>`__
+See the `Units API <{{% ct_docs sphinx/html/yaml/general.html#units %}}>`__
 documentation for additional details, including the full set of supported units.
 
 Default units
@@ -360,7 +360,7 @@ it may be imported successfully.
 
          .. container:: btn btn-primary
             :tagname: a
-            :attributes: href={{% ct_dev_docs sphinx/html/yaml/index.html %}}
+            :attributes: href={{% ct_docs sphinx/html/yaml/index.html %}}
                          title="YAML Format Reference"
 
             Next: YAML Format Reference


### PR DESCRIPTION
Add clarifications that CTI is deprecated / replaced by YAML.

Closes #144, closes #145