### PR TITLE
Update Python example location

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -298,7 +298,8 @@ FILES_FOLDERS = {"files/survey2013": "survey2013", "files/license": ""}
 # the site. The format is a dictionary of {source: relative destination}.
 # Default is:
 EXAMPLES_FOLDERS = {
-    "../cantera/interfaces/cython/cantera/examples": "examples/python",
+    # "../cantera/samples/python": "examples/python", # starting with Cantera 3.0
+    "../cantera/interfaces/cython/cantera/examples": "examples/python", # Cantera 2.6
     "../cantera-jupyter": "examples/jupyter",
     "../cantera/samples/matlab": "examples/matlab",
     "../cantera/samples/cxx": "examples/cxx",

--- a/plugins/render_matlab_examples.py
+++ b/plugins/render_matlab_examples.py
@@ -6,7 +6,7 @@ in the top-level conf.py file in the ``EXAMPLES_FOLDERS`` dictionary. That
 dictionary has keys with the source folder and values with the destination
 folder (relative to the ``OUTPUT_FOLDER``). The relevant source folder is found
 as the key associated with the value that contains the string ``matlab``,
-typically ``"../cantera/interfaces/cython/cantera/examples": "examples/python"``.
+typically ``"../cantera/samples/matlab": "examples/matlab"``.
 """
 from pathlib import Path
 

--- a/plugins/render_python_examples.py
+++ b/plugins/render_python_examples.py
@@ -1,12 +1,12 @@
-"""Render the Matlab examples from the Cantera repository into Nikola listings.
+"""Render the Python examples from the Cantera repository into Nikola listings.
 
-This plugin renders Matlab examples from the main Cantera repository into the
+This plugin renders Python examples from the main Cantera repository into the
 examples/matlab output folder. It looks for the examples in the folder configured
 in the top-level conf.py file in the ``EXAMPLES_FOLDERS`` dictionary. That
 dictionary has keys with the source folder and values with the destination
 folder (relative to the ``OUTPUT_FOLDER``). The relevant source folder is found
-as the key associated with the value that contains the string ``matlab``,
-typically ``"../cantera/samples/matlab": "examples/matlab"``.
+as the key associated with the value that contains the string ``python``,
+typically ``"../cantera/samples/python": "examples/python"``.
 """
 from pathlib import Path
 import ast

--- a/themes/cantera/templates/python-example-index.tmpl
+++ b/themes/cantera/templates/python-example-index.tmpl
@@ -3,14 +3,10 @@
 {% block content %}
 <h2 class="display-3">Index of Python Examples</h2>
 
-<p>This is an index of the examples included with the Cantera Python module. They
-can be found in the <code style="display: inline;">examples</code> subdirectory of the Cantera Python module's
-installation directory. To determine the location of this directory, run the following in your Python interpreter:</p>
+<p>This is an index of Python examples included with Cantera.</p>
 
-<pre class="code python">
-<span class="kn">import</span> <span class="nn">cantera</span><span class="o">.</span><span class="nn">examples</span>
-<span class="k">print</span><span class="p">(</span><span class="n">cantera</span><span class="o">.</span><span class="n">examples</span><span class="o">.</span><span class="n">__path__</span><span class="p">)</span>
-</pre>
+<p>Cantera's Python examples can be downloaded by clicking the "Source" link at the top
+of each example page.</p>
 
 <h3>Table of Contents</h3>
 <ul>


### PR DESCRIPTION
As Python examples are no longer packaged with the Python module after Cantera/cantera#1352, the website needs to be updated accordingly.