### PR TITLE
Add getting involved page

### DIFF
--- a/source/affiliated.md
+++ b/source/affiliated.md
@@ -51,8 +51,6 @@ Maintainer(s): Chao Xu, Richard West
 :::{grid-item-card} ctwrap
 A light-weight Python wrapper facilitating batch simulations.
 
-[Website](https://microcombustion.github.io/ctwrap/)
-
 [Repository](https://github.com/microcombustion/ctwrap)
 
 Maintainer(s): Ingmar Schoegl
@@ -67,6 +65,14 @@ curvature, and steady 2D flames in a prescribed velocity field.
 [Repository](https://github.com/speth/ember)
 
 Maintainer(s): [Ray Speth](https://github.com/speth)
+:::
+
+:::{grid-item-card} FPVgen
+An automated flamelet progress variable (FPV) table assembly tool.
+
+[Repository](https://github.com/IhmeGroup/FPVgen)
+
+Maintainer(s): Matthew Bonanni
 :::
 
 :::{grid-item-card} Frhodo

--- a/source/community.md
+++ b/source/community.md
@@ -12,7 +12,8 @@ ensuring that the software will remain open source and available for all to use.
 In this vein, Cantera software relies exclusively upon the volunteer contributions of
 its users. These contributions range from diagnosing and reporting problems/bugs, to
 helping others learn to use Cantera, to developing and implementing new software
-capabilities.
+capabilities. For a brief overview, see our {doc}`getting involved <getting-involved>`
+page.
 
 While Cantera provides some standalone models and applications, numerous external
 packages exist that provide more specialized functionality and rely on Cantera. We
@@ -188,6 +189,7 @@ Donate to Cantera {octicon}`link-external`
 :hidden:
 
 News <news-index>
+Getting Involved <getting-involved>
 Affiliated Packages <affiliated>
 Governance <governance>
 Dave Goodwin <dave-goodwin>

--- a/source/getting-involved.md
+++ b/source/getting-involved.md
@@ -1,0 +1,53 @@
+# Getting Involved
+
+Cantera is an open-source suite for chemical kinetics, thermodynamics, and transport
+modeling, widely used in fields like combustion, electrochemistry, and materials
+science. As a community-driven project, we depend on contributions from users and
+developers who are interested in writing code, improving documentation, or assisting
+fellow users.
+
+## Ways to Contribute
+
+- **Engage with the Community**
+  Join the [Cantera Users’ Group](https://groups.google.com/g/cantera-users) to ask
+  questions, share knowledge, and connect with other users and developers.
+
+- **Contribute Code**
+  Explore our [open issues](https://github.com/Cantera/cantera/issues) and
+  [feature requests](https://github.com/Cantera/enhancements/issues) to find tasks that
+  match your interests.
+
+- **Enhance Documentation**
+  Help us improve tutorials, examples, and API references to make Cantera more
+  accessible to users of all levels.
+
+- **Report and Fix Bugs**
+  Identify issues or bugs and contribute fixes to enhance the stability and performance
+  of Cantera.
+
+## Getting Started
+
+- **Review the [Contributor's Guide](https://cantera.org/stable/develop/CONTRIBUTING.html)**
+  Learn about our development workflow, coding standards, and testing practices.
+
+- **Set Up Your Development Environment**
+  Follow our [development documentation](https://cantera.org/stable/develop/index.html)
+  to compile Cantera from source and configure your tools.
+
+- **Reach Out**
+  If you're unsure where to start, contact the
+  [core developers](mailto:developers@cantera.org) to discuss areas where you
+  can contribute effectively.
+
+## Community and Support
+
+Cantera is governed by a {doc}`Steering Committee <governance>` dedicated to
+maintaining a respectful and inclusive community. All interactions are guided by our
+[Code of Conduct](https://github.com/Cantera/cantera/blob/main/CODE_OF_CONDUCT.md) to
+ensure a welcoming environment for everyone.
+
+## Recognition
+
+Your contributions are valuable! If you make significant improvements, feel free to add
+your name to the `AUTHORS` file in your pull request. We appreciate and acknowledge the
+efforts of all our contributors.


### PR DESCRIPTION
This PR adds a 'getting involved' page per discussion in #268 - this would create the landing page for a 'getting involved' link in a banner envisioned in Cantera/cantera#1884.

In addition, it adds FPVgen to the list of affiliated packages (per #264).

Closes: #264

Screenshot:
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/5ac213e5-24b2-4127-bb5d-900d967ee191" />
