### PR TITLE
Installation related updates for 2.6

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout the repository
       with:
+        submodules: recursive
         path: ${{ env.WEBSITE_CLONE_DIR }}
     - uses: actions/checkout@v2
       name: Checkout Cantera repository

--- a/pages/community.rst
+++ b/pages/community.rst
@@ -157,24 +157,24 @@ your work, as well as giving credit to the many `authors
 their time to developing Cantera. The recommended citation for Cantera is as
 follows:
 
-   David G. Goodwin, Raymond L. Speth, Harry K. Moffat, and Bryan W. Weber.
-   *Cantera: An object-oriented software toolkit for chemical kinetics,
+   David G. Goodwin, Harry K. Moffat, Ingmar Schoegl, Raymond L. Speth, and Bryan W.
+   Weber. *Cantera: An object-oriented software toolkit for chemical kinetics,
    thermodynamics, and transport processes*. https://www.cantera.org,
-   2021. Version 2.5.1. doi:10.5281/zenodo.4527812
+   2022. Version 2.6.0. doi:10.5281/zenodo.6387882
 
 The following BibTeX entry may also be used:
 
 .. code:: bibtex
 
    @misc{cantera,
-       author = "David G. Goodwin and Raymond L. Speth and Harry K. Moffat
-                 and Bryan W. Weber",
+       author = "David G. Goodwin and Harry K. Moffat and Ingmar Schoegl and Raymond L.
+                 Speth and Harry K. Moffat and Bryan W. Weber",
        title = "Cantera: An Object-oriented Software Toolkit for Chemical
                 Kinetics, Thermodynamics, and Transport Processes",
-       year = 2021,
-       note = "Version 2.5.1",
+       year = 2022,
+       note = "Version 2.6.0",
        howpublished = "\url{https://www.cantera.org}",
-       doi = {10.5281/zenodo.4527812}
+       doi = {10.5281/zenodo.6387882}
    }
 
 If you are using a different version of Cantera, update the ``year``, ``note``

--- a/pages/documentation/dev-docs.html
+++ b/pages/documentation/dev-docs.html
@@ -123,7 +123,7 @@
       </div>
       <div class="list-group list-group-flush">
         <a href="{{% ct_dev_docs sphinx/html/cti/classes.html %}}" class="list-group-item dev-docs">
-          CTI Input File Class Reference
+          CTI Input File Class Reference <i>(deprecated in Cantera 2.5)</i>
         </a>
       </div>
     </div>

--- a/pages/documentation/glossary.rst
+++ b/pages/documentation/glossary.rst
@@ -11,7 +11,7 @@ the names of variables and classes:
 
 * **CK**: Chemkin
 * **CT**: Cantera
-* **CTI**: Cantera Input
+* **CTI**: Cantera Input *(Deprecated in Cantera 2.5)*
 * **CTML**: Cantera Markup Language
 * **HKFT**: Helgeson-Kirkham-Flowers-Tanger
 * **HMW**: Harvie, Møller, and Weare

--- a/pages/documentation/index.html
+++ b/pages/documentation/index.html
@@ -124,9 +124,9 @@
         <a href="{{% ct_docs sphinx/html/yaml/index.html %}}" class="list-group-item docs">
           YAML Input File API Reference
         </a>
-        <a href="/tutorials/input-files.html" class="list-group-item docs">CTI Input File Tutorial</a>
+        <a href="/tutorials/input-files.html" class="list-group-item docs">CTI Input File Tutorial <i>(Deprecated in Cantera 2.5)</i></a>
         <a href="{{% ct_docs sphinx/html/cti/classes.html %}}" class="list-group-item docs">
-          CTI Input File Class Reference
+          CTI Input File Class Reference <i>(Deprecated in Cantera 2.5)</i>
         </a>
         <a href="/documentation/glossary.html" class="list-group-item docs">Glossary of Terms</a>
       </div>

--- a/pages/install/conda-install.rst
+++ b/pages/install/conda-install.rst
@@ -95,7 +95,7 @@ the file somewhere and remember that location.
    - cantera  # or use cantera/label/dev for alpha/beta packages
    - defaults
    dependencies:
-   - python  # Cantera supports Python 3.6 and up
+   - python  # Cantera supports Python 3.7 and up
    - cantera
    - ipython  # optional (needed for nicer interactive command line)
    - jupyter  # optional (needed for Jupyter Notebook)

--- a/pages/install/install.rst
+++ b/pages/install/install.rst
@@ -21,11 +21,12 @@
 Installing the Cantera Python Interface
 =======================================
 
-- The easiest way to install the Cantera Python interface on all operating systems is by
+- If you don't already have Python installed (or already use Conda), the easiest way to
+  install the Cantera Python interface on all operating systems is by
   using :ref:`Conda <sec-install-conda>`.
 
-- Windows users can use
-  :ref:`MSI installer packages <sec-install-windows>`.
+- If you already have a different Python installation, Cantera can be installed using
+  :ref:`Pip <sec-install-pip>`.
 
 - Ubuntu users can install the ``cantera-python3`` package from the
   :ref:`Cantera PPA <sec-install-ubuntu>`.

--- a/pages/install/macos-install.rst
+++ b/pages/install/macos-install.rst
@@ -13,43 +13,27 @@
 
    .. class:: lead
 
-      The Python interface for Cantera should be installed using Anaconda / Miniconda;
-      directions for that can be found :ref:`on the Conda install page <sec-install-conda>`.
-      If you would like to use the Matlab toolbox, these instructions are for you.
-      The Cantera Matlab toolbox requires macOS/Mac OS X version 10.11 (El Capitan) or higher and
-      a 64-bit Intel processor.
+      The Cantera Matlab toolbox can be installed using a macOS-specific installer. The
+      toolbox requires macOS/Mac OS X version 10.11 (El Capitan) or higher and a 64-bit
+      Intel or M1 processor.
 
-**Install Conda and the Python Interface**
+To install the Cantera Python package, see the :ref:`pip <sec-install-pip>` or
+:ref:`conda <sec-install-conda>` instructions. The Python package is required if:
 
-Cantera requires Python and the Python interface to be able to process input files (see
-:ref:`Why Two File Formats? <sec-two-file-formats>` for more information). The easiest way
-to obtain the Cantera Python interface is via Conda. First install Miniconda by running the
-following commands in Terminal:
-
-.. code-block:: bash
-
-   cd Downloads
-   curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o miniconda.sh;
-   bash miniconda.sh
-
-This installs the minimal Conda installation called Miniconda in a folder in your home directory.
-
-Next, install Cantera into an environment called ``cantera25``:
-
-.. code-block:: bash
-
-   $HOME/miniconda3/bin/conda create -n cantera25 -c cantera cantera
+- You need to work with legacy CTI or XML input files
+- You need to convert legacy input files to YAML
+- You need to convert Chemkin-format input files to YAML
 
 **Download and run the Matlab Interface Installer**
 
 Download the Matlab Interface Installer package from GitHub:
-https://github.com/Cantera/cantera/releases/tag/v2.5.1
+https://github.com/Cantera/cantera/releases/tag/v2.6.0
 
 When the file has downloaded, find it in Finder, hold Control and click the file. Choose
 "Open" from the resulting menu, and select "Open" in the security dialog that appears.
 Click "Continue" to proceed in the installer (noting that the installer may open in the background;
 you can find its icon on the Dock), agreeing to the
-`Cantera license terms <https://github.com/Cantera/cantera/blob/v2.5.1/License.txt>`__
+`Cantera license terms <https://github.com/Cantera/cantera/blob/v2.6.0/License.txt>`__
 and the terms of the other open source software that we use.
 
 By default, the installer will add some lines to the file ``$HOME/Documents/MATLAB/startup.m``

--- a/pages/install/pip-install.rst
+++ b/pages/install/pip-install.rst
@@ -1,0 +1,120 @@
+.. title: Installing Cantera with Pip
+.. slug: pip-install
+.. description: Installation instructions for Cantera using Pip
+.. type: text
+.. _sec-install-pip:
+
+.. jumbotron::
+
+   .. raw:: html
+
+      <h1 class="display-3">Installing with Pip</h1>
+
+   .. class:: lead
+
+      `Pip <https://pip.pypa.io/en/stable/>`__ is a package installer for Python that
+      can be used to install the Cantera Python module from
+      `PyPI <https://pypi.org/project/Cantera/>`__.
+
+Prerequisites
+=============
+
+The first step in installing the Cantera Python module using ``pip`` is to make sure you
+have a compatible version of Python installed and are able to run ``pip`` from the
+command line. Packages for Cantera 2.6.0 are available for Python versions 3.7, 3.8,
+3.9, and 3.10.
+
+If you don't already have Python installed, it can be downloaded from
+`python.org <https://www.python.org/>`__ or installed using your operating system's
+package manager.
+
+To check that you are able run `pip`, open a terminal / command prompt and run the
+following command:
+
+*Linux / macOS*:
+
+.. code:: shell
+
+   python3 -m pip --version
+
+*Windows*:
+
+.. code:: shell
+
+   py -m pip --version
+
+If the above command doesn't work, see the instructions at
+`packaging.python.org <https://packaging.python.org/en/latest/tutorials/installing-packages/>`__
+for how to get `pip` working with your Python installation.
+
+Virtual Environments
+====================
+
+Virtual environments provide a way keeping separate sets of Python packages installed
+for different projects, where different environments can have different versions of
+packages that might otherwise conflict. To create and activate a virtual environment
+named ``ct-env`` to be used with Cantera, run the commands:
+
+*Linux / macOS*:
+
+.. code:: shell
+
+   python3 -m venv ct-env
+   source ct-env/bin/activate
+
+
+*Windows*:
+
+.. code:: bat
+
+   py -m venv ct-env
+   ct-env\Scripts\activate
+
+The second command should be run in the terminal each time you want to use the specified
+environment.
+
+Installing Cantera
+==================
+
+To install the Cantera Python module, first activate your virtual environment, if you're
+using one. Then, run the command:
+
+*Linux / macOS*:
+
+.. code:: shell
+
+   python3 -m pip install cantera
+
+*Windows*:
+
+.. code:: bat
+
+   py -m pip install cantera
+
+You can test that your installation is working by running one of the examples included
+with Cantera:
+
+*Linux / macOS*:
+
+.. code:: shell
+
+   python3 -m cantera.examples.thermo.critical_properties
+
+*Windows*:
+
+.. code:: bat
+
+   py -m cantera.examples.thermo.critical_properties
+
+You should get the following output::
+
+   Critical State Properties
+                  Fluid      Tc [K]     Pc [Pa]          Zc
+                  water        647.3    2.209E+07      0.2333
+               nitrogen        126.2      3.4E+06      0.2891
+                methane        190.6    4.599E+06      0.2904
+               hydrogen        32.94    1.284E+06      0.3013
+                 oxygen        154.6    5.043E+06      0.2879
+         carbon dioxide        304.2    7.384E+06      0.2769
+                heptane        537.7     2.62E+06      0.2972
+                hfc134a        374.2    4.059E+06        0.26

--- a/pages/install/ubuntu-install.rst
+++ b/pages/install/ubuntu-install.rst
@@ -13,14 +13,13 @@
 
    .. class:: lead
 
-      Ubuntu packages are provided for recent versions of Ubuntu using a Personal Package Archive
-      (PPA). Note that the Matlab packages are not available from this archive; to install the
-      Matlab packages on Ubuntu, you must :ref:`compile the source code <sec-compiling>`.
+      Ubuntu packages are provided for recent versions of Ubuntu using a Personal
+      Package Archive (PPA).
 
-As of Cantera 2.5.1, packages are available for Ubuntu 18.04 (Bionic Beaver), Ubuntu 20.04
-(Focal Fossa), Ubuntu 20.10 (Groovy Gorilla), Ubuntu 21.04 (Hirsute Hippo), and
-Ubuntu 21.10 (Impish Indri). To see which Ubuntu releases and Cantera versions are
-currently available, visit https://launchpad.net/~cantera-team/+archive/ubuntu/cantera.
+As of Cantera 2.6.0, packages are available for Ubuntu 20.04 (Focal Fossa), Ubuntu 21.10
+(Impish Indri), and Ubuntu 22.04 (Jammy Jellyfish). To see which Ubuntu releases and
+Cantera versions are currently supported, visit
+https://launchpad.net/~cantera-team/+archive/ubuntu/cantera.
 
 The available packages are:
 
@@ -30,6 +29,14 @@ The available packages are:
   Fortran 90 programs that use Cantera.
 
 - ``cantera-common`` - Cantera data files and example programs
+
+Note that the Matlab packages are not available from this archive; to install the
+Matlab packages on Ubuntu, you must install it using
+:ref:`conda <sec-conda-matlab-interface>`
+or :ref:`compile the source code <sec-compiling>`.
+
+Installing
+----------
 
 To add the Cantera PPA:
 

--- a/pages/install/windows-install.rst
+++ b/pages/install/windows-install.rst
@@ -13,111 +13,38 @@
 
    .. class:: lead
 
-      Windows installers are provided for stable versions of Cantera. These
-      installation instructions are for Cantera 2.5.1. Use these installers if you
-      want to work with a copy of Python downloaded from `Python.org
-      <https://www.python.org/>`__. If you are using Anaconda / Miniconda, see the
-      directions :ref:`for conda <sec-install-conda>`.
+      Windows installers are provided for stable versions of Cantera. These installers
+      provide the Matlab toolbox and header/library files that can be used to compile
+      C++ applications.
 
-**Choose your Python version and architecture**
+To install the Cantera Python package, see the :ref:`pip <sec-install-pip>` or
+:ref:`conda <sec-install-conda>` instructions. The Python package is required if:
 
-- On Windows, Installers are provided for Python 3.5, Python 3.6, Python 3.7,
-  Python 3.8 and Python 3.9. You can install multiple Cantera Python modules
-  simultaneously.
-
-- Cantera supports both 32- and 64-bit Python installations.
-
-- You need choose the matching Cantera installer for your Python version and
-  machine architecture.
-
-- The rest of these instructions will refer to your chosen version of Python
-  as *3.X*.
-
-- If you are using Matlab, you must use the same architecture for Cantera and
-  Matlab. Matlab defaults to 64-bit if you are running a 64-bit operating
-  system.
-
-**Install Python**
-
-- Go to `python.org <https://www.python.org/>`__.
-
-  - *64-bit*: Download the most recent "Windows X86-64 MSI Installer" for
-    Python *3.X*.
-  - *32-bit*: Download the most recent "Windows x86 MSI Installer" for
-    Python *3.X*.
-
-- Run the installer. The default installation options should be fine.
-
-- Python is required in order to work with ``.cti`` input files even if you are
-  not using the Python interface to Cantera.
-
-- Cantera can also be used with alternative Python distributions such as the
-  `Enthought distribution <https://www.enthought.com/enthought-deployment-manager/>`__.
-  These distributions will generally be based on the 64-bit
-  version of Python, and will include Numpy as well as many other
-  packages useful for scientific users.
-
-**Install required and optional Python packages**
-
-- If you plan on using Cantera from Python, note that we highly recommend
-  installing the `conda package </install/conda-install.html>`__ instead of
-  using the standalone installer. Installation with this procedure is sufficient
-  if you will mainly be using a different interface, such as Matlab.
-
-- Open a Command Prompt. If you chose to install Python for all users, you
-  should open the Command Prompt as Administrator.
-
-- Install Cantera's required dependencies by running:
-
-  .. code:: bash
-
-     py -m pip install numpy ruamel.yaml
-
-- Some Cantera features and examples require additional Python packages.
-  These can be installed by running:
-
-  .. code:: bash
-
-     py -m pip install h5py pandas matplotlib
-
-- You may also want to install IPython, an advanced interactive Python interpreter:
-
-  .. code:: bash
-
-     py -m pip install ipython
-
+- You need to work with legacy CTI or XML input files
+- You need to convert legacy input files to YAML
+- You need to convert Chemkin-format input files to YAML
 
 **Remove old versions of Cantera**
 
-- Use The Windows "Add/Remove Programs" interface
-
-- Remove both the main Cantera package and the Python module.
-
-- The Python module will be listed as "Python *3.X* Cantera ..."
+- Use The Windows "Add/Remove Programs" interface to remove previous versions of
+  the `Cantera` package.
 
 **Install Cantera**
 
 - Go to the `Cantera Releases <https://github.com/Cantera/cantera/releases>`_
-  page.
+  page and download **Cantera-2.6.0-x64.msi**.
 
-  - *64-bit*: Download **Cantera-2.5.1-x64.msi** and
-    **Cantera-Python-2.5.1-x64-py3.X.msi**.
-  - *32-bit*: Download **Cantera-2.5.1-x86.msi** and
-    **Cantera-Python-2.5.1-x86-py3.Y.msi**.
+- Run the installer and follow the prompts.
 
-- If you are only using the Python module, you do not need to download and
-  install the base package (the one without Python in the name).
+**Configure Matlab**
 
-- Run the installer(s).
+- If you have also installed the Python module, set the environment variable
+  ``PYTHON_CMD`` accordingly.
 
-**Configure Matlab** (optional)
-
-- Set the environment variable ``PYTHON_CMD``
-
-  - From the *Start* screen or menu type "edit environment" and select
+  - From the *Start* menu, type "edit environment" and select
     "Edit environment variables for your account".
   - Add a *New* variable with ``PYTHON_CMD`` as the *name* and the full path
-    to the Python executable (for example, ``C:\python37\python.exe``) as the
+    to the Python executable (for example, ``C:\python310\python.exe``) as the
     *value*.
   - Setting ``PYTHON_CMD`` is not necessary if the path to ``python.exe`` is
     in your ``PATH`` (which can be set from the same configuration dialog).
@@ -134,17 +61,9 @@
 
 **Test the installation**
 
-- Python:
-
-  .. code-block:: python
-
-     import cantera
-     gas = cantera.Solution('gri30.yaml')
-     h2o = cantera.PureFluid('liquidvapor.yaml', 'water')
-
-- Matlab:
+- From the Matlab prompt, run:
 
   .. code-block:: matlab
 
      gas = IdealGasMix('gri30.yaml')
-     h2o = Solution('liquidvapor.yaml','water')
+     h2o = Solution('liquidvapor.yaml', 'water')

--- a/pages/science/kinetics.rst
+++ b/pages/science/kinetics.rst
@@ -38,7 +38,7 @@ as:
 
    R_f = [\mathrm{A}] [\mathrm{B}] k_f
 
-An elementary reaction can be defined in the CTI format using the
+An elementary reaction can be defined in the legacy CTI format using the
 :cti:class:`reaction` entry, or in the YAML format using the
 :ref:`elementary <sec-yaml-elementary>` reaction ``type``.
 
@@ -79,7 +79,7 @@ where :math:`C_k` is the concentration of species :math:`k`. Since any constant
 collision efficiency can be absorbed into the rate coefficient :math:`k_f(T)`, the default collision
 efficiency is 1.0.
 
-A three-body reaction may be defined in the CTI format using the
+A three-body reaction may be defined in the legacy CTI format using the
 :cti:class:`three_body_reaction` entry, or in the YAML format using the
 :ref:`three-body <sec-yaml-three-body>` reaction ``type``.
 
@@ -125,7 +125,7 @@ This expression is used to compute the rate coefficient for falloff
 reactions. The function :math:`F(T, P_r)` is the falloff function, and is
 specified by assigning an embedded entry to the ``falloff`` field.
 
-A falloff reaction may be defined in the CTI format using the
+A falloff reaction may be defined in the legacy CTI format using the
 :cti:class:`falloff_reaction` entry, or in the YAML format using the
 :ref:`falloff <sec-yaml-falloff>` reaction ``type``.
 
@@ -147,7 +147,7 @@ al. [#Gilbert1983]_:
 
    N = 0.75 - 1.27\; \log_{10} F_{cent}
 
-A Troe falloff function may be specified in the CTI format using the
+A Troe falloff function may be specified in the legacy CTI format using the
 :cti:class:`Troe` directive, or in the YAML format using the
 :ref:`Troe <sec-yaml-falloff>` field in the reaction entry. The first
 three parameters, :math:`(A, T_3, T_1)`, are required. The fourth parameter,
@@ -198,7 +198,7 @@ given by:
 In keeping with the nomenclature of Kee et al. [#Kee1989]_, we will refer to this as
 the **SRI falloff function**.
 
-An SRI falloff function may be specified in the CTI format using the
+An SRI falloff function may be specified in the legacy CTI format using the
 :cti:class:`SRI` directive, or in the YAML format using the
 :ref:`SRI <sec-yaml-falloff>` field in the entry.
 
@@ -230,7 +230,7 @@ to the *low-pressure* rate constant:
 and the optional blending function :math:`F` may described by any of the
 parameterizations allowed for falloff reactions.
 
-Chemically-activated reactions can be defined in the CTI format using the
+Chemically-activated reactions can be defined in the legacy CTI format using the
 :cti:class:`chemically_activated_reaction` entry, or in the YAML format using
 the :ref:`chemically-activated <sec-yaml-chemically-activated>` reaction ``type``.
 
@@ -267,7 +267,7 @@ temperatures that the sum of the reaction rates at each pressure is positive. Un
 these checks fail, the only options are to remove the reaction or contact the author
 of the reaction/mechanism in question, because the reaction is mathematically unsound.
 
-P-log reactions can be defined in the CTI format using the
+P-log reactions can be defined in the legacy CTI format using the
 :cti:class:`pdep_arrhenius` entry, or in the YAML format using the
 :ref:`pressure-dependent-Arrhenius <sec-yaml-pressure-dependent-Arrhenius>`
 reaction ``type``.
@@ -307,7 +307,7 @@ Note that the Chebyshev polynomials are not defined outside the interval
 :math:`(-1,1)`, and therefore extrapolation of rates outside the range of
 temperatures and pressure for which they are defined is strongly discouraged.
 
-Chebyshev reactions can be defined in the CTI format using the
+Chebyshev reactions can be defined in the legacy CTI format using the
 :cti:class:`chebyshev_reaction` entry, or in the YAML format using the
 :ref:`Chebyshev <sec-yaml-Chebyshev>` reaction ``type``.
 
@@ -379,7 +379,7 @@ where :math:`A`, :math:`b`, and :math:`E_a` are the modified Arrhenius
 parameters and :math:`a_k`, :math:`m_k`, and :math:`E_k` are the coverage
 dependencies from species :math:`k`.
 
-Surface reactions can be defined in the CTI format using the
+Surface reactions can be defined in the legacy CTI format using the
 :cti:class:`surface_reaction` entry, with coverage information provided using
 the ``coverage`` keyword argument supplied to the :cti:class:`Arrhenius`
 directive. In the YAML format, surface reactions are identified by the presence
@@ -412,9 +412,7 @@ where :math:`\Gamma_\mathrm{tot}` is the total molar site density, :math:`m` is
 the sum of all the surface reactant stoichiometric coefficients, and :math:`W`
 is the molecular weight of the gas phase species.
 
-.. TODO: Link to :cti:class:`stick` after 2.5.0 release adds that to the docs
-
-Sticking reactions can be defined in the CTI format using the `stick` entry, or
+Sticking reactions can be defined in the legacy CTI format using the `stick` entry, or
 in the YAML format by specifying the rate constant in the reaction's
 :ref:`sticking-coefficient <sec-yaml-interface-reaction>` field.
 

--- a/pages/science/phase-thermo.rst
+++ b/pages/science/phase-thermo.rst
@@ -25,7 +25,7 @@ It supports all of the options in the widely-used model described by Kee et al.
 [#Kee1989]_, plus some additional options for species thermodynamic properties
 and reaction rate expressions.
 
-Ideal gas mixtures can be defined in the CTI format using the
+Ideal gas mixtures can be defined in the legacy CTI format using the
 :cti:class:`ideal_gas` entry, or in the YAML format by specifying
 :ref:`ideal-gas <sec-yaml-ideal-gas>` in the ``thermo`` field.
 
@@ -37,7 +37,7 @@ given by the composition of the one species present. A stoichiometric solid can 
 condensed phase that can participate in heterogeneous reactions. (Of course, there cannot be
 homogeneous reactions, since the composition is fixed.)
 
-A stoichiometric solid can be defined in the CTI format using the
+A stoichiometric solid can be defined in the legacy CTI format using the
 :cti:class:`stoichiometric_solid` entry, or in the YAML format by specifying
 :ref:`fixed-stoichiometry <sec-yaml-fixed-stoichiometry>` in the ``thermo`` field.
 
@@ -62,7 +62,7 @@ to the surface concentration :math:`C_k` by
 
 where :math:`n_k` is the number of sites covered or blocked by species :math:`k`.
 
-An interface can be defined in the CTI format using the
+An interface can be defined in the legacy CTI format using the
 :cti:class:`ideal_interface` entry, or in the YAML format by specifying
 :ref:`ideal-surface <sec-yaml-ideal-surface>` in the ``thermo``
 field.

--- a/pages/science/species-thermo.rst
+++ b/pages/science/species-thermo.rst
@@ -21,7 +21,7 @@ that definitions of elements are not often needed, since Cantera has definitions
 for the standard chemical elements. Explicit element definitions are usually
 only needed for isotopes.
 
-An element can be defined in the CTI format using the :cti:class:`element`
+An element can be defined in the legacy CTI format using the :cti:class:`element`
 entry, or in the YAML format by adding entries to the :ref:`elements
 <sec-yaml-elements>` section of the input file.
 
@@ -30,7 +30,7 @@ Species
 
 For each species, a species definition is required.
 
-A species can be defined in the CTI format using the :cti:class:`species` entry,
+A species can be defined in the legacy CTI format using the :cti:class:`species` entry,
 or in the YAML format by adding an entry to the :ref:`species
 <sec-yaml-species>` section of the input file.
 
@@ -130,7 +130,7 @@ temperature regions. It is not compatible with the form used in the most recent
 version of the NASA equilibrium program, which uses 9 coefficients for each
 temperature region.
 
-A NASA-7 parameterization can be defined in the CTI format using the
+A NASA-7 parameterization can be defined in the legacy CTI format using the
 :cti:class:`NASA` entry, or in the YAML format by specifying
 :ref:`NASA7 <sec-yaml-nasa7>` as the ``model`` in the species ``thermo`` field.
 
@@ -162,7 +162,7 @@ the following equations:
 A common source for species data in the NASA9 format is the
 :ref:`NASA ThermoBuild <sec-thermobuild>` tool.
 
-A NASA-9 parameterization can be defined in the CTI format using the
+A NASA-9 parameterization can be defined in the legacy CTI format using the
 :cti:class:`NASA9` entry, or in the YAML format by specifying
 :ref:`NASA9 <sec-yaml-nasa9>` as the ``model`` in the species ``thermo`` field.
 
@@ -187,7 +187,7 @@ properties in the `NIST Chemistry WebBook <http://webbook.nist.gov/chemistry>`__
 coefficients :math:`A` through :math:`G` should be entered precisely as shown there, with no units
 attached. Unit conversions to SI will be handled internally.
 
-A Shomate parameterization can be defined in the CTI format using the
+A Shomate parameterization can be defined in the legacy CTI format using the
 :cti:class:`Shomate` entry, or in the YAML format by specifying
 :ref:`Shomate <sec-yaml-shomate>` as the ``model`` in the species
 ``thermo`` field.
@@ -212,7 +212,7 @@ The parameterization uses four constants: :math:`T^\circ, \hat{c}_p^\circ(T^\cir
 \hat{h}^\circ(T^\circ), and \hat{s}^\circ(T)`. The default value of :math:`T^\circ` is 298.15 K; the
 default value for the other parameters is 0.0.
 
-A constant heat capacity parameterization can be defined in the CTI format using
+A constant heat capacity parameterization can be defined in the legacy CTI format using
 the :cti:class:`const_cp` entry, or in the YAML format by specifying
 :ref:`constant-cp <sec-yaml-constcp>` as the ``model`` in the species ``thermo`` field.
 

--- a/pages/tutorials/MatlabTutorial.rst
+++ b/pages/tutorials/MatlabTutorial.rst
@@ -290,7 +290,7 @@ directory where they are located. Alternatively, you can call function
 Cantera currently supports three input formats for data. The primary format,
 introduced in Cantera 2.5.0, is the YAML format. Two older formats (CTI and XML)
 can also be used, but they are deprecated and support for them will be removed
-in a future release. Utilities are provided for converting existing CTI and XML
+in a Cantera 3.0. Utilities are provided for converting existing CTI and XML
 files to YAML. For more info, see
 `Converting CTI and XML input files to YAML <legacy2yaml.html>`__.
 

--- a/pages/tutorials/cti/cti-processing.rst
+++ b/pages/tutorials/cti/cti-processing.rst
@@ -13,8 +13,9 @@
       A description of how Cantera processes legacy CTI input files, to help with
       debugging any errors that occur.
 
-      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
+      Note that the legacy CTI input file format was deprecated in Cantera 2.5 in
+      favor of the :doc:`YAML <defining-phases>` input format, and will be removed
+      in Cantera 3.0.
 
 Cantera Input Files
 ===================

--- a/pages/tutorials/cti/cti-syntax.rst
+++ b/pages/tutorials/cti/cti-syntax.rst
@@ -11,8 +11,9 @@
 
       CTI is the legacy human-readable input format for Cantera, and we describe it's syntax here
 
-      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
+      Note that the legacy CTI input file format was deprecated in Cantera 2.5 in
+      favor of the :doc:`YAML <defining-phases>` input format, and will be removed
+      in Cantera 3.0.
 
 Input File Syntax
 =================

--- a/pages/tutorials/cti/defining-phases-cti.rst
+++ b/pages/tutorials/cti/defining-phases-cti.rst
@@ -11,8 +11,9 @@
 
       A guide to Cantera's legacy CTI input file format
 
-      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
+      Note that the legacy CTI input file format was deprecated in Cantera 2.5 in
+      favor of the :doc:`YAML <defining-phases>` input format, and will be removed
+      in Cantera 3.0.
 
 Virtually every Cantera simulation involves one or more phases of
 matter. Depending on the calculation being performed, it may be necessary to

--- a/pages/tutorials/cti/phases.rst
+++ b/pages/tutorials/cti/phases.rst
@@ -12,8 +12,9 @@
       Cantera simulations model interactions between and within different phases of matter, as
       described here.
 
-      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
+      Note that the legacy CTI input file format was deprecated in Cantera 2.5 in
+      favor of the :doc:`YAML <defining-phases>` input format, and will be removed
+      in Cantera 3.0.
 
 Phases
 ======

--- a/pages/tutorials/cti/reactions.rst
+++ b/pages/tutorials/cti/reactions.rst
@@ -12,8 +12,9 @@
 
       A description of how reactions are defined in legacy CTI input files
 
-      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
+      Note that the legacy CTI input file format was deprecated in Cantera 2.5 in
+      favor of the :doc:`YAML <defining-phases>` input format, and will be removed
+      in Cantera 3.0.
 
 Basic Reactions
 ===============

--- a/pages/tutorials/cti/species.rst
+++ b/pages/tutorials/cti/species.rst
@@ -12,8 +12,9 @@
 
       A description of how elements and species are defined in legacy CTI input files
 
-      Note that the legacy CTI input file format will be deprecated in Cantera 2.6
-      and fully replaced by :doc:`YAML <defining-phases>` input in Cantera 3.0.
+      Note that the legacy CTI input file format was deprecated in Cantera 2.5 in
+      favor of the :doc:`YAML <defining-phases>` input format, and will be removed
+      in Cantera 3.0.
 
 Elements
 ========

--- a/pages/tutorials/cxx-guide/factories.rst
+++ b/pages/tutorials/cxx-guide/factories.rst
@@ -4,7 +4,7 @@
 
    .. raw:: html
 
-      <h1 class="display-3">Creating ``ThermoPhase``, ``Kinetics``, and ``Transport`` objects</h1>
+      <h1 class="display-3">Creating ThermoPhase, Kinetics, and Transport objects</h1>
 
    .. class:: lead
 

--- a/pages/tutorials/cxx-guide/index.rst
+++ b/pages/tutorials/cxx-guide/index.rst
@@ -10,115 +10,125 @@
 
       This guide shows the basics of using the C++ interface
 
-.. container:: card-deck
+.. container:: container
 
-   .. container:: card
+   .. row::
 
-      .. container::
-         :tagname: a
-         :attributes: href=compiling.html
-                      title="Compiling Cantera C++ Applications"
+      .. container:: col-12
 
-         .. container:: card-header section-card
+         .. container:: card-deck
 
-            Compiling Cantera C++ Applications
+            .. container:: card
 
-      .. container:: card-body
+               .. container::
+                  :tagname: a
+                  :attributes: href=compiling.html
+                              title="Compiling Cantera C++ Applications"
 
-         .. class:: card-text
+                  .. container:: card-header section-card
 
-            Instructions to compile Cantera C++ applications using a variety of build systems,
-            including make, CMake, SCons, etc. Note: This section is about compiling Cantera
-            applications that use the Cantera library; instructions to compile the Cantera library
-            are over :doc:`there <installation-reqs>`.
+                     Compiling Cantera C++ Applications
 
-   .. container:: card
+               .. container:: card-body
 
-      .. container::
-         :tagname: a
-         :attributes: href=headers.html
-                      title="Cantera C++ Header Files"
+                  .. class:: card-text
 
-         .. container:: card-header section-card
+                     Instructions to compile Cantera C++ applications using a variety of build systems,
+                     including make, CMake, SCons, etc. Note: This section is about compiling Cantera
+                     applications that use the Cantera library; instructions to compile the Cantera library
+                     are over :doc:`there <installation-reqs>`.
 
-            Cantera C++ Header Files
+            .. container:: card
 
-      .. container:: card-body
+               .. container::
+                  :tagname: a
+                  :attributes: href=headers.html
+                              title="Cantera C++ Header Files"
 
-         .. class:: card-text
+                  .. container:: card-header section-card
 
-            Information about the header files used to include Cantera functionality in your C++
-            application.
+                     Cantera C++ Header Files
 
-   .. container:: card
+               .. container:: card-body
 
-      .. container::
-         :tagname: a
-         :attributes: href=simple-example.html
-                      title="A Very Simple C++ Program"
+                  .. class:: card-text
 
-         .. container:: card-header section-card
+                     Information about the header files used to include Cantera functionality in your C++
+                     application.
 
-            A Very Simple C++ Program
+            .. container:: card
 
-      .. container:: card-body
+               .. container::
+                  :tagname: a
+                  :attributes: href=simple-example.html
+                              title="A Very Simple C++ Program"
 
-         .. class:: card-text
+                  .. container:: card-header section-card
 
-            A simple example of a C++ program including error handling
+                     A Very Simple C++ Program
 
-.. container:: card-deck
+               .. container:: card-body
 
-   .. container:: card
+                  .. class:: card-text
 
-      .. container::
-         :tagname: a
-         :attributes: href=thermo.html
-                      title="Computing Thermodynamic Properties"
+                     A simple example of a C++ program including error handling
 
-         .. container:: card-header section-card
+   .. row::
 
-            Computing Thermodynamic Properties
+      .. container:: col-12
 
-      .. container:: card-body
+         .. container:: card-deck
 
-         .. class:: card-text
+            .. container:: card
 
-            An example demonstrating the calculation of various thermodynamic properties associated
-            with a particular phase of a substance.
+               .. container::
+                  :tagname: a
+                  :attributes: href=thermo.html
+                              title="Computing Thermodynamic Properties"
 
-   .. container:: card
+                  .. container:: card-header section-card
 
-      .. container::
-         :tagname: a
-         :attributes: href=equil-example.html
-                      title="Chemical Equilibrium Example Program"
+                     Computing Thermodynamic Properties
 
-         .. container:: card-header section-card
+               .. container:: card-body
 
-            Chemical Equilibrium Example Program
+                  .. class:: card-text
 
-      .. container:: card-body
+                     An example demonstrating the calculation of various thermodynamic properties associated
+                     with a particular phase of a substance.
 
-         .. class:: card-text
+            .. container:: card
 
-            An example using the built-in equilibration algorithms to compute the chemical
-            equilibrium of a mixture.
+               .. container::
+                  :tagname: a
+                  :attributes: href=equil-example.html
+                              title="Chemical Equilibrium Example Program"
 
-   .. container:: card
+                  .. container:: card-header section-card
 
-      .. container::
-         :tagname: a
-         :attributes: href=factories.html
-                      title="Creating ThermoPhase, Kinetics, and Transport objects"
+                     Chemical Equilibrium Example Program
 
-         .. container:: card-header section-card
+               .. container:: card-body
 
-            Creating ``ThermoPhase``, ``Kinetics``, and ``Transport`` objects
+                  .. class:: card-text
 
-      .. container:: card-body
+                     An example using the built-in equilibration algorithms to compute the chemical
+                     equilibrium of a mixture.
 
-         .. class:: card-text
+            .. container:: card
 
-            How to create objects that allow calculation of thermodynamic properties and kinetic and
-            transport rates.
+               .. container::
+                  :tagname: a
+                  :attributes: href=factories.html
+                              title="Creating ThermoPhase, Kinetics, and Transport objects"
+
+                  .. container:: card-header section-card
+
+                     Creating ThermoPhase, Kinetics, and Transport objects
+
+               .. container:: card-body
+
+                  .. class:: card-text
+
+                     How to create objects that allow calculation of thermodynamic properties and kinetic and
+                     transport rates.


### PR DESCRIPTION
Main updates:
- Add instructions for installing with pip
- Revise Windows instructions to account for removal of Python MSIs
- Update macOS Matlab install instructions
- Do CI builds for PRs that target the `testing` branch
- Fixes #193
- Clarify deprecation of CTI/XML
- Update recommended citation
- Fix some formatting issues with the guide for the C++ interface
