### PR TITLE
Add mole reactor science pages

### DIFF
--- a/pages/science/reactors/constpresmolereactor.rst
+++ b/pages/science/reactors/constpresmolereactor.rst
@@ -1,0 +1,69 @@
+.. title: Constant Pressure Reactor
+.. has_math: true
+
+.. jumbotron::
+
+   .. raw:: html
+
+      <h1 class="display-3">Constant Pressure Mole Reactor</h1>
+
+   .. class:: lead
+
+      This page shows the derivation of the governing equations used in
+      Cantera's Constant Pressure Mole Reactor model.
+
+      More information on the Constant Pressure Mole Reactor class can be found `here.
+      <{{% ct_docs doxygen/html/d5/d7d/classCantera_1_1ConstPressureMoleReactor.html %}}>`__
+
+Constant Pressure Mole Reactor
+******************************
+
+For this reactor model, the pressure is held constant. The energy equation is
+defined by the total enthalpy.
+
+A Constant Pressure Reactor is defined by the two state variables:
+
+- :math:`H`, the total enthalpy of the reactor's contents (in J)
+
+- :math:`n_k`, the number of moles for each species (in kmol)
+
+Using the definition of the total enthalpy:
+
+.. math::
+
+   H = U + pV
+
+   \frac{d H}{d t} = \frac{d U}{d t} + p \frac{dV}{dt} + V \frac{dp}{dt}
+
+Noting that :math:`dp/dt = 0` and substituting into the energy equation yields:
+
+.. math::
+
+   \frac{dH}{dt} = \dot{Q} + \sum_{in} \dot{n}_{in} \bar{h}_{in}
+                   - \bar{h} \sum_{out} \dot{n}_{out}
+                   \tag{1}
+
+Where the total specific enthalpy :math:`h` is defined as :math:`h = \sum_k{\bar{h}_k n_k}`.
+The enthalpy terms in equation 2 appear due to enthalpy flowing in and out
+of the reactor.
+The rate of heat transfer :math:`\dot{Q}` can replace :math:`\frac{d U}{d t} + p \frac{dV}{dt}` in the above equation due to the first law
+of thermodynamics, which states :math:`\dot{Q} = \dot{H}` in a closed system where
+no work is done.
+Positive :math:`\dot{Q}` represents heat addition to the system.
+
+The moles of each species in the reactor's contents changes as a result of flow through
+the reactor's inlets and outlets, and production of homogeneous gas phase species and reactions on the reactor :py:class:`Wall`.
+The rate of moles of species :math:`k` generated through homogeneous phase
+reactions is :math:`V \dot{\omega}_k`, and the total rate at which moles of species
+:math:`k` is generated is:
+
+.. math::
+
+   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{in} - \sum_{out} \dot{n}_{out} + \dot{n}_{wall}
+   \tag{2}
+
+Where the subscripts *in* and *out* refer to the sum of the superscripted property
+over all inlets and outlets respectively. A dot above a variable signifies a time
+derivative. Reactor *Walls* are defined `here. <{{% ct_docs sphinx/html/cython/zerodim.html#cantera.Wall %}}>`__
+
+Equations 1-2 are the governing equations for a Constant Pressure Reactor.

--- a/pages/science/reactors/constpresmolereactor.rst
+++ b/pages/science/reactors/constpresmolereactor.rst
@@ -21,7 +21,7 @@ Constant Pressure Mole Reactor
 For this reactor model, the pressure is held constant. The energy equation is
 defined by the total enthalpy.
 
-A Constant Pressure Reactor is defined by the two state variables:
+A Constant Pressure Mole Reactor is defined by the two state variables:
 
 - :math:`H`, the total enthalpy of the reactor's contents (in J)
 
@@ -55,15 +55,15 @@ The moles of each species in the reactor's contents changes as a result of flow 
 the reactor's inlets and outlets, and production of homogeneous gas phase species and reactions on the reactor :py:class:`Wall`.
 The rate of moles of species :math:`k` generated through homogeneous phase
 reactions is :math:`V \dot{\omega}_k`, and the total rate at which moles of species
-:math:`k` is generated is:
+:math:`k` changes is:
 
 .. math::
 
-   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{in} - \sum_{out} \dot{n}_{out} + \dot{n}_{wall}
+   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{k, in} - \sum_{out} \dot{n}_{k, out} + \dot{n}_{k, wall}
    \tag{2}
 
 Where the subscripts *in* and *out* refer to the sum of the superscripted property
 over all inlets and outlets respectively. A dot above a variable signifies a time
 derivative. Reactor *Walls* are defined `here. <{{% ct_docs sphinx/html/cython/zerodim.html#cantera.Wall %}}>`__
 
-Equations 1-2 are the governing equations for a Constant Pressure Reactor.
+Equations 1-2 are the governing equations for a Constant Pressure Mole Reactor.

--- a/pages/science/reactors/cvodes.rst
+++ b/pages/science/reactors/cvodes.rst
@@ -9,32 +9,32 @@
 
    .. class:: lead
 
-      This guide explains ways Cantera can solve the governing equations of 
-      a transient Reactor Network problem. Additional insights 
+      This guide explains ways Cantera can solve the governing equations of
+      a transient Reactor Network problem. Additional insights
       into the integrator utilized by Cantera (CVODES) are also provided.
 
 Using Cantera to Advance a Reactor Network in Time
 **************************************************
 
-A ``ReactorNetwork`` can be advanced in time by one of the following three 
+A ``ReactorNetwork`` can be advanced in time by one of the following three
 methods:
 
-- ``step()``: The ``step()`` method computes the state of the system after one 
-  time step. The size of the step is determined by CVODES when the method is called. 
-  CVODES determines the step size by estimating the local error at every step, which 
-  must satisfy tolerance conditions. The step is redone with reduced step size whenever 
-  that error test fails. CVODES also periodically checks if the maximum step size is 
-  being used. The time step must not be larger than a predefined maximum time step 
-  :math:`\Delta t_{\mathrm{max}}`. The new time :math:`t_{\mathrm{new}}` at the end 
-  of the single step is returned by this function. This method produces the highest time 
+- ``step()``: The ``step()`` method computes the state of the system after one
+  time step. The size of the step is determined by CVODES when the method is called.
+  CVODES determines the step size by estimating the local error at every step, which
+  must satisfy tolerance conditions. The step is redone with reduced step size whenever
+  that error test fails. CVODES also periodically checks if the maximum step size is
+  being used. The time step must not be larger than a predefined maximum time step
+  :math:`\Delta t_{\mathrm{max}}`. The new time :math:`t_{\mathrm{new}}` at the end
+  of the single step is returned by this function. This method produces the highest time
   resolution in the output data of the methods implemented in Cantera.
 
-- ``advance(t_new)``: This method computes the state of the system at the 
-  user-provided time :math:`t_{\mathrm{new}}`. :math:`t_{\mathrm{new}}` is the absolute 
-  time from the initial time of the system. Although the user specifies the time when 
-  integration should stop, CVODES chooses the time step size as the network is integrated. 
-  Many of these internal CVODES time steps are usually required to reach 
-  :math:`t_{\mathrm{new}}`. As such, ``advance(t_new)`` preserves the accuracy of using 
+- ``advance(t_new)``: This method computes the state of the system at the
+  user-provided time :math:`t_{\mathrm{new}}`. :math:`t_{\mathrm{new}}` is the absolute
+  time from the initial time of the system. Although the user specifies the time when
+  integration should stop, CVODES chooses the time step size as the network is integrated.
+  Many of these internal CVODES time steps are usually required to reach
+  :math:`t_{\mathrm{new}}`. As such, ``advance(t_new)`` preserves the accuracy of using
   ``step()`` but allows consistent time step spacing in the output data.
 
 - ``advance_to_steady_state(max_steps, residual_threshold, atol,
@@ -44,10 +44,10 @@ methods:
   at steady state if the feature-scaled residual of the state vector is below a
   given threshold value (which by default is 10 times the time step ``rtol``).
 
-The ``advance(t_new)`` is typically used when consistent, regular, time steps are 
-required in the output data. This usually simplifies comparisons among many 
-simulation results at a single time point. However, some detail, for example, a 
-fast ignition process, might not be resolved in the output data if the user-provided 
+The ``advance(t_new)`` is typically used when consistent, regular, time steps are
+required in the output data. This usually simplifies comparisons among many
+simulation results at a single time point. However, some detail, for example, a
+fast ignition process, might not be resolved in the output data if the user-provided
 time step is not small enough.
 
 To avoid losing this detail, the
@@ -55,31 +55,31 @@ To avoid losing this detail, the
 method (C++) or the :py:func:`Reactor.set_advance_limit` method (Python) can be
 used to set the maximum amount that a specified solution component can change
 between output times. For an example of this feature's use, see the example
-`reactor1.py </examples/python/reactors/reactor1.py.html>`__. However, as a tradeoff, 
+`reactor1.py </examples/python/reactors/reactor1.py.html>`__. However, as a tradeoff,
 the time step sizes in the output data are no longer guaranteed to be uniform.
 
 Even though Cantera comes pre-defined with typical parameters for tolerances
 and the maximum internal time step, the solver may not be correctly configured
-for the specific system. In this case the internal timestep solutions may not 
-converge towards a single value. To solve this problem, three parameters can be 
-tuned: The absolute time stepping tolerances, the relative time stepping tolerances, 
-and the maximum time step. A reduction of the latter value is particularly useful 
-when dealing with abrupt changes in the boundary conditions (for example, 
+for the specific system. In this case the internal timestep solutions may not
+converge towards a single value. To solve this problem, three parameters can be
+tuned: The absolute time stepping tolerances, the relative time stepping tolerances,
+and the maximum time step. A reduction of the latter value is particularly useful
+when dealing with abrupt changes in the boundary conditions (for example,
 opening/closing valves; see also the `IC engine example </examples/python/reactors
 /ic_engine.py.html>`__).
 
 How Does Cantera's Reactor Network Time Integration Feature Actually Work?
 ==========================================================================
 
-A description of the science behind Cantera's reactor network 
-simulation capabilities is available on the Cantera website, 
-`here <https://cantera.org/science/reactors/reactors.html>`__. This section will go into more 
-developer-oriented detail about how the last step, ``ReactorNet``'s 
+A description of the science behind Cantera's reactor network
+simulation capabilities is available on the Cantera website,
+`here <https://cantera.org/science/reactors/reactors.html>`__. This section will go into more
+developer-oriented detail about how the last step, ``ReactorNet``'s
 `time integration methods <https://cantera.org/science/reactors/reactors.html#time-
-integration-for-reactor-networks>`__, actually work. A ``ReactorNet`` object doesn't 
-perform time integration on its own. Cantera generates a Jacobian array for the set 
-of ``Reactor`` objects contained in the ``ReactorNet``. This Jacobian, along with 
-functions to evaluate the residual of each ODE representing the system, is passed to 
+integration-for-reactor-networks>`__, actually work. A ``ReactorNet`` object doesn't
+perform time integration on its own. Cantera generates a Jacobian array for the set
+of ``Reactor`` objects contained in the ``ReactorNet``. This Jacobian, along with
+functions to evaluate the residual of each ODE representing the system, is passed to
 an ``Integrator``.
 
 Following integration from Reactor Network creation to completion
@@ -88,10 +88,10 @@ Following integration from Reactor Network creation to completion
 Step 1: Reactor(s) created in Reactor Network
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-First, let's take a look at a basic example to see how we might utilize Cantera's time integration 
-functionality. We'll simulate an isolated reactor in Python that is homogeneously filled by a gas 
-mixture (the gas state used in this example is arbitrary, but interesting because it's 
-explosive). Then we'll advance the simulation in time to an (arbitrary) absolute time of 
+First, let's take a look at a basic example to see how we might utilize Cantera's time integration
+functionality. We'll simulate an isolated reactor in Python that is homogeneously filled by a gas
+mixture (the gas state used in this example is arbitrary, but interesting because it's
+explosive). Then we'll advance the simulation in time to an (arbitrary) absolute time of
 1 second, noting the changes in the state of the gas.
 
 .. code-block:: python
@@ -106,19 +106,39 @@ explosive). Then we'll advance the simulation in time to an (arbitrary) absolute
     sim.advance(1)  # advance the simulation to the specified absolute time, t = 1 sec
     gas()  # view the updated state of the mixture, reflecting properties at t = 1 sec
 
-For a more advanced example that adds inlets and outlets to the reactor, see Cantera's combustor example 
-(`Python </examples/python/reactors/combustor.py.html>`__ 
-| `C++ </examples/cxx/combustor.html>`__). Additional examples can be found in the 
+For a more advanced example that adds inlets and outlets to the reactor, see Cantera's combustor example
+(`Python </examples/python/reactors/combustor.py.html>`__
+| `C++ </examples/cxx/combustor.html>`__). Additional examples can be found in the
 `Python Reactor Network Examples <https://cantera.org/examples/python/index.html#python-example-
 reactors>`__ section of the Cantera website.
+
+Optional Preconditioning
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some mole reactors are capable of leveraging preconditioning to accelerate integration of the system.
+The former code can be modified as follows to use preconditioning.
+The preconditioner can also be assigned to a python object and tunable parameters can adjusted.
+
+.. code-block:: python
+
+    import cantera as ct  # import Cantera's Python module
+
+    gas = ct.Solution("gri30.yaml")  # create a default GRI-Mech 3.0 gas mixture
+    gas.TPX = 1000.0, ct.one_atm, "H2:2,O2:1,N2:4"  # set gas to an interesting state
+    reac = ct.IdealGasMoleReactor(gas)  # create a reactor containing the gas
+    sim = ct.ReactorNet([reac])  # add the reactor to a new ReactorNet simulator
+    sim.preconditioner = ct.AdaptivePreconditioner() # add preconditioner to the network
+    gas()  # view the initial state of the mixture (state summary will be printed to console)
+    sim.advance(1)  # advance the simulation to the specified absolute time, t = 1 sec
+    gas()  # view the updated state of the mixture, reflecting properties at t = 1 sec
 
 Step 2: ``advance()`` method called
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In any case, after properly configuring a reactor network and its components in Cantera, a call to the 
-``ReactorNet``'s ``advance()`` method can be used to predict the state of the network at a specified time. 
+In any case, after properly configuring a reactor network and its components in Cantera, a call to the
+``ReactorNet``'s ``advance()`` method can be used to predict the state of the network at a specified time.
 The initial condition information is passed off to the `Integrator` when calling `advance()`.
-Transient physical and chemical interactions are simulated by integrating the network's system of ODE 
+Transient physical and chemical interactions are simulated by integrating the network's system of ODE
 governing equations through time, a process that's actually performed by an external `Integrator` object.
 
 Step 3: Information about current gas state provided to an `Integrator`
@@ -126,28 +146,28 @@ Step 3: Information about current gas state provided to an `Integrator`
 
 The ``Integrator`` class is Cantera's interface for ODE system integrators.
 
-``Integrator`` is a `polymorphic base class <http://www.cplusplus.com/doc/tutorial/polymorphism/>`__; it 
-defines a set of *virtual* functionalities that derived classes (the actual ODE system integrators) will 
+``Integrator`` is a `polymorphic base class <http://www.cplusplus.com/doc/tutorial/polymorphism/>`__; it
+defines a set of *virtual* functionalities that derived classes (the actual ODE system integrators) will
 provide implementations for.
 
-**Integrator.h** creates a ``newIntegrator()``. Factory Method ``newIntegrator()`` creates and returns a 
-pointer to an ``Integrator`` instance of type ``itype``. The ``newIntegrator()`` instance will automatically 
-have an ``itype`` of ``CVODES``, which is installed with Cantera. The ``newIntegrator()`` will be stored as 
+**Integrator.h** creates a ``newIntegrator()``. Factory Method ``newIntegrator()`` creates and returns a
+pointer to an ``Integrator`` instance of type ``itype``. The ``newIntegrator()`` instance will automatically
+have an ``itype`` of ``CVODES``, which is installed with Cantera. The ``newIntegrator()`` will be stored as
 variable ``m_integ``.
 
 Step 4: Communicate with CVODES using a wrapper function
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Because ``CVODES`` is written in C, the ``CVodesIntegrator`` C++ wrapper is used to access the solver.
-The ``CVodesIntegrator`` class is a C++ wrapper class for ``CVODES``. (`Documentation 
+The ``CVodesIntegrator`` class is a C++ wrapper class for ``CVODES``. (`Documentation
 <{{% ct_docs doxygen/html/d9/d6b/classCantera_1_1CVodesIntegrator.html %}}>`__)
 The ``CVodesIntegrator`` class makes the appropriate call to the ``CVODES`` driver function, ``CVode()``.
 
 Step 5: ``Cvode()`` driver function is called
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Method ``CVode()`` is the main driver of the ``CVODES`` package. ``CVode()`` integrates over a time interval defined by 
-the user, by calling ``cvStep()`` to do internal time steps (not specified by the user). (*Documentation:* 
+Method ``CVode()`` is the main driver of the ``CVODES`` package. ``CVode()`` integrates over a time interval defined by
+the user, by calling ``cvStep()`` to do internal time steps (not specified by the user). (*Documentation:*
 see `CVODES User Guide <https://sundials.readthedocs.io/en/latest/cvodes/index.html>`__)
 
 The arguments taken by the ``CVode()`` method is shown below:
@@ -159,15 +179,15 @@ The arguments taken by the ``CVode()`` method is shown below:
 There are some interesting things to note about this call to ``CVode()``:
 
 - ``m_cvode_mem`` is a pointer to the block of memory that was allocated and configured during initialization.
-- After execution, ``m_y`` will contain the computed solution vector, and will later be used to update the ``ReactorNet`` 
+- After execution, ``m_y`` will contain the computed solution vector, and will later be used to update the ``ReactorNet``
   to its time-integrated state.
-- The ``CV_NORMAL`` option tells the solver that it should continue taking internal timesteps until it has reached 
-  user-specified ``tout`` (or just passed it, in which case solutions are reached by interpolation). This provides the 
-  appropriate functionality for ``ReactorNet::advance()``. The alternate option, ``CV_ONE_STEP``, tells the solver to take 
+- The ``CV_NORMAL`` option tells the solver that it should continue taking internal timesteps until it has reached
+  user-specified ``tout`` (or just passed it, in which case solutions are reached by interpolation). This provides the
+  appropriate functionality for ``ReactorNet::advance()``. The alternate option, ``CV_ONE_STEP``, tells the solver to take
   a single internal step, and is used in ``ReactorNet::step()``.
 
-The result of the ``CVode()`` method is assigned to the ``flag`` object. ``CVode()`` returns 1 or 0, correpsonding to 
-a successful or unsuccessful integration, respectively. 
+The result of the ``CVode()`` method is assigned to the ``flag`` object. ``CVode()`` returns 1 or 0, correpsonding to
+a successful or unsuccessful integration, respectively.
 
 .. code-block:: C++
 
@@ -176,43 +196,43 @@ a successful or unsuccessful integration, respectively.
 Step 6: ``FuncEval`` class describes ODEs to solve
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-How does ``CVODES`` know what ODE system it should be solving? 
+How does ``CVODES`` know what ODE system it should be solving?
 
 The ODE system was actually already specified using ``CVodeInit()``, one of the methods automatically invoked during the
-``ReactorNet::initialize()`` routine. ``CVODES`` requires that its user provide a C function that defines their ODE, 
-able to compute the right-hand side of the ODE system (dy/dt) for a given value of the independent variable, `t`, 
-and the state vector, ``y``. For more information about ODE right-hand side function requirements, 
+``ReactorNet::initialize()`` routine. ``CVODES`` requires that its user provide a C function that defines their ODE,
+able to compute the right-hand side of the ODE system (dy/dt) for a given value of the independent variable, `t`,
+and the state vector, ``y``. For more information about ODE right-hand side function requirements,
 see `CVODES User Guide <https://sundials.readthedocs.io/en/latest/cvodes/Usage/SIM.html#user-supplied-functions>`__.
 
-The ``CVodesIntegrator`` wrapper class provides a useful C++ interface for configuring this C function by pairing with 
-``FuncEval``, an abstract base class for ODE right-hand-side function evaluators (`Documentation 
-<{{% ct_docs doxygen/html/d1/dd1/classCantera_1_1FuncEval.html %}}>`__). Classes derived 
+The ``CVodesIntegrator`` wrapper class provides a useful C++ interface for configuring this C function by pairing with
+``FuncEval``, an abstract base class for ODE right-hand-side function evaluators (`Documentation
+<{{% ct_docs doxygen/html/d1/dd1/classCantera_1_1FuncEval.html %}}>`__). Classes derived
 from ``FuncEval`` will implement the evaluation of the provided ODE system.
 
-An ODE right-hand-side evaluator is always needed in the ODE solution process (it's the only way to describe the system!), and for that reason a `FuncEval` object is a required parameter 
+An ODE right-hand-side evaluator is always needed in the ODE solution process (it's the only way to describe the system!), and for that reason a `FuncEval` object is a required parameter
 when initializing any type of ``Integrator``.
 
-Let's take a look at how ``ReactorNet`` implements this ``FuncEval`` object. ``ReactorNet`` actually points to itself when 
+Let's take a look at how ``ReactorNet`` implements this ``FuncEval`` object. ``ReactorNet`` actually points to itself when
 defining a ``FuncEval`` type, meaning it defines *itself* as a ``FuncEval`` derivative.
 
-Then, ``ReactorNet`` initializes the ``Integrator``, using a reference to itself (as a ``FuncEval``) from the 
+Then, ``ReactorNet`` initializes the ``Integrator``, using a reference to itself (as a ``FuncEval``) from the
 `this <https://en.cppreference.com/w/cpp/language/this>`__ pointer.
 
-To be a valid ``FuncEval`` object, a ``ReactorNet`` needs to provide implementations for all of ``FuncEval``'s 
-virtual functions, particularly the actual ODE right-hand-side computation 
-function, ``FuncEval::eval()``. Note that this is declared as a `pure virtual 
-<https://en.cppreference.com/w/cpp/language/abstract_class>`__ function, which makes 
+To be a valid ``FuncEval`` object, a ``ReactorNet`` needs to provide implementations for all of ``FuncEval``'s
+virtual functions, particularly the actual ODE right-hand-side computation
+function, ``FuncEval::eval()``. Note that this is declared as a `pure virtual
+<https://en.cppreference.com/w/cpp/language/abstract_class>`__ function, which makes
 ``FuncEval`` an abstract class:
 
 To evaluate the reactor governing equations the following parameters must be known:
 
 #. Time, t
     Current time in seconds.
-#. LHS pointer to start of vector of left-hand side coefficients for governing equations. 
+#. LHS pointer to start of vector of left-hand side coefficients for governing equations.
     Has length m_nv, default values 1.
 #. RHS pointer to start of vector of right-hand side coefficients for governing equations.
     Has length m_nv, default values 0.
-    
+
 .. code-block:: C++
 
     virtual void eval(double t, double* LHS, double* RHS);
@@ -226,14 +246,14 @@ state varaible to the solution vector (``y``).
 Step 7: ``eval()`` is called to solve provided ODEs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Along with the rest of ``FuncEval``'s virtual functions, an appropriate override is provided for ``FuncEval::eval()`` in 
+Along with the rest of ``FuncEval``'s virtual functions, an appropriate override is provided for ``FuncEval::eval()`` in
 ``ReactorNet``
 
 .. code-block:: C++
 
     void ReactorNet::eval(doublereal t, doublereal* y,
                       doublereal* ydot, doublereal* p)
-    
+
     m_time = t;
     updateState(y);
     m_LHS.assign(m_nv, 1);
@@ -289,9 +309,9 @@ Along with the rest of ``FuncEval``'s virtual functions, an appropriate override
 
 
 
-``ReactorNet``'s ``eval()`` method evaluates the governing equations of all 
-``Reactors`` contained in the network. This brings us right back to where we started. Cantera still currently supports 
-the deprecated ``evalEqs()`` function, hence the deprecation warning. For more information see 
-Cantera's `reactor network science page </science/reactors/reactors.html>`__. 
+``ReactorNet``'s ``eval()`` method evaluates the governing equations of all
+``Reactors`` contained in the network. This brings us right back to where we started. Cantera still currently supports
+the deprecated ``evalEqs()`` function, hence the deprecation warning. For more information see
+Cantera's `reactor network science page </science/reactors/reactors.html>`__.
 
 This documentation is based off @paulblum's `blog post <https://cantera.org/blog/gsoc-2020-blog-3.html>`__.

--- a/pages/science/reactors/idealgasconstpresmolereactor.rst
+++ b/pages/science/reactors/idealgasconstpresmolereactor.rst
@@ -39,18 +39,18 @@ temperature:
 
 .. math::
 
-   \frac{dT}{dt} = \frac{\dot{Q} - \sum \bar{h}_k \dot{n}_k}{\sum_k n_k \bar{c}_{p,k} }
+   \sum_k n_k \bar{c}_{p,k} \frac{dT}{dt} = \dot{Q} - \sum \bar{h}_k \dot{n}_k
   \tag{1}
 
 The moles of each species in the reactor's contents changes as a result of flow through
 the reactor's inlets and outlets, and production of homogeneous gas phase species and reactions on the reactor :py:class:`Wall`.
 The rate of moles of species :math:`k` generated through homogeneous phase
 reactions is :math:`V \dot{\omega}_k`, and the total rate at which moles of species
-:math:`k` is generated is:
+:math:`k` changes is:
 
 .. math::
 
-   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{in} - \sum_{out} \dot{n}_{out} + \dot{n}_{wall}
+   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{k, in} - \sum_{out} \dot{n}_{k, out} + \dot{n}_{k, wall}
    \tag{2}
 
 Where the subscripts *in* and *out* refer to the sum of the superscripted property
@@ -59,4 +59,4 @@ derivative. Reactor *Walls* are defined `here. <{{% ct_docs sphinx/html/cython/z
 
 
 Equations 1-2 are the governing equations for an Ideal Gas Constant Pressure
-Reactor.
+Mole Reactor.

--- a/pages/science/reactors/idealgasconstpresmolereactor.rst
+++ b/pages/science/reactors/idealgasconstpresmolereactor.rst
@@ -1,0 +1,62 @@
+.. title: Ideal Gas Constant Pressure Mole Reactor
+.. has_math: true
+
+.. jumbotron::
+
+   .. raw:: html
+
+      <h1 class="display-3">Ideal Gas Constant Pressure
+      Mole Reactor</h1>
+
+   .. class:: lead
+
+      This page shows the derivation of the governing equations used in
+      Cantera's Ideal Gas Constant Pressure Mole Reactor model.
+
+      More information on the Ideal Gas Constant Pressure Mole Reactor class can
+      be found `here. <{{% ct_docs doxygen/html/de/daa/classCantera_1_1IdealGasConstPressureMoleReactor.html %}}>`__
+
+Ideal Gas Constant Pressure Reactor
+***********************************
+
+An Ideal Gas Constant Pressure Mole Reactor is defined by the two state variables:
+
+- :math:`T`, the temperature (in K)
+
+- :math:`n_k`, the number of moles for each species (in kmol)
+
+The energy equation in terms of temperature is necessary as we replaced enthalpy in the state vector with temperature.
+We develop the equation for temperature by writing the total enthalpy in terms of the molar enthalpy and moles of each species.
+
+.. math::
+
+   H = \sum_k \bar{h}_k(T) n_k(T)
+
+   \frac{dH}{dt} = \frac{dT}{dt}\sum_k n_k \bar{c_{p,k}} + \sum \bar{h}_k \dot{n}_k
+
+After some manipulations yields an equation for the
+temperature:
+
+.. math::
+
+   \frac{dT}{dt} = \frac{\dot{Q} - \sum \bar{h}_k \dot{n}_k}{\sum_k n_k \bar{c}_{p,k} }
+  \tag{1}
+
+The moles of each species in the reactor's contents changes as a result of flow through
+the reactor's inlets and outlets, and production of homogeneous gas phase species and reactions on the reactor :py:class:`Wall`.
+The rate of moles of species :math:`k` generated through homogeneous phase
+reactions is :math:`V \dot{\omega}_k`, and the total rate at which moles of species
+:math:`k` is generated is:
+
+.. math::
+
+   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{in} - \sum_{out} \dot{n}_{out} + \dot{n}_{wall}
+   \tag{2}
+
+Where the subscripts *in* and *out* refer to the sum of the superscripted property
+over all inlets and outlets respectively. A dot above a variable signifies a time
+derivative. Reactor *Walls* are defined `here. <{{% ct_docs sphinx/html/cython/zerodim.html#cantera.Wall %}}>`__
+
+
+Equations 1-2 are the governing equations for an Ideal Gas Constant Pressure
+Reactor.

--- a/pages/science/reactors/idealgasmolereactor.rst
+++ b/pages/science/reactors/idealgasmolereactor.rst
@@ -1,0 +1,65 @@
+.. title: Ideal Gas Mole Reactor
+.. has_math: true
+
+.. jumbotron::
+
+   .. raw:: html
+
+      <h1 class="display-3">Ideal Gas Mole Reactor</h1>
+   .. class:: lead
+
+      This page shows the derivation of the governing equations used in
+      Cantera's Ideal Gas Mole Reactor model.
+
+      More information on the Ideal Gas Mole Reactor class can be found `here.
+      <{{% ct_docs doxygen/html/d0/d03/classCantera_1_1IdealGasMoleReactor.html %}}>`__
+
+Ideal Gas Mole Reactor
+**********************
+
+An Ideal Gas Mole Reactor is defined by the three state variables:
+
+- :math:`T`, the temperature (in K)
+
+- :math:`V`, the reactor volume (in m\ :sup:`3`)
+
+- :math:`n_k`, the number of moles for each species (in kmol)
+
+The energy equation in terms of temperature is necessary as we replaced internal energy in the state vector with temperature.
+We develop the equation for temperature by writing the total enthalpy in terms of the molar enthalpy and moles of each species.
+
+.. math::
+
+   U = \sum_k \bar{u}_k(T) n_k(T)
+
+   \frac{dU}{dt} = \frac{dT}{dt}\sum_k n_k \bar{c_{v,k}} + \sum \bar{u}_k \dot{n}_k
+
+After some manipulations yields an equation for the
+temperature:
+
+.. math::
+
+   \frac{dT}{dt} = \frac{\dot{Q} - \sum \bar{u}_k \dot{n}_k}{\sum_k n_k \bar{c}_{p,k} }
+  \tag{1}
+
+The reactor volume changes as a function of time due to the motion of one or
+more walls:
+
+.. math::
+
+   \frac{dV}{dt} = \sum_w f_w A_w v_w(t)
+   \tag{2}
+
+Where :math:`f_w = \pm 1` indicates the facing of the wall (whether moving the wall increases or decreases the volume of the reactor), :math:`A_w` is the surface area of the wall, and :math:`v_w(t)` is the velocity of the wall as a function of time.
+
+Finally, the moles of each species in the reactor's contents changes as a result of flow through the reactor's inlets and outlets, and production of homogeneous gas phase species and reactions on the reactor :py:class:`Wall`.
+The rate of moles of species :math:`k` generated through homogeneous phase
+reactions is :math:`V \dot{\omega}_k`, and the total rate at which moles of species
+:math:`k` is generated is:
+
+.. math::
+
+   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{in} - \sum_{out} \dot{n}_{out} + \dot{n}_{wall}
+   \tag{3}
+
+Equations 1-3 are the governing equations for an Ideal Gas Mole Reactor.

--- a/pages/science/reactors/idealgasmolereactor.rst
+++ b/pages/science/reactors/idealgasmolereactor.rst
@@ -55,11 +55,11 @@ Where :math:`f_w = \pm 1` indicates the facing of the wall (whether moving the w
 Finally, the moles of each species in the reactor's contents changes as a result of flow through the reactor's inlets and outlets, and production of homogeneous gas phase species and reactions on the reactor :py:class:`Wall`.
 The rate of moles of species :math:`k` generated through homogeneous phase
 reactions is :math:`V \dot{\omega}_k`, and the total rate at which moles of species
-:math:`k` is generated is:
+:math:`k` changes is:
 
 .. math::
 
-   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{in} - \sum_{out} \dot{n}_{out} + \dot{n}_{wall}
+   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{k, in} - \sum_{out} \dot{n}_{k, out} + \dot{n}_{k, wall}
    \tag{3}
 
 Equations 1-3 are the governing equations for an Ideal Gas Mole Reactor.

--- a/pages/science/reactors/molereactor.rst
+++ b/pages/science/reactors/molereactor.rst
@@ -25,7 +25,7 @@ and :py:class:`Valve`.
 
 A Mole Reactor is defined by the three state variables:
 
-- :math:`U`, the total internal energy of the reactors contents (in J)
+- :math:`U`, the total internal energy of the reactor's contents (in J)
 
 - :math:`V`, the reactor volume (in m\ :sup:`3`)
 
@@ -38,7 +38,7 @@ for an open system:
 
    \frac{dU}{dt} = - p \frac{dV}{dt} + \dot{Q} +
                     \sum_{in} \dot{n}_{in} \bar{h}_{in} - \bar{h} \sum_{out} \dot{n}_{out}
-   \tag{3}
+   \tag{1}
 
 Where :math:`\dot{Q}` is the net rate of heat addition to the system.
 
@@ -59,11 +59,11 @@ The moles of each species in the reactor's contents changes as a result of flow 
 the reactor's inlets and outlets, and production of homogeneous gas phase species and reactions on the reactor :py:class:`Wall`.
 The rate of moles of species :math:`k` generated through homogeneous phase
 reactions is :math:`V \dot{\omega}_k`, and the total rate at which moles of species
-:math:`k` is generated is:
+:math:`k` changes is:
 
 .. math::
 
-   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{in} - \sum_{out} \dot{n}_{out} + \dot{n}_{wall}
+   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{k, in} - \sum_{out} \dot{n}_{k, out} + \dot{n}_{k, wall}
    \tag{3}
 
 Where the subscripts *in* and *out* refer to the sum of the superscripted property

--- a/pages/science/reactors/molereactor.rst
+++ b/pages/science/reactors/molereactor.rst
@@ -1,0 +1,73 @@
+.. title: Mole Reactor
+.. has_math: true
+
+.. jumbotron::
+
+   .. raw:: html
+
+      <h1 class="display-3">Mole Reactor</h1>
+
+   .. class:: lead
+
+      This page shows the derivation of the governing equations used in
+      Cantera's Mole Reactor model.
+
+      More information on the Mole Reactor class can be found `here.
+      <{{% ct_docs doxygen/html/da/d29/classCantera_1_1MoleReactor.html %}}>`__
+
+Mole Reactor
+************
+
+A homogeneous zero-dimensional reactor. By default, they are closed (no inlets or outlets),
+have fixed volume, and have adiabatic, chemically-inert walls. These properties may all be
+changed by adding appropriate components such as :py:class:`Wall`, :py:class:`MassFlowController`
+and :py:class:`Valve`.
+
+A Mole Reactor is defined by the three state variables:
+
+- :math:`U`, the total internal energy of the reactors contents (in J)
+
+- :math:`V`, the reactor volume (in m\ :sup:`3`)
+
+- :math:`n_k`, the number of moles for each species (in kmol)
+
+The equation for the total internal energy is found by writing the first law
+for an open system:
+
+.. math::
+
+   \frac{dU}{dt} = - p \frac{dV}{dt} + \dot{Q} +
+                    \sum_{in} \dot{n}_{in} \bar{h}_{in} - \bar{h} \sum_{out} \dot{n}_{out}
+   \tag{3}
+
+Where :math:`\dot{Q}` is the net rate of heat addition to the system.
+
+The reactor volume changes as a function of time due to the motion of one or
+more walls:
+
+.. math::
+
+   \frac{dV}{dt} = \sum_w f_w A_w v_w(t)
+   \tag{2}
+
+where :math:`f_w = \pm 1` indicates the facing of the wall (whether moving the wall increases or
+decreases the volume of the reactor), :math:`A_w` is the
+surface area of the wall, and :math:`v_w(t)` is the velocity of the wall as a
+function of time.
+
+The moles of each species in the reactor's contents changes as a result of flow through
+the reactor's inlets and outlets, and production of homogeneous gas phase species and reactions on the reactor :py:class:`Wall`.
+The rate of moles of species :math:`k` generated through homogeneous phase
+reactions is :math:`V \dot{\omega}_k`, and the total rate at which moles of species
+:math:`k` is generated is:
+
+.. math::
+
+   \frac{dn_k}{dt} = V \dot{\omega}_k + \sum_{in} \dot{n}_{in} - \sum_{out} \dot{n}_{out} + \dot{n}_{wall}
+   \tag{3}
+
+Where the subscripts *in* and *out* refer to the sum of the superscripted property
+over all inlets and outlets respectively. A dot above a variable signifies a time
+derivative. Reactor *Walls* are defined `here. <{{% ct_docs sphinx/html/cython/zerodim.html#cantera.Wall %}}>`__
+
+Equations 1-3 are the governing equations for a Mole Reactor.

--- a/pages/science/reactors/reactors.rst
+++ b/pages/science/reactors/reactors.rst
@@ -52,12 +52,12 @@ heat or move to do work.
 Reactor Types and Governing Equations
 =====================================
 
-All reactor types are modelled using combinations of Cantera's governing equations of state. 
+All reactor types are modelled using combinations of Cantera's governing equations of state.
 The specific governing equations defining Cantera's supported reactor models are derived and described below.
 
 .. container:: container
 
-   .. row:: 
+   .. row::
 
       .. container:: col-12
 
@@ -73,7 +73,7 @@ The specific governing equations defining Cantera's supported reactor models are
                   .. container:: card-header section-card
 
                      Control Volume Reactor
-                     
+
                      ..
 
 
@@ -82,7 +82,7 @@ The specific governing equations defining Cantera's supported reactor models are
                   .. container:: card-text
 
                      Derivations of governing equations for a Control Volume Reactor.
-                     A reactor where the volume is prescribed by the motion of the 
+                     A reactor where the volume is prescribed by the motion of the
                      reactor's walls.
             .. container:: card
 
@@ -120,17 +120,17 @@ The specific governing equations defining Cantera's supported reactor models are
                      Derivations of governing equations for an Ideal Gas
                      Control Volume Reactor.
                      A reactor where all gasses follow the ideal gas law,
-                     volume is prescribed by the motion of the reactor's walls, 
+                     volume is prescribed by the motion of the reactor's walls,
                      and temperature is the energy equation state variable.
-                     
+
 .. container:: container
 
-   .. row:: 
+   .. row::
 
       .. container:: col-12
 
          .. container:: card-deck
-            
+
             .. container:: card
 
                .. container::
@@ -149,9 +149,9 @@ The specific governing equations defining Cantera's supported reactor models are
                      Derivations of governing equations for an Ideal Gas Constant Pressure Reactor.
                      A reactor where all gasses follow the ideal gas law, pressure is held
                      constant, and temperature is the energy equation state variable.
-               
+
             .. container:: card
-               
+
                .. container::
                   :tagname: a
                   :attributes: href="pfr.html"
@@ -160,7 +160,7 @@ The specific governing equations defining Cantera's supported reactor models are
                   .. container:: card-header section-card
 
                      Plug Flow Reactor
-                     
+
                      ..
 
 
@@ -169,17 +169,111 @@ The specific governing equations defining Cantera's supported reactor models are
                   .. container:: card-text
 
                      Derivations of governing equations for a Plug Flow Reactor.
-                     A steady-state reactor channel where typically an ideal gas 
+                     A steady-state reactor channel where typically an ideal gas
                      flows through it at a constant mass flow rate.
 
-In some cases, Cantera's solver is insufficient to describe 
+A set of reactors with a mole based state vector were implemented to leverage preconditioning techniques which do not have the same applicability to traditional mass fraction based solutions.
+The primary difference in "Mole reactors" being that the governing equations are derived using moles instead of mass fractions.
+
+
+.. container:: container
+
+   .. row::
+
+      .. container:: col-12
+
+         .. container:: card-deck
+
+            .. container:: card
+
+               .. container::
+                  :tagname: a
+                  :attributes: href="molereactor.html"
+                              title="Mole Reactor"
+
+                  .. container:: card-header section-card
+
+                     Mole Reactor
+
+               .. container:: card-body
+
+                  .. container:: card-text
+
+                     Derivations of governing equations for a Mole Reactor.
+
+
+            .. container:: card
+
+               .. container::
+                  :tagname: a
+                  :attributes: href="constpresmolereactor.html"
+                              title="Constant Pressure Mole Reactor"
+
+                  .. container:: card-header section-card
+
+                     Constant Pressure Mole Reactor
+
+                     ..
+
+               .. container:: card-body
+
+                  .. container:: card-text
+
+                     Derivations of governing equations for a Constant Pressure Mole.
+                     A reactor where the pressure is held constant by varying the volume.
+   .. row::
+
+      .. container:: col-12
+
+         .. container:: card-deck
+
+            .. container:: card
+
+               .. container::
+                  :tagname: a
+                  :attributes: href="idealgasmolereactor.html"
+                              title="Ideal Gas Mole Reactor"
+
+                  .. container:: card-header section-card
+
+                     Ideal Gas Mole Reactor
+
+               .. container:: card-body
+
+                  .. container:: card-text
+
+                     Derivations of governing equations for a Mole Reactor.
+
+
+            .. container:: card
+
+               .. container::
+                  :tagname: a
+                  :attributes: href="idealgasconstpresmolereactor.html"
+                              title="Ideal Gas Constant Pressure Mole Reactor"
+
+                  .. container:: card-header section-card
+
+                     Ideal Gas Constant Pressure Mole Reactor
+
+                     ..
+
+               .. container:: card-body
+
+                  .. container:: card-text
+
+                     Derivations of governing equations for a Constant Pressure Mole.
+                     A reactor where the pressure is held constant by varying the volume.
+
+
+In some cases, Cantera's solver is insufficient to describe
 a certain configuration. In this situation, there are two options for customizing
 a reactor in Cantera. These two approaches are described below: Extensible Reactor and
 Custom Reactor.
 
 .. container:: container
 
-   .. row:: 
+   .. row::
 
       .. container:: col-12
 
@@ -195,7 +289,7 @@ Custom Reactor.
                   .. container:: card-header section-card
 
                      Extensible Reactor
-                     
+
                      ..
 
 
@@ -205,7 +299,7 @@ Custom Reactor.
 
                      Documentation for reactor type where the user can modify existing
                      governing equations of a chosen reactor.
-               
+
             .. container:: card
 
                .. container::
@@ -221,10 +315,10 @@ Custom Reactor.
 
                   .. container:: card-text
 
-                     Documentation for reactor type where Cantera provides chemical and 
-                     thermodynamic computations, but external ODE solvers can be applied 
+                     Documentation for reactor type where Cantera provides chemical and
+                     thermodynamic computations, but external ODE solvers can be applied
                      to solve user supplied governing equation(s).
-               
+
 
 Reactor Networks
 ================
@@ -233,13 +327,13 @@ While reactors by themselves just define the above governing equations of the
 reactor, the time integration is performed in reactor networks. In other words
 defining a reactor without assigning it to a reactor network prevents Cantera
 from performing time integration to solve the governing equations. A reactor
-network is therefore necessary to define even if only a single reactor is considered. 
+network is therefore necessary to define even if only a single reactor is considered.
 An example of a single reactor network can be found `here
 </examples/python/reactors/combustor.py.html>`__.
 
 .. container:: container
 
-   .. row:: 
+   .. row::
 
       .. container:: col-12
 
@@ -255,7 +349,7 @@ An example of a single reactor network can be found `here
                   .. container:: card-header section-card
 
                      Time Integration for Reactor Networks: CVODES
-                     
+
                      ..
 
 
@@ -263,8 +357,8 @@ An example of a single reactor network can be found `here
 
                   .. container:: card-text
 
-                     Cantera uses the CVODES solver from the `SUNDIALS 
-                     <https://computing.llnl.gov/projects/sundials>`__ 
+                     Cantera uses the CVODES solver from the `SUNDIALS
+                     <https://computing.llnl.gov/projects/sundials>`__
                      package to integrate the stiff ODEs of reacting systems. These stiff ODEs are referring to
                      the governing equations defining the reactors above.
                      More in-depth information on the CVODES solver can be found here.
@@ -272,9 +366,9 @@ An example of a single reactor network can be found `here
 Reactor Peripherals
 ===================
 
-Reactor networks are also how Cantera interconnects multiple reactors. Not 
-only mass flow from one reactor into another can be incorporated, but also heat 
-can be transferred, or the wall between reactors can move. Documentation 
+Reactor networks are also how Cantera interconnects multiple reactors. Not
+only mass flow from one reactor into another can be incorporated, but also heat
+can be transferred, or the wall between reactors can move. Documentation
 on the different ways to connect reactors is explained here.
 
 To set up a network, the following components can be defined in addition
@@ -375,7 +469,7 @@ to the reactors previously mentioned:
   since a reversal of the flow direction is not allowed.
 
   Cantera comes with a broad variety of well-commented example scrips for reactor
-  networks. Please see the `Cantera Examples </examples/index.html>`__ for further 
+  networks. Please see the `Cantera Examples </examples/index.html>`__ for further
   information.
 
 Wall Interactions
@@ -505,7 +599,7 @@ approach is to use the equilibrium composition of the reactants (which can be
 computed using Cantera's ``equilibrate`` function) as an initial guess.
 
 *Cantera always solves a transient problem. If you are interested in steady-state
-conditions, you can run your simulation for a long time until the states are converged (see the* 
+conditions, you can run your simulation for a long time until the states are converged (see the*
 `surface reactor example </examples/python/reactors/surf_pfr.py.html>`__ *and the* `combustor example
 </examples/python/reactors/combustor.html>`__ *).*
 

--- a/pages/science/reactors/reactors.rst
+++ b/pages/science/reactors/reactors.rst
@@ -173,6 +173,7 @@ The specific governing equations defining Cantera's supported reactor models are
                      flows through it at a constant mass flow rate.
 
 A set of reactors with a mole based state vector were implemented to leverage preconditioning techniques which do not have the same applicability to traditional mass fraction based solutions.
+More on preconditioning can be found in the CVODES time integration `here. <https://cantera.org/science/reactors/cvodes.html>`__
 The primary difference in "Mole reactors" being that the governing equations are derived using moles instead of mass fractions.
 
 
@@ -534,11 +535,18 @@ For each surface species :math:`i`, the rate of change of the site fraction
 
 .. math::
 
-   \frac{d\theta_{i,w}}{dt} = \frac{\dot{s}_{i,w} n_i}{\Gamma_w}
+   \frac{d\theta_{i,w}}{dt} = \frac{\dot{s}_{i,w} \sigma_i}{\Gamma_w}
 
 where :math:`\Gamma_w` is the total surface site density on wall :math:`w` and
-:math:`n_i` is the number of surface sites occupied by a molecule of species
+:math:`\sigma_i` is the number of surface sites occupied by a molecule of species
 :math:`i` (sometimes referred to within Cantera as the molecule's "size").
+
+In the case of mole based reactors,
+:math:`\dot{n}_{wall}` is needed which is calculated as:
+
+.. math::
+
+      \dot{n}_{k, wall} = A_{w}\sum_{w}\dot{s}_{w, k}
 
 Common Reactor Types and their Implementation in Cantera
 ========================================================


### PR DESCRIPTION
The mole based reactors are currently undocumented in the science pages. This adds science pages for them. It is my intention to more content in regards to preconditioning. This closes #244.