### PR TITLE
Fix doxygen links and add context to installation paths

### DIFF
--- a/pages/tutorials/cxx-guide/compiling.rst
+++ b/pages/tutorials/cxx-guide/compiling.rst
@@ -29,6 +29,8 @@ can be set from the command line as:
    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/lib
    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/path/to/lib/pkgconfig
 
+where ``/path/to/lib`` should be replaced by Cantera's library installation path.
+
 pkg-config
 ==========
 

--- a/pages/tutorials/cxx-guide/thermo.rst
+++ b/pages/tutorials/cxx-guide/thermo.rst
@@ -24,9 +24,9 @@ prints its temperature is shown below:
    :code: c++
 
 Here, ``newSolution`` imports all information held by a YAML input file into a Cantera
-``Solution`` object, which is accessed by the pointer ``sol``. The thermodynamic
+`Solution`_ object, which is accessed by the pointer ``sol``. The thermodynamic
 information is accessible via ``sol->thermo()``, which itself returns a pointer to
-a `ThermoPhase` object.
+a `ThermoPhase`_ object.
 
 Class `ThermoPhase`_ is the base class for Cantera classes that represent
 phases of matter. It defines the public interface for all classes that represent
@@ -127,6 +127,7 @@ of matter derive.
 
 See `ThermoPhase`_ for the full list of available thermodynamic properties.
 
+.. _Solution: {{% ct_docs doxygen/html/d5/d40/classCantera_1_1Solution.html %}}
 .. _ThermoPhase: {{% ct_docs doxygen/html/dc/d38/classCantera_1_1ThermoPhase.html %}}
 .. _IdealGasPhase: {{% ct_docs doxygen/html/d7/dfa/classCantera_1_1IdealGasPhase.html %}}
 


### PR DESCRIPTION
These edits take care of minor issues left from #192:

* fixes doxygen links (had overlooked that those require a trailing underscore + definition)
* improve documentation on export paths