### PR TITLE
Add Python RGFROSH to affiliated

### DIFF
--- a/pages/affiliated.rst
+++ b/pages/affiliated.rst
@@ -106,6 +106,14 @@ post on the `Google Users' Group <https://groups.google.com/forum/#!forum/canter
 
 ------------
 
+**RGFROSH**: A Python real and ideal gas frozen shock solver.
+
+| `Website <https://VasuLab.github.io/RGFROSH>`__
+| `Repository <https://github.com/VasuLab/RGFROSH>`__
+| Maintainer(s): Cory Kinney
+
+------------
+
 **RMG**: Reaction Mechanism Generator, a tool for automatically generating chemical reaction mechanisms for modeling reaction systems including pyrolysis, combustion, atmospheric science, and more.
 
 | `Website <https://rmg.mit.edu>`__


### PR DESCRIPTION
Hey! I was hoping to add the package [VasuLab/RGFROSH](https://github.com/VasuLab/RGFROSH) to the affiliated packages page of the Cantera website. 

It is a solver for shock conditions in a shock tube for arbitrary equations of state - with a focus on real gases. The package itself can be used with any backend, but its interface was specifically designed for Cantera so that `ct.ThermoPhase` objects can be passed directly to the solver.