### PR TITLE
Add documentation for core.h in C++ tutorial (and minor fixes)

### DIFF
--- a/pages/install/conda-install.rst
+++ b/pages/install/conda-install.rst
@@ -207,16 +207,19 @@ by running the commands:
    conda activate ct-dev
    conda update --channel cantera cantera cantera-matlab
 
+.. _sec-conda-development-interface:
+
 Development (C++ & Fortran 90) Interface
 ========================================
 
 **Warning:** The ``conda`` package for Cantera's development interface is experimental.
 For the most recent version of the package, use the ``cantera/label/dev`` channel
-instead of the stable ``cantera`` channel.
+instead of the stable ``cantera`` channel. The development interface for stable releases
+is also available from the ``conda-forge`` channel.
 
-Cantera's development interface can be installed from the ``cantera`` channel. In this
-example, the command will create a new conda environment named ``ct-dev``. From the
-command line (or the Anaconda Prompt on Windows), run:
+In the following example, Cantera's development interface is installed from the
+``cantera/label/dev`` channel. From the command line (or the Anaconda Prompt on
+Windows), create a new conda environment named ``ct-dev`` using:
 
 .. code:: shell
 
@@ -257,20 +260,28 @@ programs can be compiled as follows using the ``pkg-config`` build system:
    $ g++ demo.cpp -o demo $(pkg-config --cflags --libs cantera)
    $ ./demo
 
+A simple sample program for the Fortran 90 interface can be compiled as follows:
+
+.. code::shell
+
+   $ cd /path/to/conda/envs/ct-env/share/cantera/samples/f90
+   $ gfortran demo.f90 -o demo -I/path/to/conda/envs/ct-env/include/cantera
+   $ ./demo
+
 Windows Systems
 ---------------
 
-Installation folders for the C++ and Fortran 90 interface are:
+Installation folders for the C++ interface are:
 
 .. code:: shell
 
-   library files               path\to\conda\envs\ct-dev\Library\lib
-   C++ headers                 path\to\conda\envs\ct-dev\Library\include
-   samples                     path\to\conda\envs\ct-dev\share\cantera\samples
-   data files                  path\to\conda\envs\ct-dev\share\cantera\data
+   library files               path/to/conda/envs/ct-dev/Library/lib
+   C++ headers                 path/to/conda/envs/ct-dev/Library/include
+   samples                     path/to/conda/envs/ct-dev/share/cantera/samples
+   data files                  path/to/conda/envs/ct-dev/share/cantera/data
 
-The development package on Windows is experimental. While all libraries and headers are
-installed, compilation of custom programs is untested.
+The development package on Windows is experimental, with Fortran 90 currently not being
+supported.
 
 Upgrading from an earlier Cantera version
 -----------------------------------------

--- a/pages/install/conda-install.rst
+++ b/pages/install/conda-install.rst
@@ -260,14 +260,6 @@ programs can be compiled as follows using the ``pkg-config`` build system:
    $ g++ demo.cpp -o demo $(pkg-config --cflags --libs cantera)
    $ ./demo
 
-A simple sample program for the Fortran 90 interface can be compiled as follows:
-
-.. code::shell
-
-   $ cd /path/to/conda/envs/ct-env/share/cantera/samples/f90
-   $ gfortran demo.f90 -o demo -I/path/to/conda/envs/ct-env/include/cantera
-   $ ./demo
-
 Windows Systems
 ---------------
 

--- a/pages/install/install.rst
+++ b/pages/install/install.rst
@@ -47,7 +47,7 @@ Installing the Cantera Python Interface
 Installing the Cantera Matlab Toolbox
 =====================================
 - The Cantera Matlab toolbox can be installed on all operating systems using
-  :ref:`Conda <sec-install-conda>`.
+  :ref:`Conda <sec-conda-matlab-interface>`.
 
 - Windows users can use :ref:`MSI installer packages <sec-install-windows>`.
 
@@ -59,7 +59,7 @@ Installing the Cantera Matlab Toolbox
 Installing the Cantera C++ Interface & Fortran 90 Module
 ========================================================
 - The Cantera development interface can be installed on all operating systems using
-  :ref:`Conda <sec-install-conda>` (*experimental*).
+  :ref:`Conda <sec-conda-development-interface>` (*experimental*).
 
 - Ubuntu users can install the ``cantera-dev`` package from the
   :ref:`Cantera PPA <sec-install-ubuntu>`.

--- a/pages/tutorials/cxx-guide/equil-example.rst
+++ b/pages/tutorials/cxx-guide/equil-example.rst
@@ -15,6 +15,9 @@
 In the program below, the ``equilibrate`` method is called to set the gas to a
 state of chemical equilibrium, holding the temperature and pressure fixed.
 
+..
+   TODO: Update example to use "core.h" after release of Cantera 3.0
+
 .. include:: pages/tutorials/cxx-guide/demoequil.cpp
    :code: c++
 

--- a/pages/tutorials/cxx-guide/factories.rst
+++ b/pages/tutorials/cxx-guide/factories.rst
@@ -21,6 +21,9 @@ object types from a ``Solution`` object:
 This program uses "factory" functions to create derived objects objects of the
 appropriate type which are specified in the input file ``gri30.yaml``.
 
+..
+   TODO: Update example to use "core.h" after release of Cantera 3.0
+
 .. include:: pages/tutorials/cxx-guide/factory_demo.cpp
    :code: c++
 

--- a/pages/tutorials/cxx-guide/headers.rst
+++ b/pages/tutorials/cxx-guide/headers.rst
@@ -16,20 +16,11 @@ These headers are designed for use in C++ application programs, and are not
 included by the Cantera core. The headers and their functions are:
 
 
-``thermo.h``
-    Base thermodynamic classes and functions for creating
-    `ThermoPhase <{{% ct_docs doxygen/html/dc/d38/classCantera_1_1ThermoPhase.html %}}>`__
-    objects from input files.
-
-``kinetics.h``
-    Base kinetics classes and functions for creating
-    `Kinetics <{{% ct_docs doxygen/html/d4/dc4/classCantera_1_1Kinetics.html %}}>`__ objects from
-    input files.
-
-``transport.h``
-    Base transport property classes and functions for creating
-    `Transport <{{% ct_docs doxygen/html/d2/dfb/classCantera_1_1Transport.html %}}>`__
-    objects from input files.
+``core.h``
+    Base classes and functions for creating
+    `Solution <{{% ct_docs doxygen/html/d5/d40/classCantera_1_1Solution.html %}}>`__
+    objects from input files, as well as associated classes defining a phase
+    *(New in Cantera 3.0)*.
 
 ``zerodim.h``
     Zero-dimensional reactor networks.
@@ -39,6 +30,21 @@ included by the Cantera core. The headers and their functions are:
 
 ``reactionpaths.h``
     Reaction path diagrams.
+
+``thermo.h``
+    Base thermodynamic classes and functions for creating
+    `ThermoPhase <{{% ct_docs doxygen/html/dc/d38/classCantera_1_1ThermoPhase.html %}}>`__
+    objects from input files *(Superseded by ``core.h`` in Cantera 3.0)*.
+
+``kinetics.h``
+    Base kinetics classes and functions for creating
+    `Kinetics <{{% ct_docs doxygen/html/d4/dc4/classCantera_1_1Kinetics.html %}}>`__ objects from
+    input files *(Superseded by ``core.h`` in Cantera 3.0)*.
+
+``transport.h``
+    Base transport property classes and functions for creating
+    `Transport <{{% ct_docs doxygen/html/d2/dfb/classCantera_1_1Transport.html %}}>`__
+    objects from input files *(Superseded by ``core.h`` in Cantera 3.0)*.
 
 
 .. container:: container

--- a/pages/tutorials/cxx-guide/simple-example.rst
+++ b/pages/tutorials/cxx-guide/simple-example.rst
@@ -17,6 +17,9 @@ specification of a gas mixture from an input file, and then builds a new object
 representing the mixture. It then sets the thermodynamic state and composition
 of the gas mixture, and prints out a summary of its properties.
 
+..
+   TODO: Update example to use "core.h" after release of Cantera 3.0
+
 .. include:: pages/tutorials/cxx-guide/demo1a.cpp
    :code: c++
 

--- a/pages/tutorials/cxx-guide/thermo.rst
+++ b/pages/tutorials/cxx-guide/thermo.rst
@@ -20,6 +20,9 @@ phases. The first step is to create an object that represents each phase. A
 simple, complete program that creates an object representing a gas mixture and
 prints its temperature is shown below:
 
+..
+   TODO: Update example to use "core.h" after release of Cantera 3.0
+
 .. include:: pages/tutorials/cxx-guide/thermobasic.cpp
    :code: c++
 


### PR DESCRIPTION
This PR contains minor updates:

- Add documentation for `core.h` in the C++ tutorial (and "todo" items for future simplifications)
- Some formatting fixes (single backslash does not render correctly in code block, see [sphinx issue](https://github.com/sphinx-doc/sphinx/issues/8396))