### PR TITLE
Adjacent phase documentation and some minor updates

### DIFF
--- a/pages/science/reactions.rst
+++ b/pages/science/reactions.rst
@@ -157,8 +157,6 @@ not used.
 Tsang's Approximation to :math:`F_{cent}`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**New in Cantera 2.6.0**
-
 Wing Tsang presented approximations for the value of :math:`F_{cent}` for Troe
 falloff in databases of reactions, for example, Tsang and Herron [#Tsang1991]_.
 Tsang's approximations are linear in temperature:
@@ -180,7 +178,7 @@ where :math:`A` and :math:`B` are constants. The remaining equations for :math:`
    N = 0.75 - 1.27\; \log_{10} F_{cent}
 
 A Tsang falloff function may be specified in the YAML format using the
-:ref:`Tsang <sec-yaml-falloff>` field in the reaction entry.
+:ref:`Tsang <sec-yaml-falloff>` field in the reaction entry. *(New in Cantera 2.6)*
 
 .. _sec-sri-falloff:
 
@@ -318,8 +316,6 @@ Chebyshev reactions can be defined in the CTI format using the
 Blowers-Masel Reactions
 -----------------------
 
-**New in Cantera 2.6**
-
 In some circumstances like thermodynamic sensitivity analysis, or
 modeling heterogeneous reactions from one catalyst surface to another,
 the enthalpy change of a reaction (:math:`\Delta H`) can be modified. Due to the change in :math:`\Delta H`,
@@ -359,6 +355,7 @@ After :math:`E_a` is evaluated, the reaction rate can be calculated using the mo
 
 Blowers Masel reaction can be defined in the YAML format using the
 `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-blowers-masel>`__ reaction ``type``.
+*(New in Cantera 2.6)*
 
 .. _sec-surface:
 
@@ -424,15 +421,14 @@ in the YAML format by specifying the rate constant in the reaction's
 Surface Blowers-Masel Reactions
 -------------------------------
 
-**New in Cantera 2.6**
-
 .. TODO: Update the link once version 2.6 is released
 
 Surface Blowers-Masel Reactions have the same Arrhenius-like rate expression described in
 :ref:`Surface Reactions<sec-surface>`, and the activation energy :math:`E_a` is determined
-as described in :ref:`Blowers-Masel Reactions<sec-Blowers-Masel>`.
+as described in :ref:`Blowers-Masel Reactions<sec-Blowers-Masel>`. *(New in Cantera 2.6)*
 
-Surface Blowers-Masel reactions can be identified by the presence of surface spcecies and
+
+Surface Blowers-Masel reactions can be identified by the presence of surface species and
 the `Blowers-Masel <https://cantera.org/documentation/dev/sphinx/html/yaml/reactions.html#sec-yaml-surface-blowers-masel>`__
 reaction ``type`` in a YAML input file.
 

--- a/pages/tutorials/ck2cti-tutorial.rst
+++ b/pages/tutorials/ck2cti-tutorial.rst
@@ -13,8 +13,9 @@
       If you want to convert a Chemkin-format file to CTI format, or you're having
       errors when you try to do so, this section will help.
 
-      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
+      Note that the legacy CTI input file is deprecated in Cantera 2.5, and will be
+      removed in Cantera 3.0. It is superseded by the :doc:`YAML <defining-phases>`
+      format. ```ck2cti``` is replaced by :doc:```ck2yaml`` <ck2yaml-tutorial>`.
 
 CK2CTI
 ------

--- a/pages/tutorials/input-files.rst
+++ b/pages/tutorials/input-files.rst
@@ -23,9 +23,9 @@ The required input files can be provided via one of several methods:
 - Create your own YAML file from scratch or by editing an existing file *(New in
   Cantera 2.5)*
 - Convert a pre-existing mechanism from Chemkin (CK) format to the legacy Cantera (CTI)
-  format *(Not recommended due to pending deprecation of CTI in Cantera 2.6)*
+  format *(Deprecated in Cantera 2.5; to be removed in Cantera 3.0)*
 - Create your own CTI file, either from scratch or by editing an existing file
-  *(Not recommended due to pending deprecation of CTI in Cantera 2.6)*
+  *(Deprecated in Cantera 2.5; to be removed in Cantera 3.0)*
 
 The first option will suffice for tutorials and introductory work with thermodynamic
 phases and reaction kinetics. Most modern reaction mechanisms are published in Chemkin
@@ -105,7 +105,7 @@ There are three primary options for creating a new Cantera input file:
 
                   Convert a Chemkin-formatted ('CK') file to the Cantera legacy input
                   format (CTI).
-                  *(Not recommended due to pending deprecation of CTI in favor of YAML)*
+                  *(Deprecated in Cantera 2.5; to be removed in Cantera 3.0)*
 
    .. row::
 
@@ -147,7 +147,7 @@ There are three primary options for creating a new Cantera input file:
 
                   Create a completely new mechanism, by defining new species,
                   phases, and/or reactions, using the legacy CTI format.
-                  *(Not recommended due to pending deprecation of CTI in favor of YAML)*
+                  *(Deprecated in Cantera 2.5; To be removed in Cantera 3.0)*
 
    .. row::
 
@@ -235,5 +235,4 @@ to errors in the CK syntax formatting).
          .. container:: card-text
 
             This tutorial covers the details of the legacy CTI format and its syntax
-            *(Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-            and fully replaced by YAML input in Cantera 3.0.)*
+            *(Deprecated in Cantera 2.5; to be removed in Cantera 3.0)*

--- a/pages/tutorials/yaml/phases.rst
+++ b/pages/tutorials/yaml/phases.rst
@@ -260,6 +260,38 @@ specified in the ``transport`` field. Supported models are:
 - `water <{{% ct_docs doxygen/html/df/d1f/classCantera_1_1WaterTransport.html#details %}}>`__:
   A transport model for pure water applicable in both liquid and vapor phases
 
+Declaring Adjacent Phases
+-------------------------
+
+For interface phases (surfaces and edges), the names of phases adjacent to the interface
+can be specified, in which case these additional phases can be automatically constructed
+when creating the interface phase. This behavior is useful when the interface has
+reactions that include species from one of these adjacent phases, since those phases
+must be known when adding such reactions to the interface.
+
+If the definitions of the adjacent phases are contained in the `phases` section of the
+same input file as the interface, they can be specified as a list of names:
+
+.. code:: yaml
+
+    adjacent: [gas, bulk]
+
+Alternatively, if the adjacent phase definitions are in other sections or other input
+files, they can be specified as a list of single-key mappings where the key is the
+section name (or file and section name) and the value is the phase name:
+
+.. code:: yaml
+
+    adjacent:
+    - {sectionname: gas} # a phase defined in a different section of the same YAML file
+    - {path/to/other-file.yaml/phases: bulk} # a phase defined in the 'phases' section
+                                             # of a different YAML file
+
+Since an interface kinetics mechanism is defined for the lowest-dimensional phase
+involved in the mechanism, only higher-dimensional adjacent phases should be specified.
+For example, when defining a surface, adjacent bulk phases may be specified, but
+adjacent edges must not.
+
 Setting the Initial State
 -------------------------
 
@@ -370,6 +402,7 @@ species data not shown for clarity:
 
     - name: anode-surface
       thermo: ideal-surface
+      adjacent: [graphite, electrolyte]
       kinetics: surface
       reactions: [graphite-anode-reactions]
       species: [{anode-species: all}]


### PR DESCRIPTION
- Document the 'adjacent' option for YAML phase definitions (completing Cantera/enhancements#103)
- Update formatting of "New in Cantera 2.X" labels
- Correct some deprecation notices regarding CTI/XML