### PR TITLE
Fixing some installation instructions.

### DIFF
--- a/pages/compiling/configure-build-dev.rst
+++ b/pages/compiling/configure-build-dev.rst
@@ -89,14 +89,6 @@ the Python module is built:
 
 * :ref:`python_prefix <python-prefix-dev>`
 
-For backwards compatibility, the following options are also allowed, but are
-overridden by the above options. These options will be removed in a future
-version of Cantera:
-
-* :ref:`python3_cmd <python3-cmd-dev>`
-* :ref:`python3_package <python3-package-dev>`
-* :ref:`python3_prefix <python3-prefix-dev>`
-
 Windows Only Options
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/pages/compiling/installation-reqs.rst
+++ b/pages/compiling/installation-reqs.rst
@@ -55,7 +55,7 @@ General Notes
 
 * By default, Cantera is installed into the active conda environment, where the
   layout of the directory structure corresponds to the
-  [configuration option](https://cantera.org/compiling/configure-build.html)
+  `configuration option <https://cantera.org/compiling/configure-build.html>`__
   ``layout=conda``.
 
 .. _sec-conda-reqs:


### PR DESCRIPTION
A link was in markdown or something other than restructuredtext, 
and some other deprecated options hadn't been removed.