### PR TITLE
Minor fixes and update to supported Ubuntu versions

### DIFF
--- a/pages/install/ubuntu-install.rst
+++ b/pages/install/ubuntu-install.rst
@@ -17,8 +17,8 @@
       Package Archive (PPA).
 
 As of Cantera 3.0.0, packages are available for Ubuntu 20.04 (Focal Fossa), Ubuntu 22.04
-(Jammy Jellyfish), Ubuntu 22.10 (Karmic Koala) and Ubuntu 23.04 (Lunar Lobster). To see
-which Ubuntu releases and Cantera versions are currently supported, visit
+(Jammy Jellyfish), Ubuntu 23.04 (Lunar Lobster), and Ubuntu 23.10 (Mantic Minotaur). To
+see which Ubuntu releases and Cantera versions are currently supported, visit
 https://launchpad.net/~cantera-team/+archive/ubuntu/cantera.
 
 The available packages are:

--- a/pages/tutorials/PythonTutorial.rst
+++ b/pages/tutorials/PythonTutorial.rst
@@ -399,7 +399,7 @@ reactions are zero. Here is the code to do this:
     >>> rf = g.forward_rates_of_progress
     >>> rr = g.reverse_rates_of_progress
     >>> for i in range(g.n_reactions):
-    ...     if g.is_reversible(i) and rf[i] != 0.0:
+    ...     if g.reaction(i).reversible and rf[i] != 0.0:
     ...         print(' %4i  %10.4g  ' % (i, (rf[i] - rr[i])/rf[i]))
 
 If the magnitudes of the numbers in this list are all very small, then each

--- a/pages/tutorials/PythonTutorial.rst
+++ b/pages/tutorials/PythonTutorial.rst
@@ -435,7 +435,7 @@ are used extensively within Cantera's
 and `1D flame model <{{% ct_docs sphinx/html/cython/onedim.html#sec-cython-onedim %}}>`__.
 
 Information about individual reactions that is independent of the thermodynamic
-state can be obtained by accessing :py:class:`Reaction` objects with the
+state can be obtained by accessing :py:class:`cantera.Reaction` objects with the
 :py:func:`Kinetics.reaction` method:
 
 .. code:: pycon


### PR DESCRIPTION
- Fixes #257
- Fixes #256
- Update Ubuntu PPA instructions:
  - Karmic (22.10) is no longer supported because it can no longer be built on Launchpad
  - Mantic (23.10) packages for Cantera 3.0 are now available on Launchpad
