### PR TITLE
Add documentation of installation of unstable Ubuntu packages

### DIFF
--- a/pages/install/ubuntu-install.rst
+++ b/pages/install/ubuntu-install.rst
@@ -70,3 +70,32 @@ you have the latest available version installed by running:
 
 If you also have the ``cantera-dev`` package installed, it should also be included on
 the ``apt install`` command line.
+
+Installing pre-release Cantera versions
+---------------------------------------
+
+Sometimes, pre-release (alpha or beta) versions of Cantera which represent work toward
+the next Cantera release will be available for users who want to use cutting-edge
+features or test compatibility with the new version before it is released. To see the
+latest Cantera versions available from this PPA, visit
+https://launchpad.net/~cantera-team/+archive/ubuntu/cantera-unstable.
+
+These packages can be installed by additionally enabling the
+``cantera-team/cantera-unstable`` PPA and then upgrading Cantera:
+
+.. code-block:: bash
+
+    sudo apt-add-repository ppa:cantera-team/cantera-unstable
+    sudo apt install cantera-python3 cantera-dev
+
+You should also have the ``cantera-team/cantera`` PPA enabled, since the
+``cantera-unstable`` PPA *only* includes development versions.
+
+If you later want to remove the development version and return to the latest stable
+version, run the commands:
+
+.. code-block:: bash
+
+    sudo apt-add-repository --remove ppa:cantera-team/cantera-unstable
+    sudo apt remove cantera cantera-common cantera-dev cantera-python3
+    sudo apt install cantera-python3 cantera-dev

--- a/pages/install/ubuntu-install.rst
+++ b/pages/install/ubuntu-install.rst
@@ -18,9 +18,9 @@
       Matlab packages on Ubuntu, you must :ref:`compile the source code <sec-compiling>`.
 
 As of Cantera 2.5.1, packages are available for Ubuntu 18.04 (Bionic Beaver), Ubuntu 20.04
-(Focal Fossa), Ubuntu 20.10 (Groovy Gorilla), and Ubuntu 21.04 (Hirsute Hippo). To see which Ubuntu
-releases and Cantera versions are currently available, visit
-https://launchpad.net/~cantera-team/+archive/ubuntu/cantera
+(Focal Fossa), Ubuntu 20.10 (Groovy Gorilla), Ubuntu 21.04 (Hirsute Hippo), and
+Ubuntu 21.10 (Impish Indri). To see which Ubuntu releases and Cantera versions are
+currently available, visit https://launchpad.net/~cantera-team/+archive/ubuntu/cantera.
 
 The available packages are:
 


### PR DESCRIPTION
Packages for alpha/beta versions are now (as of 2.6.0b1) added to a separate PPA (`cantera-unstable`). This explains how users can install these packages and return to the stable packages later.

This is intended to be merged now, and does not include any changes that will not be applicable until the full 2.6.0 release.