### PR TITLE
Fix indent in nested list

### DIFF
--- a/pages/compiling/installation-reqs.rst
+++ b/pages/compiling/installation-reqs.rst
@@ -53,6 +53,11 @@ General Notes
 * You will need to install compilers for your system by following the instructions in the sections
   below to install the compiler for your operating system.
 
+* By default, Cantera is installed into the active conda environment, where the
+  layout of the directory structure corresponds to the
+  [configuration option](https://cantera.org/compiling/configure-build.html)
+  ``layout=conda``.
+
 .. _sec-conda-reqs:
 
 Conda Requirements
@@ -154,18 +159,10 @@ Conda Requirements
   containing ``sphinx``, ``doxygen``, ``graphviz``, ``pip`` as well as all relevant
   items listed for the ``pip:`` entry in ``environment.yaml``.
 
-* Now you can build and test Cantera with
-
-  .. code:: bash
-
-     scons build
-     scons test
-
-* To install Cantera, use the command
-
-  .. code:: bash
-
-     scons install
+* (Cantera < 2.6 only) On previous Cantera versions, the build process requires
+  configuration options ``boost_inc_dir`` and ``prefix`` (see
+  [configuration options](https://cantera.org/compiling/configure-build.html));
+  starting with Cantera 2.6, these settings are detected automatically.
 
 .. note::
 

--- a/pages/compiling/installation-reqs.rst
+++ b/pages/compiling/installation-reqs.rst
@@ -63,36 +63,36 @@ Conda Requirements
 
 * Launch the command line interface:
 
-   * On macOS and Linux, the installer should add the appropriate activation mechanism
-     for your normal terminal by default. You can test this by running
+  * On macOS and Linux, the installer should add the appropriate activation mechanism
+    for your normal terminal by default. You can test this by running
 
-     .. code:: bash
+    .. code:: bash
 
-      conda --version
+     conda --version
 
-     in the terminal. If there is no output or an error appears, locate your Conda
-     installation and run the following code in the terminal:
+    in the terminal. If there is no output or an error appears, locate your Conda
+    installation and run the following code in the terminal:
 
-     .. code:: bash
+    .. code:: bash
 
-       /path/to/conda/install/folder/bin/conda init -all
+      /path/to/conda/install/folder/bin/conda init -all
 
-     Then restart your terminal or shell.
+    Then restart your terminal or shell.
 
-   * On Windows, use the Anaconda PowerShell to run the build process (available from
-     the Start Menu). When using MSVC compilers, you also need to set environment
-     variables for x64-native tools (see `Developer command file locations
-     <https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170#developer_command_file_locations>`__)
-     by running
+  * On Windows, use the Anaconda PowerShell to run the build process (available from
+    the Start Menu). When using MSVC compilers, you also need to set environment
+    variables for x64-native tools (see `Developer command file locations
+    <https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170#developer_command_file_locations>`__)
+    by running
 
-     .. code:: bash
+    .. code:: bash
 
-       . "C:\path\to\MSVC\Auxiliary\Build\vcvars64.bat"
+      . "C:\path\to\MSVC\Auxiliary\Build\vcvars64.bat"
 
-     (note that the period ``'.'`` is part of the command). The path can be found as
-     follows: locate the **x64 Native Tools Command Prompt** in the Start Menu,
-     right-click, select **More > Open File Location**, right-click on the shortcut,
-     select **Properties** and copy the **Target** command.
+    (note that the period ``'.'`` is part of the command). The path can be found as
+    follows: locate the **x64 Native Tools Command Prompt** in the Start Menu,
+    right-click, select **More > Open File Location**, right-click on the shortcut,
+    select **Properties** and copy the **Target** command.
 
 * Create an environment ``ct-build`` with the dependencies to build Cantera. Create a
   file called ``environment.yaml`` with the following content


### PR DESCRIPTION
Nested lists on reST require two character indents (not three) which created some mangled output in #184 ... added #186 so formatting can be checked also for PR's that target the `testing` branch.