### PR TITLE
Update Jupyter examples

### DIFF
--- a/plugins/render_jupyter_examples.py
+++ b/plugins/render_jupyter_examples.py
@@ -83,7 +83,7 @@ def render_example(site, kw, in_name, out_name):
     code = lxml.html.tostring(ipynb_html, encoding="unicode")
 
     data_files = set()
-    pattern = re.compile(r"data/(\w*?\.\w*)")
+    pattern = re.compile(r"data/([\w-]+?\.\w*)")
     for cell in nb_json["cells"]:
         if cell["cell_type"] != "code":
             continue

--- a/plugins/render_jupyter_examples.py
+++ b/plugins/render_jupyter_examples.py
@@ -182,6 +182,7 @@ class RenderJupyterExamples(Task):
             reactors=dict(name="Reactor Networks", files=[], summaries={}, titles={}),
             flames=dict(name="One-Dimensional Flames", files=[], summaries={}, titles={}),
             electrochemistry=dict(name="Electrochemistry", files=[], summaries={}, titles={}),
+            input=dict(name="Input Files", files=[], summaries={}, titles={}),
         )
 
         def get_b64_str(parent, img_fname):

--- a/plugins/render_jupyter_examples.py
+++ b/plugins/render_jupyter_examples.py
@@ -82,6 +82,14 @@ def render_example(site, kw, in_name, out_name):
     ipynb_html = lxml.html.fromstring(ipynb_raw)
     code = lxml.html.tostring(ipynb_html, encoding="unicode")
 
+    data_files = set()
+    pattern = re.compile(r"data/(\w*?\.\w*)")
+    for cell in nb_json["cells"]:
+        if cell["cell_type"] != "code":
+            continue
+        for match in pattern.findall(cell["source"]):
+            data_files.add(match)
+
     title = in_name.name
 
     permalink = out_name.relative_to(kw["output_folder"])
@@ -89,6 +97,7 @@ def render_example(site, kw, in_name, out_name):
     context = {
         "code": code,
         "title": title,
+        "data_files": data_files,
         "permalink": str(permalink),
         "lang": kw["default_lang"],
         "description": title,

--- a/themes/cantera/templates/examples.tmpl
+++ b/themes/cantera/templates/examples.tmpl
@@ -13,6 +13,15 @@
         <small><a href="{{ source_link }}">({{ messages("Source") }})</a></small>
     {% endif %}
     </h1>
+    {% if data_files %}
+    Data files used in this example:
+      {% for i, file in enumerate(data_files) -%}
+        <a href="https://raw.githubusercontent.com/Cantera/cantera-jupyter/main/data/{{ file }}">{{ file }}</a>
+        {%- if i + 1 != data_files | length -%}
+        ,
+        {% endif %}
+      {% endfor %}
+    {% endif %}
     {{ code }}
 {% endif %}
 {% if title.endswith('.ipynb') %}

--- a/themes/cantera/templates/jupyter-example-index.tmpl
+++ b/themes/cantera/templates/jupyter-example-index.tmpl
@@ -15,7 +15,7 @@ just want to experiment, you can give Cantera a test drive in the cloud. Click o
 below to launch an interactive environment where you can run these examples. For this, there is no
 installation required, but you cannot save and resume your work.</p>
 
-<a href="https://mybinder.org:/repo/cantera/cantera-jupyter" rel="nofollow">
+<a href="https://mybinder.org/v2/gh/Cantera/cantera-jupyter/main" rel="nofollow">
   <img src="https://camo.githubusercontent.com/70c5b4d050d4019f4f20b170d75679a9316ac5e5/687474703a2f2f6d7962696e6465722e6f72672f62616467652e737667" alt="Binder" data-canonical-src="https://mybinder.org/badge.svg" style="max-width:100%;">
 </a>
 

--- a/themes/cantera/templates/jupyter-example-index.tmpl
+++ b/themes/cantera/templates/jupyter-example-index.tmpl
@@ -12,7 +12,10 @@ the "Source" link at the top of each example page and you should be able to run 
 some examples, you will also need to download the additional data files listed below the
 "Source" link. These data files should either be placed in a subdirectory named "data"
 one level up from the directory containing the notebook file, or the notebook can be
-modified to point to the location of these data files on your computer.
+modified to point to the location of these data files on your computer. Alternatively,
+you can download all of these examples and their accompanying data files by cloning the
+<a href="https://github.com/Cantera/cantera-jupyter">cantera-jupyter</a> repository from
+GitHub.
 </p>
 
 <p><strong>New Cantera Users</strong>: If you don't have an existing Cantera installation and you

--- a/themes/cantera/templates/jupyter-example-index.tmpl
+++ b/themes/cantera/templates/jupyter-example-index.tmpl
@@ -31,7 +31,7 @@ installation required, but you cannot save and resume your work.</p>
       {% set fname = file.name %}
       <!-- <div class="col-sm-4"> -->
         <div class="card">
-          <a href="{{ head }}/{{ fname }}.html"><h5 class="card-header">{{ fname }}</h5></a>
+          <a href="{{ head }}/{{ fname }}.html"><h5 class="card-header">{{ file_dict['titles'][fname] }}</h5></a>
           <div class="card-body">
             <p class="card-text">{{ file_dict['summaries'][fname] }}</p>
           </div>

--- a/themes/cantera/templates/jupyter-example-index.tmpl
+++ b/themes/cantera/templates/jupyter-example-index.tmpl
@@ -6,9 +6,14 @@
 <p>Cantera examples in the form of <a href="https://jupyter.org" title="Jupyter">Jupyter</a>
 notebooks. To see the rendered notebooks, browse the files below.</p>
 
-<p><strong>Existing Cantera users</strong>: If you have Cantera and the Jupyter Notebook server
-installed on your local machine, simply download any Jupyter notebook by clicking the "Source" link
-at the top of each example page and you should be able to run it.</p>
+<p><strong>Existing Cantera users</strong>: If you have Cantera and the Jupyter Notebook
+server installed on your local machine, simply download any Jupyter notebook by clicking
+the "Source" link at the top of each example page and you should be able to run it. For
+some examples, you will also need to download the additional data files listed below the
+"Source" link. These data files should either be placed in a subdirectory named "data"
+one level up from the directory containing the notebook file, or the notebook can be
+modified to point to the location of these data files on your computer.
+</p>
 
 <p><strong>New Cantera Users</strong>: If you don't have an existing Cantera installation and you
 just want to experiment, you can give Cantera a test drive in the cloud. Click on the Binder link


### PR DESCRIPTION
- Improve descriptions given in the index of Jupyter examples (in combination with Cantera/cantera-jupyter#33). For example, this:
![image](https://user-images.githubusercontent.com/644977/149842216-7d317fb2-3d1e-44d0-b89a-711510257d95.png)
becomes:
![image](https://user-images.githubusercontent.com/644977/149842261-c30f43f5-0ffc-4ebd-b399-57759ebb466f.png)

- Automatically link to any input files used in each example that come from the `data` directory (also reorganized by Cantera/cantera-jupyter#33). For example:
![image](https://user-images.githubusercontent.com/644977/149842374-784177a1-bc1c-4231-a22a-3c42deb14b27.png)
