### PR TITLE
Fix broken build / upgrade Nikola version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Nikola[extras]==8.2.0
+Nikola[extras]==8.2.1
 yapsy==1.11.*
 attrs>=17.4.0
 pymdown-extensions==5.0


### PR DESCRIPTION
Nikola 8.2.0 and doit 0.36.0 are not compatible due to removal of `doit.auto_cmd`.

Fixes #200